### PR TITLE
Fixes typo in the kn help command

### DIFF
--- a/pkg/kn/commands/revision.go
+++ b/pkg/kn/commands/revision.go
@@ -21,7 +21,7 @@ import (
 func NewRevisionCommand(p *KnParams) *cobra.Command {
 	revisionCmd := &cobra.Command{
 		Use:   "revision",
-		Short: "Revision command group.",
+		Short: "Revision command group",
 	}
 	revisionCmd.PersistentFlags().StringP("namespace", "n", "default", "Namespace to use.")
 	revisionCmd.AddCommand(NewRevisionListCommand(p))

--- a/pkg/kn/commands/root.go
+++ b/pkg/kn/commands/root.go
@@ -58,8 +58,8 @@ func NewKnCommand(params ...KnParams) *cobra.Command {
 
 	rootCmd := &cobra.Command{
 		Use:   "kn",
-		Short: "Knative client.",
-		Long: `Manage your Knative building blokcs:
+		Short: "Knative client",
+		Long: `Manage your Knative building blocks:
 
 Serving: Manage your services and release new software to them.
 Build: Create builds and keep track of their results.

--- a/pkg/kn/commands/service.go
+++ b/pkg/kn/commands/service.go
@@ -21,7 +21,7 @@ import (
 func NewServiceCommand(p *KnParams) *cobra.Command {
 	serviceCmd := &cobra.Command{
 		Use:   "service",
-		Short: "Service command group.",
+		Short: "Service command group",
 	}
 	serviceCmd.PersistentFlags().StringP("namespace", "n", "default", "Namespace to use.")
 	serviceCmd.AddCommand(NewServiceListCommand(p))


### PR DESCRIPTION
 s/blokcs/blocks

 and removes few unneeded dots (.)