### PR TITLE
`service create` beginning implementation

### DIFF
--- a/pkg/kn/commands/configuration_edit_flags.go
+++ b/pkg/kn/commands/configuration_edit_flags.go
@@ -14,10 +14,31 @@
 
 package commands
 
-import "github.com/spf13/cobra"
+import (
+	serving_lib "github.com/knative/client/pkg/serving"
+	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/spf13/cobra"
+)
 
-func AddConfigurationEditFlags(command *cobra.Command, image *string, env *map[string]string) {
-	command.Flags().StringVar(image, "image", "", "Image to run.")
-	command.Flags().StringToStringVar(env, "env", map[string]string{},
+type ConfigurationEditFlags struct {
+	Image string
+	Env   map[string]string
+}
+
+func (p *ConfigurationEditFlags) AddFlags(command *cobra.Command) {
+	command.Flags().StringVar(&p.Image, "image", "", "Image to run.")
+	command.Flags().StringToStringVar(&p.Env, "env", map[string]string{},
 		"Environment, comma-separated NAME=value.")
+}
+
+func (p *ConfigurationEditFlags) Apply(config *servingv1alpha1.ConfigurationSpec) (err error) {
+	err = serving_lib.UpdateEnvVars(config, p.Env)
+	if err != nil {
+		return err
+	}
+	err = serving_lib.UpdateImage(config, p.Image)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/kn/commands/configuration_edit_flags.go
+++ b/pkg/kn/commands/configuration_edit_flags.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"strings"
 
-	serving_lib "github.com/knative/client/pkg/serving"
+	servinglib "github.com/knative/client/pkg/serving"
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/spf13/cobra"
 )
@@ -35,7 +35,7 @@ func (p *ConfigurationEditFlags) AddFlags(command *cobra.Command) {
 			"any number of times to set multiple environment variables.")
 }
 
-func (p *ConfigurationEditFlags) Apply(config *servingv1alpha1.ConfigurationSpec) (err error) {
+func (p *ConfigurationEditFlags) Apply(config *servingv1alpha1.ConfigurationSpec) error {
 	envMap := map[string]string{}
 	for _, pairStr := range p.Env {
 		pairSlice := strings.SplitN(pairStr, "=", 2)
@@ -46,11 +46,11 @@ func (p *ConfigurationEditFlags) Apply(config *servingv1alpha1.ConfigurationSpec
 		}
 		envMap[pairSlice[0]] = pairSlice[1]
 	}
-	err = serving_lib.UpdateEnvVars(config, envMap)
+	err := servinglib.UpdateEnvVars(config, envMap)
 	if err != nil {
 		return err
 	}
-	err = serving_lib.UpdateImage(config, p.Image)
+	err = servinglib.UpdateImage(config, p.Image)
 	if err != nil {
 		return err
 	}

--- a/pkg/kn/commands/configuration_edit_flags.go
+++ b/pkg/kn/commands/configuration_edit_flags.go
@@ -14,18 +14,10 @@
 
 package commands
 
-import (
-	"github.com/spf13/cobra"
-)
+import "github.com/spf13/cobra"
 
-func NewServiceCommand(p *KnParams) *cobra.Command {
-	serviceCmd := &cobra.Command{
-		Use:   "service",
-		Short: "Service command group",
-	}
-	serviceCmd.PersistentFlags().StringP("namespace", "n", "default", "Namespace to use.")
-	serviceCmd.AddCommand(NewServiceListCommand(p))
-	serviceCmd.AddCommand(NewServiceDescribeCommand(p))
-	serviceCmd.AddCommand(NewServiceCreateCommand(p))
-	return serviceCmd
+func AddConfigurationEditFlags(command *cobra.Command, image *string, env *map[string]string) {
+	command.Flags().StringVar(image, "image", "", "Image to run.")
+	command.Flags().StringToStringVar(env, "env", map[string]string{},
+		"Environment, comma-separated NAME=value.")
 }

--- a/pkg/kn/commands/service_create.go
+++ b/pkg/kn/commands/service_create.go
@@ -17,23 +17,31 @@ package commands
 import (
 	"errors"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 
+	serving_cli "github.com/knative/client/pkg/serving"
 	"github.com/spf13/cobra"
 )
 
-func NewCreateCommand(p *KnParams) *cobra.Command {
+func NewServiceCreateCommand(p *KnParams) *cobra.Command {
+
+	var image string
+	var env map[string]string
 
 	serviceCreateCommand := &cobra.Command{
 		Use:   "create NAME",
 		Short: "Create a service.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := p.ServingFactory()
-			if err != nil {
-				return err
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			changes := []serving_cli.ConfigChange{}
+			if image != "" {
+				changes = append(changes, serving_cli.ImageUpdate(image))
+			}
+			if len(env) > 0 {
+				changes = append(changes, serving_cli.EnvVarUpdate(env))
 			}
 
 			if len(args) < 1 {
@@ -47,7 +55,17 @@ func NewCreateCommand(p *KnParams) *cobra.Command {
 					Name:      args[0],
 					Namespace: namespace,
 				},
-				Spec: servingv1alpha1.ServiceSpec{},
+				Spec: servingv1alpha1.ServiceSpec{
+					RunLatest: &servingv1alpha1.RunLatestType{
+						Configuration: servingv1alpha1.ConfigurationSpec{
+							RevisionTemplate: servingv1alpha1.RevisionTemplateSpec{
+								Spec: servingv1alpha1.RevisionSpec{
+									Container: corev1.Container{},
+								},
+							},
+						},
+					},
+				},
 			}
 			service.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
 				Group:   "knative.dev",
@@ -55,8 +73,26 @@ func NewCreateCommand(p *KnParams) *cobra.Command {
 				Kind:    "Service"},
 			)
 
+			for _, change := range changes {
+				err = change(&service.Spec.RunLatest.Configuration)
+				if err != nil {
+					return err
+				}
+			}
+
+			client, err := p.ServingFactory()
+			if err != nil {
+				return err
+			}
+
+			_, err = client.Services(namespace).Create(&service)
+			if err != nil {
+				return err
+			}
+
 			return nil
 		},
 	}
+	AddConfigurationEditFlags(serviceCreateCommand, &image, &env)
 	return serviceCreateCommand
 }

--- a/pkg/kn/commands/service_create.go
+++ b/pkg/kn/commands/service_create.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 
@@ -27,14 +26,13 @@ import (
 )
 
 func NewServiceCreateCommand(p *KnParams) *cobra.Command {
-
 	var editFlags ConfigurationEditFlags
 
 	serviceCreateCommand := &cobra.Command{
 		Use:   "create NAME",
 		Short: "Create a service.",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			if len(args) < 1 {
+			if len(args) != 1 {
 				return errors.New("requires the service name.")
 			}
 
@@ -47,11 +45,6 @@ func NewServiceCreateCommand(p *KnParams) *cobra.Command {
 				},
 			}
 			service.Spec.RunLatest = &servingv1alpha1.RunLatestType{}
-			service.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   "knative.dev",
-				Version: "v1alpha1",
-				Kind:    "Service"},
-			)
 
 			config, err := serving_lib.GetConfiguration(&service)
 			if err != nil {

--- a/pkg/kn/commands/service_create.go
+++ b/pkg/kn/commands/service_create.go
@@ -1,0 +1,62 @@
+// Copyright © 2019 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"errors"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCreateCommand(p *KnParams) *cobra.Command {
+
+	serviceCreateCommand := &cobra.Command{
+		Use:   "create NAME",
+		Short: "Create a service.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := p.ServingFactory()
+			if err != nil {
+				return err
+			}
+
+			if len(args) < 1 {
+				return errors.New("requires the service name.")
+			}
+
+			namespace := cmd.Flag("namespace").Value.String()
+
+			service := servingv1alpha1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      args[0],
+					Namespace: namespace,
+				},
+				Spec: servingv1alpha1.ServiceSpec{},
+			}
+			service.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "knative.dev",
+				Version: "v1alpha1",
+				Kind:    "Service"},
+			)
+
+			return nil
+		},
+	}
+	return serviceCreateCommand
+}

