### PR TITLE
Support --all-namespaces option for service and revision list

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/sergi/go-diff v1.0.0 // indirect
 	github.com/spf13/afero v1.2.0 // indirect
 	github.com/spf13/cobra v0.0.3
+	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.3.1
 	github.com/stretchr/testify v1.3.0 // indirect
 	golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc // indirect

--- a/pkg/kn/commands/namespaced.go
+++ b/pkg/kn/commands/namespaced.go
@@ -16,14 +16,14 @@ func AddNamespaceFlags(flags *pflag.FlagSet, allowAll bool) {
 		"namespace",
 		"n",
 		"",
-		"Namespace to use. (default \"default\")",
+		"List the requested object(s) in given namespace.",
 	)
 
 	if allowAll {
 		flags.Bool(
 			"all-namespaces",
 			false,
-			"If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace",
+			"If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.",
 		)
 	}
 }

--- a/pkg/kn/commands/namespaced.go
+++ b/pkg/kn/commands/namespaced.go
@@ -1,0 +1,23 @@
+package commands
+
+import "github.com/spf13/pflag"
+
+// AddNamespaceFlags adds the namespace-related flags:
+// * --namespace
+// * --all-namespaces
+func AddNamespaceFlags(flags *pflag.FlagSet, allowAll bool) {
+	flags.StringP(
+		"namespace",
+		"n",
+		"",
+		"If present, the namespace scope for this request",
+	)
+
+	if allowAll {
+		flags.Bool(
+			"all-namespaces",
+			false,
+			"If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace",
+		)
+	}
+}

--- a/pkg/kn/commands/namespaced.go
+++ b/pkg/kn/commands/namespaced.go
@@ -1,6 +1,12 @@
 package commands
 
-import "github.com/spf13/pflag"
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// TODO: default namespace should be same scope for the request
+const defaultNamespace = "default"
 
 // AddNamespaceFlags adds the namespace-related flags:
 // * --namespace
@@ -10,7 +16,7 @@ func AddNamespaceFlags(flags *pflag.FlagSet, allowAll bool) {
 		"namespace",
 		"n",
 		"",
-		"If present, the namespace scope for this request",
+		"Namespace to use. (default \"default\")",
 	)
 
 	if allowAll {
@@ -20,4 +26,24 @@ func AddNamespaceFlags(flags *pflag.FlagSet, allowAll bool) {
 			"If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace",
 		)
 	}
+}
+
+// GetNamespace returns namespace from command specified by flag
+func GetNamespace(cmd *cobra.Command) (string, error) {
+	namespace := cmd.Flag("namespace").Value.String()
+	if cmd.Flags().Lookup("all-namespaces") == nil {
+		if namespace == "" {
+			return defaultNamespace, nil
+		}
+		return namespace, nil
+	}
+
+	all, err := cmd.Flags().GetBool("all-namespaces")
+	if err != nil {
+		return "", err
+	}
+	if all {
+		namespace = ""
+	}
+	return namespace, nil
 }

--- a/pkg/kn/commands/revision.go
+++ b/pkg/kn/commands/revision.go
@@ -23,10 +23,6 @@ func NewRevisionCommand(p *KnParams) *cobra.Command {
 		Use:   "revision",
 		Short: "Revision command group",
 	}
-	revisionCmd.PersistentFlags().StringP("namespace", "n", "default", "Namespace to use.")
-	revisionCmd.PersistentFlags().BoolVar(&p.getAllNamespaces, "all-namespaces", false,
-		"If present, list the requested object(s) across all namespaces. Namespace in current "+
-			"context is ignored even if specified with --namespace.")
 	revisionCmd.AddCommand(NewRevisionListCommand(p))
 	revisionCmd.AddCommand(NewRevisionDescribeCommand(p))
 	return revisionCmd

--- a/pkg/kn/commands/revision.go
+++ b/pkg/kn/commands/revision.go
@@ -24,6 +24,9 @@ func NewRevisionCommand(p *KnParams) *cobra.Command {
 		Short: "Revision command group",
 	}
 	revisionCmd.PersistentFlags().StringP("namespace", "n", "default", "Namespace to use.")
