### PR TITLE
Pick up default namespace from config

### DIFF
--- a/pkg/kn/commands/revision.go
+++ b/pkg/kn/commands/revision.go
@@ -23,7 +23,6 @@ func NewRevisionCommand(p *KnParams) *cobra.Command {
 		Use:   "revision",
 		Short: "Revision command group",
 	}
-	revisionCmd.PersistentFlags().StringP("namespace", "n", "default", "Namespace to use.")
 	revisionCmd.AddCommand(NewRevisionListCommand(p))
 	revisionCmd.AddCommand(NewRevisionDescribeCommand(p))
 	return revisionCmd

--- a/pkg/kn/commands/revision_list.go
+++ b/pkg/kn/commands/revision_list.go
@@ -23,10 +23,10 @@ import (
 
 var revisionListPrintFlags *genericclioptions.PrintFlags
 
-// listCmd represents the list command
+// NewRevisionListCommand represents the revision list command
 func NewRevisionListCommand(p *KnParams) *cobra.Command {
 	revisionListPrintFlags = genericclioptions.NewPrintFlags("").WithDefaultOutput(
-		"jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}")
+		"jsonpath={range .items[*]}{.metadata.namespace}{\"\\t\"}{.metadata.name}{\"\\n\"}{end}")
 	revisionListCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List available revisions.",
@@ -49,11 +49,7 @@ func NewRevisionListCommand(p *KnParams) *cobra.Command {
 				Group:   "knative.dev",
 				Version: "v1alpha1",
 				Kind:    "Revision"})
-			err = printer.PrintObj(revision, cmd.OutOrStdout())
-			if err != nil {
-				return err
-			}
-			return nil
+			return printer.PrintObj(revision, cmd.OutOrStdout())
 		},
 	}
 	revisionListPrintFlags.AddFlags(revisionListCmd)

--- a/pkg/kn/commands/root.go
+++ b/pkg/kn/commands/root.go
@@ -82,7 +82,12 @@ func InitializeConfig() {
 }
 
 func initKubeConfig() {
-	if kubeCfgFile == "" {
+	if kubeCfgFile != "" {
+		return
+	}
+	if kubeEnvConf, ok := os.LookupEnv("KUBECONFIG"); ok {
+		kubeCfgFile = kubeEnvConf
+	} else {
 		home, err := homedir.Dir()
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)

--- a/pkg/kn/commands/service.go
+++ b/pkg/kn/commands/service.go
@@ -23,7 +23,6 @@ func NewServiceCommand(p *KnParams) *cobra.Command {
 		Use:   "service",
 		Short: "Service command group",
 	}
-	serviceCmd.PersistentFlags().StringP("namespace", "n", "default", "Namespace to use.")
 	serviceCmd.AddCommand(NewServiceListCommand(p))
 	serviceCmd.AddCommand(NewServiceDescribeCommand(p))
 	return serviceCmd

--- a/pkg/kn/commands/service_describe.go
+++ b/pkg/kn/commands/service_describe.go
@@ -24,7 +24,6 @@ import (
 )
 
 func NewServiceDescribeCommand(p *KnParams) *cobra.Command {
-
 	serviceDescribePrintFlags := genericclioptions.NewPrintFlags("").WithDefaultOutput("yaml")
 	serviceDescribeCommand := &cobra.Command{
 		Use:   "describe NAME",

--- a/pkg/kn/commands/service_list.go
+++ b/pkg/kn/commands/service_list.go
@@ -23,11 +23,10 @@ import (
 
 var serviceListPrintFlags *genericclioptions.PrintFlags
 
-// listCmd represents the list command
+// NewServiceListCommand represents the service list command
 func NewServiceListCommand(p *KnParams) *cobra.Command {
-
 	serviceListPrintFlags := genericclioptions.NewPrintFlags("").WithDefaultOutput(
-		"jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}")
+		"jsonpath={range .items[*]}{.metadata.namespace}{\"\\t\"}{.metadata.name}{\"\\n\"}{end}")
 	serviceListCommand := &cobra.Command{
 		Use:   "list",
 		Short: "List available services.",
@@ -50,11 +49,7 @@ func NewServiceListCommand(p *KnParams) *cobra.Command {
 				Group:   "knative.dev",
 				Version: "v1alpha1",
 				Kind:    "Service"})
-			err = printer.PrintObj(service, cmd.OutOrStdout())
-			if err != nil {
-				return err
-			}
-			return nil
+			return printer.PrintObj(service, cmd.OutOrStdout())
 		},
 	}
 	serviceListPrintFlags.AddFlags(serviceListCommand)


### PR DESCRIPTION
Namespace parameter moved to root persistent flags. Function `setNamespace()` sets namespace from config context on CLI initialization. Resolves #7