### PR TITLE
Fix flag parse error by calling flag.Parse first

### DIFF
--- a/cmd/kn/main.go
+++ b/cmd/kn/main.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 
@@ -27,7 +26,6 @@ func init() {
 }
 
 func main() {
-	flag.Parse()
 	err := commands.NewKnCommand().Execute()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/kn/main.go
+++ b/cmd/kn/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 
@@ -26,6 +27,7 @@ func init() {
 }
 
 func main() {
+	flag.Parse()
 	err := commands.NewKnCommand().Execute()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/pkg/kn/commands/root.go
+++ b/pkg/kn/commands/root.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -73,6 +74,9 @@ Eventing: Manage event subscriptions and channels. Connect up event sources.`,
 	rootCmd.AddCommand(NewServiceCommand(p))
 	rootCmd.AddCommand(NewRevisionCommand(p))
 	rootCmd.AddCommand(NewCompletionCommand(p))
+
+	// For glog parse error.
+	flag.CommandLine.Parse([]string{})
 	return rootCmd
 }
 


### PR DESCRIPTION
This patch adds flag.Parse() to avoid `logging before flag.Parse` error.

c.f. -  other repository also solved the issue by calling `flag.Parse()` first.

https://github.com/knative/eventing/blob/8ba0b39f5150f8fae7184ab189f4086cbc98bf42/contrib/gcppubsub/pkg/dispatcher/cmd/main.go#L46

Fixes https://github.com/knative/client/issues/37