--- a/pkg/kn/commands/service_create.go
+++ b/pkg/kn/commands/service_create.go
@@ -17,33 +17,23 @@ package commands
 import (
 	"errors"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 
-	serving_cli "github.com/knative/client/pkg/serving"
+	serving_lib "github.com/knative/client/pkg/serving"
 	"github.com/spf13/cobra"
 )
 
 func NewServiceCreateCommand(p *KnParams) *cobra.Command {
 
-	var image string
-	var env map[string]string
+	var editFlags ConfigurationEditFlags
 
 	serviceCreateCommand := &cobra.Command{
 		Use:   "create NAME",
 		Short: "Create a service.",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			changes := []serving_cli.ConfigChange{}
-			if image != "" {
-				changes = append(changes, serving_cli.ImageUpdate(image))
-			}
-			if len(env) > 0 {
-				changes = append(changes, serving_cli.EnvVarUpdate(env))
-			}
-
 			if len(args) < 1 {
 				return errors.New("requires the service name.")
 			}
@@ -55,36 +45,26 @@ func NewServiceCreateCommand(p *KnParams) *cobra.Command {
 					Name:      args[0],
 					Namespace: namespace,
 				},
-				Spec: servingv1alpha1.ServiceSpec{
-					RunLatest: &servingv1alpha1.RunLatestType{
-						Configuration: servingv1alpha1.ConfigurationSpec{
-							RevisionTemplate: servingv1alpha1.RevisionTemplateSpec{
-								Spec: servingv1alpha1.RevisionSpec{
-									Container: corev1.Container{},
-								},
-							},
-						},
-					},
-				},
 			}
+			service.Spec.RunLatest = &servingv1alpha1.RunLatestType{}
 			service.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
 				Group:   "knative.dev",
 				Version: "v1alpha1",
 				Kind:    "Service"},
 			)
 