+	revisionCmd.PersistentFlags().BoolVar(&p.getAllNamespaces, "all-namespaces", false,
+		"If present, list the requested object(s) across all namespaces. Namespace in current "+
+			"context is ignored even if specified with --namespace.")
 	revisionCmd.AddCommand(NewRevisionListCommand(p))
 	revisionCmd.AddCommand(NewRevisionDescribeCommand(p))
 	return revisionCmd

--- a/pkg/kn/commands/revision_describe.go
+++ b/pkg/kn/commands/revision_describe.go
@@ -38,7 +38,10 @@ func NewRevisionDescribeCommand(p *KnParams) *cobra.Command {
 				return err
 			}
 
-			namespace := cmd.Flag("namespace").Value.String()
+			namespace, err := GetNamespace(cmd)
+			if err != nil {
+				return err
+			}
 			revision, err := client.Revisions(namespace).Get(args[0], v1.GetOptions{})
 			if err != nil {
 				return err

--- a/pkg/kn/commands/revision_describe.go
+++ b/pkg/kn/commands/revision_describe.go
@@ -59,6 +59,7 @@ func NewRevisionDescribeCommand(p *KnParams) *cobra.Command {
 			return nil
 		},
 	}
+	AddNamespaceFlags(revisionDescribeCmd.Flags(), false)
 	revisionDescribePrintFlags.AddFlags(revisionDescribeCmd)
 	return revisionDescribeCmd
 }

