### PR TITLE
Support generating bash completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,22 @@ $ go build ./cmd/...
 
 - knative CLI must be built outside of the $GOPATH folder unless you explicitly use `export GO111MODULE=on`.
 - For building, Go `1.11.4` is required [due to a go mod issue](https://github.com/golang/go/issues/27925)
+
+
+**Bash auto completion:**
+
+Run following to enable bash auto completion
+
+```sh
+$ source <(kn completion)
+```
+
+Use TAB to list available sub-commands
+
+```sh
+$ kn <TAB>
+completion revision service
+
+$ kn revision <TAB>
+describe list
+```

--- a/pkg/kn/commands/completion.go
+++ b/pkg/kn/commands/completion.go
@@ -1,0 +1,20 @@
+package commands
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCompletionCommand(p *KnParams) *cobra.Command {
+	completionCmd := &cobra.Command{
+		Use:   "completion",
+		Short: "Output bash completion code",
+		Run:   completionAction,
+	}
+	return completionCmd
+}
+
+func completionAction(cmd *cobra.Command, args []string) {
+	cmd.Root().GenBashCompletion(os.Stdout)
+}

--- a/pkg/kn/commands/root.go
+++ b/pkg/kn/commands/root.go
@@ -72,6 +72,7 @@ Eventing: Manage event subscriptions and channels. Connect up event sources.`,
 	rootCmd.PersistentFlags().StringVar(&kubeCfgFile, "kubeconfig", "", "kubectl config file (default is $HOME/.kube/config)")
 	rootCmd.AddCommand(NewServiceCommand(p))
 	rootCmd.AddCommand(NewRevisionCommand(p))
+	rootCmd.AddCommand(NewCompletionCommand(p))
 	return rootCmd
 }
 


### PR DESCRIPTION
This patch adds subcommand to generate completion script for bash.

As an knative user, we would like to complete subcommands and
options rather than typing them.

Usage Example:

```
$ source <(kn completion)

$ kn <TAB>
completion  revision    service

$ kn service list --<TAB>
--allow-missing-template-keys  --kubeconfig=                  --output=
--config=                      --namespace=                   --template=
```