-			for _, change := range changes {
-				err = change(&service.Spec.RunLatest.Configuration)
-				if err != nil {
-					return err
-				}
+			config, err := serving_lib.GetConfiguration(&service)
+			if err != nil {
+				return err
 			}
-
+			err = editFlags.Apply(config)
+			if err != nil {
+				return err
+			}
 			client, err := p.ServingFactory()
 			if err != nil {
 				return err
 			}
-
 			_, err = client.Services(namespace).Create(&service)
 			if err != nil {
 				return err
@@ -93,6 +73,6 @@ func NewServiceCreateCommand(p *KnParams) *cobra.Command {
 			return nil
 		},
 	}
-	AddConfigurationEditFlags(serviceCreateCommand, &image, &env)
+	editFlags.AddFlags(serviceCreateCommand)
 	return serviceCreateCommand
 }

--- a/pkg/kn/commands/service_create_test.go
+++ b/pkg/kn/commands/service_create_test.go
@@ -91,10 +91,12 @@ func TestServiceCreateEnv(t *testing.T) {
 	} else if !action.Matches("create", "services") {
 		t.Fatalf("Bad action %v", action)
 	}
-	conf, err := serving_lib.GetConfiguration(created)
+
 	expectedEnvVars := []corev1.EnvVar{
 		corev1.EnvVar{Name: "A", Value: "DOGS"},
 		corev1.EnvVar{Name: "B", Value: "WOLVES"}}