--- a/pkg/kn/commands/revision_list.go
+++ b/pkg/kn/commands/revision_list.go
@@ -35,9 +35,9 @@ func NewRevisionListCommand(p *KnParams) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			namespace := cmd.Flag("namespace").Value.String()
-			if p.getAllNamespaces {
-				namespace = ""
+			namespace, err := GetNamespace(cmd)
+			if err != nil {
+				return err
 			}
 			revision, err := client.Revisions(namespace).List(v1.ListOptions{})
 			if err != nil {

--- a/pkg/kn/commands/revision_list.go
+++ b/pkg/kn/commands/revision_list.go
@@ -25,6 +25,7 @@ var revisionListPrintFlags *genericclioptions.PrintFlags
 
 // listCmd represents the list command
 func NewRevisionListCommand(p *KnParams) *cobra.Command {
+	var getAllNamespaces bool
 	revisionListPrintFlags = genericclioptions.NewPrintFlags("").WithDefaultOutput(
 		"jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}")
 	revisionListCmd := &cobra.Command{
@@ -36,6 +37,9 @@ func NewRevisionListCommand(p *KnParams) *cobra.Command {
 				return err
 			}
 			namespace := cmd.Flag("namespace").Value.String()
+			if getAllNamespaces {
+				namespace = ""
+			}
 			revision, err := client.Revisions(namespace).List(v1.ListOptions{})
 			if err != nil {
 				return err
@@ -57,5 +61,8 @@ func NewRevisionListCommand(p *KnParams) *cobra.Command {
 		},
 	}
 	revisionListPrintFlags.AddFlags(revisionListCmd)
+	revisionListCmd.PersistentFlags().BoolVar(&getAllNamespaces, "all-namespaces", false,
+		"If present, list the requested object(s) across all namespaces. Namespace in current "+
+			"context is ignored even if specified with --namespace.")
 	return revisionListCmd
 }

--- a/pkg/kn/commands/revision_list.go
+++ b/pkg/kn/commands/revision_list.go
@@ -59,6 +59,7 @@ func NewRevisionListCommand(p *KnParams) *cobra.Command {
 			return nil
 		},
 	}
+	AddNamespaceFlags(revisionListCmd.Flags(), true)
 	revisionListPrintFlags.AddFlags(revisionListCmd)
 	return revisionListCmd
 }

--- a/pkg/kn/commands/revision_list.go
+++ b/pkg/kn/commands/revision_list.go
@@ -25,7 +25,6 @@ var revisionListPrintFlags *genericclioptions.PrintFlags
 
 // listCmd represents the list command
 func NewRevisionListCommand(p *KnParams) *cobra.Command {
-	var getAllNamespaces bool
 	revisionListPrintFlags = genericclioptions.NewPrintFlags("").WithDefaultOutput(
 		"jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}")
 	revisionListCmd := &cobra.Command{
@@ -37,7 +36,7 @@ func NewRevisionListCommand(p *KnParams) *cobra.Command {
 				return err
 			}
 			namespace := cmd.Flag("namespace").Value.String()
-			if getAllNamespaces {
+			if p.getAllNamespaces {
 				namespace = ""
 			}
 			revision, err := client.Revisions(namespace).List(v1.ListOptions{})
@@ -61,8 +60,5 @@ func NewRevisionListCommand(p *KnParams) *cobra.Command {
 		},
 	}
 	revisionListPrintFlags.AddFlags(revisionListCmd)
-	revisionListCmd.PersistentFlags().BoolVar(&getAllNamespaces, "all-namespaces", false,
-		"If present, list the requested object(s) across all namespaces. Namespace in current "+
-			"context is ignored even if specified with --namespace.")
 	return revisionListCmd
 }

--- a/pkg/kn/commands/root.go
+++ b/pkg/kn/commands/root.go
@@ -37,8 +37,6 @@ var kubeCfgFile string
 type KnParams struct {
 	Output         io.Writer
 	ServingFactory func() (serving.ServingV1alpha1Interface, error)
-
-	getAllNamespaces bool
 }
 
 func (c *KnParams) Initialize() {

--- a/pkg/kn/commands/root.go
+++ b/pkg/kn/commands/root.go
@@ -37,6 +37,8 @@ var kubeCfgFile string
 type KnParams struct {
 	Output         io.Writer
 	ServingFactory func() (serving.ServingV1alpha1Interface, error)
+
+	getAllNamespaces bool
 }
 
 func (c *KnParams) Initialize() {

--- a/pkg/kn/commands/service.go
+++ b/pkg/kn/commands/service.go
@@ -23,10 +23,6 @@ func NewServiceCommand(p *KnParams) *cobra.Command {
 		Use:   "service",
 		Short: "Service command group",
 	}
-	serviceCmd.PersistentFlags().StringP("namespace", "n", "default", "Namespace to use.")
-	serviceCmd.PersistentFlags().BoolVar(&p.getAllNamespaces, "all-namespaces", false,
-		"If present, list the requested object(s) across all namespaces. Namespace in current "+
-			"context is ignored even if specified with --namespace.")
 	serviceCmd.AddCommand(NewServiceListCommand(p))
 	serviceCmd.AddCommand(NewServiceDescribeCommand(p))
 	serviceCmd.AddCommand(NewServiceCreateCommand(p))

--- a/pkg/kn/commands/service.go
+++ b/pkg/kn/commands/service.go
@@ -24,6 +24,9 @@ func NewServiceCommand(p *KnParams) *cobra.Command {
 		Short: "Service command group",
 	}
 	serviceCmd.PersistentFlags().StringP("namespace", "n", "default", "Namespace to use.")
+	serviceCmd.PersistentFlags().BoolVar(&p.getAllNamespaces, "all-namespaces", false,
+		"If present, list the requested object(s) across all namespaces. Namespace in current "+
+			"context is ignored even if specified with --namespace.")
 	serviceCmd.AddCommand(NewServiceListCommand(p))
 	serviceCmd.AddCommand(NewServiceDescribeCommand(p))
 	serviceCmd.AddCommand(NewServiceCreateCommand(p))

--- a/pkg/kn/commands/service_create.go
+++ b/pkg/kn/commands/service_create.go
@@ -46,7 +46,10 @@ func NewServiceCreateCommand(p *KnParams) *cobra.Command {
 				return errors.New("requires the image name to run.")
 			}
 
-			namespace := cmd.Flag("namespace").Value.String()
+			namespace, err := GetNamespace(cmd)
+			if err != nil {
+				return err
+			}
 
 			service := servingv1alpha1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -76,6 +79,7 @@ func NewServiceCreateCommand(p *KnParams) *cobra.Command {
 			return nil
 		},
 	}
+	AddNamespaceFlags(serviceCreateCommand.Flags(), false)
 	editFlags.AddFlags(serviceCreateCommand)
 	return serviceCreateCommand
 }

--- a/pkg/kn/commands/service_describe.go
+++ b/pkg/kn/commands/service_describe.go
@@ -59,6 +59,7 @@ func NewServiceDescribeCommand(p *KnParams) *cobra.Command {
 			return nil
 		},
 	}
+	AddNamespaceFlags(serviceDescribeCommand.Flags(), false)
 	serviceDescribePrintFlags.AddFlags(serviceDescribeCommand)
 	return serviceDescribeCommand
 }