+
+	conf, err := serving_lib.GetConfiguration(created)
 	if err != nil {
 		t.Fatal(err)
 	} else if conf.RevisionTemplate.Spec.Container.Image != "gcr.io/foo/bar:baz" {

--- a/pkg/kn/commands/service_create_test.go
+++ b/pkg/kn/commands/service_create_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	serving_lib "github.com/knative/client/pkg/serving"
+	servinglib "github.com/knative/client/pkg/serving"
 
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	serving "github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
@@ -73,7 +73,7 @@ func TestServiceCreateImage(t *testing.T) {
 	} else if !action.Matches("create", "services") {
 		t.Fatalf("Bad action %v", action)
 	}
-	conf, err := serving_lib.GetConfiguration(created)
+	conf, err := servinglib.GetConfiguration(created)
 	if err != nil {
 		t.Fatal(err)
 	} else if conf.RevisionTemplate.Spec.Container.Image != "gcr.io/foo/bar:baz" {
@@ -95,8 +95,8 @@ func TestServiceCreateEnv(t *testing.T) {
 		"A": "DOGS",
 		"B": "WOLVES"}
 
-	conf, err := serving_lib.GetConfiguration(created)
-	actualEnvVars, err := serving_lib.EnvToMap(conf.RevisionTemplate.Spec.Container.Env)
+	conf, err := servinglib.GetConfiguration(created)
+	actualEnvVars, err := servinglib.EnvToMap(conf.RevisionTemplate.Spec.Container.Env)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kn/commands/service_create_test.go
+++ b/pkg/kn/commands/service_create_test.go
@@ -1,0 +1,106 @@
+// Copyright © 2019 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	serving_lib "github.com/knative/client/pkg/serving"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	serving "github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
+	"github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1/fake"
+	"k8s.io/apimachinery/pkg/runtime"
+	client_testing "k8s.io/client-go/testing"
+)
+
+func fakeServiceCreate(args []string) (
+	action client_testing.Action,
+	created *v1alpha1.Service,
+	output string,
+	err error) {
+
+	buf := new(bytes.Buffer)
+	fakeServing := &fake.FakeServingV1alpha1{&client_testing.Fake{}}
+	cmd := NewKnCommand(KnParams{
+		Output:         buf,
+		ServingFactory: func() (serving.ServingV1alpha1Interface, error) { return fakeServing, nil },
+	})
+	fakeServing.AddReactor("*", "*",
+		func(a client_testing.Action) (bool, runtime.Object, error) {
+			createAction, ok := a.(client_testing.CreateAction)
+			action = createAction
+			if !ok {
+				return true, nil, fmt.Errorf("wrong kind of action %v", action)
+			}
+			created, ok = createAction.GetObject().(*v1alpha1.Service)
+			if !ok {
+				return true, nil, errors.New("was passed the wrong object")
+			}
+			return true, created, nil
+		})
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	if err != nil {
+		return
+	}
+	output = buf.String()
+	return
+}
+
+func TestServiceCreateImage(t *testing.T) {
+	action, created, _, err := fakeServiceCreate([]string{
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz"})
+
+	if err != nil {
+		t.Fatal(err)
+	} else if !action.Matches("create", "services") {
+		t.Fatalf("Bad action %v", action)
+	}
+	conf, err := serving_lib.GetConfiguration(created)
+	if err != nil {
+		t.Fatal(err)
+	} else if conf.RevisionTemplate.Spec.Container.Image != "gcr.io/foo/bar:baz" {
+		t.Fatalf("wrong image set: %v", conf.RevisionTemplate.Spec.Container.Image)
+	}
+}
+
+func TestServiceCreateEnv(t *testing.T) {
+	action, created, _, err := fakeServiceCreate([]string{
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--env", "A=DOGS,B=WOLVES"})
+
+	if err != nil {
+		t.Fatal(err)
+	} else if !action.Matches("create", "services") {
+		t.Fatalf("Bad action %v", action)
+	}
+	conf, err := serving_lib.GetConfiguration(created)
+	expectedEnvVars := []corev1.EnvVar{
+		corev1.EnvVar{Name: "A", Value: "DOGS"},
+		corev1.EnvVar{Name: "B", Value: "WOLVES"}}
+	if err != nil {
+		t.Fatal(err)
+	} else if conf.RevisionTemplate.Spec.Container.Image != "gcr.io/foo/bar:baz" {
+		t.Fatalf("wrong image set: %v", conf.RevisionTemplate.Spec.Container.Image)
+	} else if !reflect.DeepEqual(conf.RevisionTemplate.Spec.Container.Env, expectedEnvVars) {
+		t.Fatalf("wrong env vars %v", conf.RevisionTemplate.Spec.Container.Env)
+	}
+
+}

--- a/pkg/serving/config_changes.go
+++ b/pkg/serving/config_changes.go
@@ -1,4 +1,4 @@
-// Copyright ¬© 2018 The Knative Authors
+// Copyright ¬© 2019 The Knative Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 package serving
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
@@ -22,7 +24,8 @@ import (
 
 func UpdateEnvVars(config *servingv1alpha1.ConfigurationSpec, vars map[string]string) error {
 	set := make(map[string]bool)
-	for _, env_var := range config.RevisionTemplate.Spec.Container.Env {
+	for i, _ := range config.RevisionTemplate.Spec.Container.Env {
+		env_var := &config.RevisionTemplate.Spec.Container.Env[i]
 		value, present := vars[env_var.Name]
 		if present {
 			env_var.Value = value
@@ -39,6 +42,18 @@ func UpdateEnvVars(config *servingv1alpha1.ConfigurationSpec, vars map[string]st
 	}
 	return nil
 
+}
+
+func EnvToMap(vars []corev1.EnvVar) (map[string]string, error) {
+	result := map[string]string{}
+	for _, env_var := range vars {
+		_, present := result[env_var.Name]
+		if present {
+			return nil, fmt.Errorf("Env var name present more than once: %v", env_var.Name)
+		}
+		result[env_var.Name] = env_var.Value
+	}
+	return result, nil
 }
 
 func UpdateImage(config *servingv1alpha1.ConfigurationSpec, image string) error {

--- a/pkg/serving/config_changes.go
+++ b/pkg/serving/config_changes.go
@@ -20,8 +20,6 @@ import (
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 )
 
-type ConfigChange func(*servingv1alpha1.ConfigurationSpec) error
-
 func UpdateEnvVars(config *servingv1alpha1.ConfigurationSpec, vars map[string]string) error {
 	set := make(map[string]bool)
 	for _, env_var := range config.RevisionTemplate.Spec.Container.Env {

--- a/pkg/serving/config_changes.go
+++ b/pkg/serving/config_changes.go
@@ -1,4 +1,4 @@
-// Copyright ¬© 2019 The Knative Authors
+// Copyright © 2019 The Knative Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/serving/config_changes.go
+++ b/pkg/serving/config_changes.go
@@ -22,6 +22,9 @@ import (
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 )
 
+// Give the configuration all the env var values listed in the given map of
+// vars.  Does not touch any environment variables not mentioned, but it can add
+// new env vars and change the values of existing ones.
 func UpdateEnvVars(config *servingv1alpha1.ConfigurationSpec, vars map[string]string) error {
 	set := make(map[string]bool)
 	for i, _ := range config.RevisionTemplate.Spec.Container.Env {
@@ -34,16 +37,20 @@ func UpdateEnvVars(config *servingv1alpha1.ConfigurationSpec, vars map[string]st
 	}
 	for name, value := range vars {
 		if !set[name] {
-			config.RevisionTemplate.Spec.Container.Env = append(config.RevisionTemplate.Spec.Container.Env, corev1.EnvVar{
-				Name:  name,
-				Value: value,
-			})
+			config.RevisionTemplate.Spec.Container.Env = append(
+				config.RevisionTemplate.Spec.Container.Env,
+				corev1.EnvVar{
+					Name:  name,
+					Value: value,
+				})
 		}
 	}
 	return nil
 
 }
 
+// Utility function to translate between the API list form of env vars, and the
+// more convenient map form.
 func EnvToMap(vars []corev1.EnvVar) (map[string]string, error) {
 	result := map[string]string{}
 	for _, env_var := range vars {

--- a/pkg/serving/config_changes.go
+++ b/pkg/serving/config_changes.go
@@ -22,31 +22,28 @@ import (
 
 type ConfigChange func(*servingv1alpha1.ConfigurationSpec) error
 
-func EnvVarUpdate(vars map[string]string) ConfigChange {
-	return func(config *servingv1alpha1.ConfigurationSpec) error {
-		set := make(map[string]bool)
-		for _, env_var := range config.RevisionTemplate.Spec.Container.Env {
-			value, present := vars[env_var.Name]
-			if present {
-				env_var.Value = value
-				set[env_var.Name] = true
-			}
+func UpdateEnvVars(config *servingv1alpha1.ConfigurationSpec, vars map[string]string) error {
+	set := make(map[string]bool)
+	for _, env_var := range config.RevisionTemplate.Spec.Container.Env {
+		value, present := vars[env_var.Name]
+		if present {
+			env_var.Value = value
+			set[env_var.Name] = true
 		}
-		for name, value := range vars {
-			if !set[name] {
-				config.RevisionTemplate.Spec.Container.Env = append(config.RevisionTemplate.Spec.Container.Env, corev1.EnvVar{
-					Name:  name,
-					Value: value,
-				})
-			}
-		}
-		return nil
 	}
+	for name, value := range vars {
+		if !set[name] {
+			config.RevisionTemplate.Spec.Container.Env = append(config.RevisionTemplate.Spec.Container.Env, corev1.EnvVar{
+				Name:  name,
+				Value: value,
+			})
+		}
+	}
+	return nil
+
 }
 
-func ImageUpdate(image string) ConfigChange {
-	return func(config *servingv1alpha1.ConfigurationSpec) error {
-		config.RevisionTemplate.Spec.Container.Image = image
-		return nil
-	}
+func UpdateImage(config *servingv1alpha1.ConfigurationSpec, image string) error {
+	config.RevisionTemplate.Spec.Container.Image = image
+	return nil
 }

--- a/pkg/serving/config_changes.go
+++ b/pkg/serving/config_changes.go
@@ -1,0 +1,25 @@
+// Copyright ¬© 2018 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serving
+
+import (
+	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+)
+
+type ConfigChange func(*servingv1alpha1.ConfigurationSpec) error
+
+func EnvVarUpdate(vars map[string]string) ConfigChange {
+
+}

--- a/pkg/serving/config_changes.go
+++ b/pkg/serving/config_changes.go
@@ -28,11 +28,11 @@ import (
 func UpdateEnvVars(config *servingv1alpha1.ConfigurationSpec, vars map[string]string) error {
 	set := make(map[string]bool)
 	for i, _ := range config.RevisionTemplate.Spec.Container.Env {
-		env_var := &config.RevisionTemplate.Spec.Container.Env[i]
-		value, present := vars[env_var.Name]
+		envVar := &config.RevisionTemplate.Spec.Container.Env[i]
+		value, present := vars[envVar.Name]
 		if present {
-			env_var.Value = value
-			set[env_var.Name] = true
+			envVar.Value = value
+			set[envVar.Name] = true
 		}
 	}
 	for name, value := range vars {
@@ -53,12 +53,12 @@ func UpdateEnvVars(config *servingv1alpha1.ConfigurationSpec, vars map[string]st
 // more convenient map form.
 func EnvToMap(vars []corev1.EnvVar) (map[string]string, error) {
 	result := map[string]string{}
-	for _, env_var := range vars {
-		_, present := result[env_var.Name]
+	for _, envVar := range vars {
+		_, present := result[envVar.Name]
 		if present {
-			return nil, fmt.Errorf("Env var name present more than once: %v", env_var.Name)
+			return nil, fmt.Errorf("Env var name present more than once: %v", envVar.Name)
 		}
-		result[env_var.Name] = env_var.Value
+		result[envVar.Name] = envVar.Value
 	}
 	return result, nil
 }

--- a/pkg/serving/config_changes_test.go
+++ b/pkg/serving/config_changes_test.go
@@ -1,0 +1,122 @@
+// Copyright ¬© 2019 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serving
+
+import (
+	"reflect"
+	"testing"
+
+	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestUpdateEnvVarsNew(t *testing.T) {
+	config := servingv1alpha1.ConfigurationSpec{}
+	env := map[string]string{
+		"a": "foo",
+		"b": "bar",
+	}
+	err := UpdateEnvVars(&config, env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found, err := EnvToMap(config.RevisionTemplate.Spec.Container.Env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(env, found) {
+		t.Fatalf("Env did not match expected %v found %v", env, found)
+	}
+}
+
+func TestUpdateEnvVarsAppend(t *testing.T) {
+	config := servingv1alpha1.ConfigurationSpec{}
+	config.RevisionTemplate.Spec.Container.Env = []corev1.EnvVar{
+		corev1.EnvVar{Name: "a", Value: "foo"}}
+	env := map[string]string{
+		"b": "bar",
+	}
+	err := UpdateEnvVars(&config, env)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := map[string]string{
+		"a": "foo",
+		"b": "bar",
+	}
+
+	found, err := EnvToMap(config.RevisionTemplate.Spec.Container.Env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(expected, found) {
+		t.Fatalf("Env did not match expected %v found %v", env, found)
+	}
+}
+
+func TestUpdateEnvVarsModify(t *testing.T) {
+	config := servingv1alpha1.ConfigurationSpec{}
+	config.RevisionTemplate.Spec.Container.Env = []corev1.EnvVar{
+		corev1.EnvVar{Name: "a", Value: "foo"}}
+	env := map[string]string{
+		"a": "fancy",
+	}
+	err := UpdateEnvVars(&config, env)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := map[string]string{
+		"a": "fancy",
+	}
+
+	found, err := EnvToMap(config.RevisionTemplate.Spec.Container.Env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(expected, found) {
+		t.Fatalf("Env did not match expected %v found %v", env, found)
+	}
+}
+
+func TestUpdateEnvVarsBoth(t *testing.T) {
+	config := servingv1alpha1.ConfigurationSpec{}
+	config.RevisionTemplate.Spec.Container.Env = []corev1.EnvVar{
+		corev1.EnvVar{Name: "a", Value: "foo"},
+		corev1.EnvVar{Name: "c", Value: "caroline"}}
+	env := map[string]string{
+		"a": "fancy",
+		"b": "boo",
+	}
+	err := UpdateEnvVars(&config, env)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := map[string]string{
+		"a": "fancy",
+		"b": "boo",
+		"c": "caroline",
+	}
+
+	found, err := EnvToMap(config.RevisionTemplate.Spec.Container.Env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(expected, found) {
+		t.Fatalf("Env did not match expected %v found %v", env, found)
+	}
+}

--- a/pkg/serving/service.go
+++ b/pkg/serving/service.go
@@ -1,0 +1,33 @@
+// Copyright © 2019 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serving
+
+import (
+	"errors"
+
+	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+)
+
+func GetConfiguration(service *servingv1alpha1.Service) (*servingv1alpha1.ConfigurationSpec, error) {
+	if service.Spec.RunLatest != nil {
+		return &service.Spec.RunLatest.Configuration, nil
+	} else if service.Spec.Release != nil {
+		return &service.Spec.Release.Configuration, nil
+	} else if service.Spec.Pinned != nil {
+		return &service.Spec.Pinned.Configuration, nil
+	} else {
+		return nil, errors.New("Service does not specify a Configuration")
+	}
+}


### PR DESCRIPTION
This implements `kn service create` supporting only the `--image` and `--env` flags.

It also provides a structure for collecting flags that will be in common between `create`, `update`, and `replace`, and using them to modify a Configuration (so they can also be reused for `configuration create` etc later)