--- a/pkg/kn/commands/service_describe.go
+++ b/pkg/kn/commands/service_describe.go
@@ -38,7 +38,10 @@ func NewServiceDescribeCommand(p *KnParams) *cobra.Command {
 				return err
 			}
 
-			namespace := cmd.Flag("namespace").Value.String()
+			namespace, err := GetNamespace(cmd)
+			if err != nil {
+				return err
+			}
 			describeService, err := client.Services(namespace).Get(args[0], v1.GetOptions{})
 			if err != nil {
 				return err

--- a/pkg/kn/commands/service_list.go
+++ b/pkg/kn/commands/service_list.go
@@ -59,6 +59,7 @@ func NewServiceListCommand(p *KnParams) *cobra.Command {
 			return nil
 		},
 	}
+	AddNamespaceFlags(serviceListCommand.Flags(), true)
 	serviceListPrintFlags.AddFlags(serviceListCommand)
 	return serviceListCommand
 }

--- a/pkg/kn/commands/service_list.go
+++ b/pkg/kn/commands/service_list.go
@@ -25,7 +25,7 @@ var serviceListPrintFlags *genericclioptions.PrintFlags
 
 // listCmd represents the list command
 func NewServiceListCommand(p *KnParams) *cobra.Command {
-
+	var getAllNamespaces bool
 	serviceListPrintFlags := genericclioptions.NewPrintFlags("").WithDefaultOutput(
 		"jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}")
 	serviceListCommand := &cobra.Command{
@@ -37,6 +37,9 @@ func NewServiceListCommand(p *KnParams) *cobra.Command {
 				return err
 			}
 			namespace := cmd.Flag("namespace").Value.String()
+			if getAllNamespaces {
+				namespace = ""
+			}
 			service, err := client.Services(namespace).List(v1.ListOptions{})
 			if err != nil {
 				return err
@@ -58,5 +61,8 @@ func NewServiceListCommand(p *KnParams) *cobra.Command {
 		},
 	}
 	serviceListPrintFlags.AddFlags(serviceListCommand)
+	serviceListCommand.PersistentFlags().BoolVar(&getAllNamespaces, "all-namespaces", false,
+		"If present, list the requested object(s) across all namespaces. Namespace in current "+
+			"context is ignored even if specified with --namespace.")
 	return serviceListCommand
 }

--- a/pkg/kn/commands/service_list.go
+++ b/pkg/kn/commands/service_list.go
@@ -35,9 +35,9 @@ func NewServiceListCommand(p *KnParams) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			namespace := cmd.Flag("namespace").Value.String()
-			if p.getAllNamespaces {
-				namespace = ""
+			namespace, err := GetNamespace(cmd)
+			if err != nil {
+				return err
 			}
 			service, err := client.Services(namespace).List(v1.ListOptions{})
 			if err != nil {

--- a/pkg/kn/commands/service_list.go
+++ b/pkg/kn/commands/service_list.go
@@ -25,7 +25,6 @@ var serviceListPrintFlags *genericclioptions.PrintFlags
 
 // listCmd represents the list command
 func NewServiceListCommand(p *KnParams) *cobra.Command {
-	var getAllNamespaces bool
 	serviceListPrintFlags := genericclioptions.NewPrintFlags("").WithDefaultOutput(
 		"jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}")
 	serviceListCommand := &cobra.Command{
@@ -37,7 +36,7 @@ func NewServiceListCommand(p *KnParams) *cobra.Command {
 				return err
 			}
 			namespace := cmd.Flag("namespace").Value.String()
-			if getAllNamespaces {
+			if p.getAllNamespaces {
 				namespace = ""
 			}
 			service, err := client.Services(namespace).List(v1.ListOptions{})
@@ -61,8 +60,5 @@ func NewServiceListCommand(p *KnParams) *cobra.Command {
 		},
 	}
 	serviceListPrintFlags.AddFlags(serviceListCommand)
-	serviceListCommand.PersistentFlags().BoolVar(&getAllNamespaces, "all-namespaces", false,
-		"If present, list the requested object(s) across all namespaces. Namespace in current "+
-			"context is ignored even if specified with --namespace.")
 	return serviceListCommand
 }


### PR DESCRIPTION
Currently `kn {service, revision} list` does not have the all-namespaces
options. Although it is possible to list them by `kn service list -n
""`(empty string), it is difficult to find such secret trick.

Hence, this patch adds `--all-namespaces` option.