### PR TITLE
 Update test-infra to use the new cluster_setup function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/knative/build v0.3.0 // indirect
 	github.com/knative/pkg v0.0.0-20190110005142-b6044a7d1795 // indirect
 	github.com/knative/serving v0.3.0
-	github.com/knative/test-infra v0.0.0-20190326053250-44d850784ecb
+	github.com/knative/test-infra v0.0.0-20190404172656-4ce16d390c55
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a // indirect
 	github.com/mitchellh/go-homedir v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/knative/serving v0.3.0 h1:kALSwD+P5GLdRj2mtZ2W4ZRRD//Q7nKjLqCPSpihkTY
 github.com/knative/serving v0.3.0/go.mod h1:ljvMfwQy2qanaM/8xnBSK4Mz3Vv2NawC2fo5kFRJS1A=
 github.com/knative/test-infra v0.0.0-20190326053250-44d850784ecb h1:4wAx6g3pRhmnnxvrX2pYB7z/2nhBtgLO/JJEZSjP1pY=
 github.com/knative/test-infra v0.0.0-20190326053250-44d850784ecb/go.mod h1:l77IWBscEV5T4sYb64/9iwRCVY4UXEIqMcAppsblHW4=
+github.com/knative/test-infra v0.0.0-20190404172656-4ce16d390c55 h1:2tpTEN6OydMWVmkKJC3iVNrYbA+iHNL9qjLXe7hocfE=
+github.com/knative/test-infra v0.0.0-20190404172656-4ce16d390c55/go.mod h1:l77IWBscEV5T4sYb64/9iwRCVY4UXEIqMcAppsblHW4=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,7 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/json-iterator/go v1.1.5 h1:gL2yXlmiIo4+t+y32d4WGwOjKGYcGOuyrg46vadswDE=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -133,6 +134,7 @@ golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c h1:fqgJT0MGcGpPgpWU7VRdRjuArfcOvC4AoJmILihzhDg=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -28,6 +28,12 @@ source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/e2e-tests.s
 
 # Helper functions.
 
+# Build kn before integration tests, so we fail fast in case of error.
+function cluster_setup() {
+  header "Building client"
+  go build -v ./cmd/... || return 1
+}
+
 function knative_setup() {
   start_latest_knative_serving
 }

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -25,7 +25,6 @@
 # project $PROJECT_ID, start Knative serving and the eventing system, run
 # the tests and delete the cluster.
 
-export GO111MODULE=on
 source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
 
 # Helper functions.
@@ -45,7 +44,7 @@ function knative_teardown() {
 
 initialize $@
 
-go build -v ./... || fail_test
+header "Running tests"
 
 ./kn service list || fail_test
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -32,16 +32,8 @@ function knative_setup() {
   start_latest_knative_serving
 }
 
-function build_kn() {
-  header "Building client"
-  GO111MODULE=on go build -v ./cmd/... || fail_test "Error building kn"
-}
-
 
 # Script entry point.
-
-# Build kn before starting knative, so we fail fast in case of error.
-(( ! RUN_TESTS )) && build_kn
 
 initialize $@
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -32,12 +32,16 @@ function knative_setup() {
   start_latest_knative_serving
 }
 
+function build_kn() {
+  header "Building client"
+  GO111MODULE=on go build -v ./cmd/... || fail_test "Error building kn"
+}
+
 
 # Script entry point.
 
-header "Building client"
-
-GO111MODULE=on go build -v ./cmd/...
+# Build kn before starting knative, so we fail fast in case of error.
+(( ! RUN_TESTS )) && build_kn
 
 initialize $@
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -14,33 +14,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script runs the end-to-end tests against the eventing sources
-# built from source.
+# This script runs the end-to-end tests for the kn client.
 
 # If you already have the `KO_DOCKER_REPO` environment variable set and a
 # cluster setup and currently selected in your kubeconfig, call the script
 # with the `--run-tests` argument and it will use the cluster and run the tests.
 
 # Calling this script without arguments will create a new cluster in
-# project $PROJECT_ID, start Knative serving and the eventing system, run
-# the tests and delete the cluster.
+# project $PROJECT_ID, start Knative serving, run the tests and delete
+# the cluster.
 
 source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
 
 # Helper functions.
 
 function knative_setup() {
-  start_latest_knative_serving || return 1
-}
-
-function knative_teardown() {
-  kubectl delete --ignore-not-found=true -f ${KNATIVE_SERVING_RELEASE}
-
-  wait_until_object_does_not_exist namespaces knative-eventing
+  start_latest_knative_serving
 }
 
 
 # Script entry point.
+
+header "Building client"
+
+GO111MODULE=on go build -v ./cmd/...
 
 initialize $@
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script runs the end-to-end tests against the eventing sources
+# built from source.
+
+# If you already have the `KO_DOCKER_REPO` environment variable set and a
+# cluster setup and currently selected in your kubeconfig, call the script
+# with the `--run-tests` argument and it will use the cluster and run the tests.
+
+# Calling this script without arguments will create a new cluster in
+# project $PROJECT_ID, start Knative serving and the eventing system, run
+# the tests and delete the cluster.
+
+export GO111MODULE=on
+source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+
+# Helper functions.
+
+function knative_setup() {
+  start_latest_knative_serving || return 1
+}
+
+function knative_teardown() {
+  kubectl delete --ignore-not-found=true -f ${KNATIVE_SERVING_RELEASE}
+
+  wait_until_object_does_not_exist namespaces knative-eventing
+}
+
+
+# Script entry point.
+
+initialize $@
+
+go build -v ./... || fail_test
+
+./kn service list || fail_test
+
+success

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -56,4 +56,9 @@ function build_tests() {
   return ${failed}
 }
 
+function pre_integration_tests() {
+  subheader "Building go code"
+  go build -v ./... || return 1
+}
+
 main $@

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -56,4 +56,10 @@ function build_tests() {
   return ${failed}
 }
 
+# Build kn before integration tests, so we fail fast in case of error.
+function pre_integration_tests() {
+  subheader "Building client"
+  go build -v ./cmd/... || return 1
+}
+
 main $@

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -56,9 +56,4 @@ function build_tests() {
   return ${failed}
 }
 
-function pre_integration_tests() {
-  subheader "Building client"
-  go build -v ./cmd/... || return 1
-}
-
 main $@

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -57,8 +57,8 @@ function build_tests() {
 }
 
 function pre_integration_tests() {
-  subheader "Building go code"
-  go build -v ./... || return 1
+  subheader "Building client"
+  go build -v ./cmd/... || return 1
 }
 
 main $@

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -56,10 +56,4 @@ function build_tests() {
   return ${failed}
 }
 
-# Build kn before integration tests, so we fail fast in case of error.
-function pre_integration_tests() {
-  subheader "Building client"
-  go build -v ./cmd/... || return 1
-}
-
 main $@

--- a/vendor/github.com/knative/test-infra/scripts/README.md
+++ b/vendor/github.com/knative/test-infra/scripts/README.md
@@ -33,6 +33,8 @@ This is a helper script to run the presubmit tests. To use it:
    - `DISABLE_MD_LINTING`: Disable linting markdown files, defaults to 0 (false).
    - `DISABLE_MD_LINK_CHECK`: Disable checking links in markdown files, defaults
      to 0 (false).
+   - `PRESUBMIT_TEST_FAIL_FAST`: Fail the presubmit test immediately if a test fails,
+     defaults to 0 (false).
 
 1. [optional] Define the functions `pre_build_tests()` and/or
    `post_build_tests()`. These functions will be called before or after the
@@ -130,9 +132,15 @@ This is a helper script for Knative E2E test scripts. To use it:
 1. [optional] Write the `test_teardown()` function, which will tear down the test
    resources.
 
+1. [optional] Write the `cluster_setup()` function, which will set up any resources
+   before the test cluster is created.
+
+1. [optional] Write the `cluster_teardown()` function, which will tear down any
+   resources after the test cluster is destroyed.
+
 1. [optional] Write the `dump_extra_cluster_state()` function. It will be
    called when a test fails, and can dump extra information about the current state
-   of the cluster (tipically using `kubectl`).
+   of the cluster (typically using `kubectl`).
 
 1. [optional] Write the `parse_flags()` function. It will be called whenever an
    unrecognized flag is passed to the script, allowing you to define your own flags.

--- a/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
@@ -120,11 +120,39 @@ function save_metadata() {
 EOF
 }
 
+# Delete target pools and health checks that might have leaked.
+# See https://github.com/knative/serving/issues/959 for details.
+# TODO(adrcunha): Remove once the leak issue is resolved.
+function delete_leaked_network_resources() {
+  (( IS_BOSKOS )) && return
+  # Ensure we're using the GCP project used by kubetest
+  local gcloud_project="$(gcloud config get-value project)"
+  local http_health_checks="$(gcloud compute target-pools list \
+    --project=${gcloud_project} --format='value(healthChecks)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
+    grep httpHealthChecks | tr '\n' ' ')"
+  local target_pools="$(gcloud compute target-pools list \
+    --project=${gcloud_project} --format='value(name)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
+    tr '\n' ' ')"
+  if [[ -n "${target_pools}" ]]; then
+    echo "Found leaked target pools, deleting"
+    gcloud compute forwarding-rules delete -q --project=${gcloud_project} --region=${E2E_CLUSTER_REGION} ${target_pools}
+    gcloud compute target-pools delete -q --project=${gcloud_project} --region=${E2E_CLUSTER_REGION} ${target_pools}
+  fi
+  if [[ -n "${http_health_checks}" ]]; then
+    echo "Found leaked health checks, deleting"
+    gcloud compute http-health-checks delete -q --project=${gcloud_project} ${http_health_checks}
+  fi
+}
+
 # Create a test cluster with kubetest and call the current script again.
 function create_test_cluster() {
   # Fail fast during setup.
   set -o errexit
   set -o pipefail
+
+  if function_exists cluster_setup; then
+    cluster_setup || fail_test "cluster setup failed"
+  fi
 
   header "Creating test cluster"
 
@@ -167,45 +195,29 @@ function create_test_cluster() {
   (( SKIP_KNATIVE_SETUP )) && test_cmd_args+=" --skip-knative-setup"
   [[ -n "${GCP_PROJECT}" ]] && test_cmd_args+=" --gcp-project ${GCP_PROJECT}"
   [[ -n "${E2E_SCRIPT_CUSTOM_FLAGS[@]}" ]] && test_cmd_args+=" ${E2E_SCRIPT_CUSTOM_FLAGS[@]}"
+  local extra_flags=()
+  # If using boskos, save time and let it tear down the cluster
+  (( ! IS_BOSKOS )) && extra_flags+=(--down)
   # Don't fail test for kubetest, as it might incorrectly report test failure
   # if teardown fails (for details, see success() below)
   set +o errexit
   run_go_tool k8s.io/test-infra/kubetest \
     kubetest "${CLUSTER_CREATION_ARGS[@]}" \
     --up \
-    --down \
     --extract "${E2E_CLUSTER_VERSION}" \
     --gcp-node-image "${SERVING_GKE_IMAGE}" \
     --test-cmd "${E2E_SCRIPT}" \
     --test-cmd-args "${test_cmd_args}" \
+    ${extra_flags[@]} \
     ${EXTRA_KUBETEST_FLAGS[@]}
   echo "Test subprocess exited with code $?"
   # Ignore any errors below, this is a best-effort cleanup and shouldn't affect the test result.
   set +o errexit
-  # Ensure we're using the GCP project used by kubetest
-  gcloud_project="$(gcloud config get-value project)"
-  # Delete target pools and health checks that might have leaked.
-  # See https://github.com/knative/serving/issues/959 for details.
-  # TODO(adrcunha): Remove once the leak issue is resolved.
-  local http_health_checks="$(gcloud compute target-pools list \
-    --project=${gcloud_project} --format='value(healthChecks)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
-    grep httpHealthChecks | tr '\n' ' ')"
-  local target_pools="$(gcloud compute target-pools list \
-    --project=${gcloud_project} --format='value(name)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
-    tr '\n' ' ')"
-  if [[ -n "${target_pools}" ]]; then
-    echo "Found leaked target pools, deleting"
-    gcloud compute forwarding-rules delete -q --project=${gcloud_project} --region=${E2E_CLUSTER_REGION} ${target_pools}
-    gcloud compute target-pools delete -q --project=${gcloud_project} --region=${E2E_CLUSTER_REGION} ${target_pools}
-  fi
-  if [[ -n "${http_health_checks}" ]]; then
-    echo "Found leaked health checks, deleting"
-    gcloud compute http-health-checks delete -q --project=${gcloud_project} ${http_health_checks}
-  fi
+  function_exists cluster_teardown && cluster_teardown
+  delete_leaked_network_resources
   local result="$(cat ${TEST_RESULT_FILE})"
   echo "Artifacts were written to ${ARTIFACTS}"
   echo "Test result code is ${result}"
-
   exit ${result}
 }
 

--- a/vendor/github.com/knative/test-infra/scripts/library.sh
+++ b/vendor/github.com/knative/test-infra/scripts/library.sh
@@ -146,6 +146,25 @@ function wait_until_pods_running() {
   return 1
 }
 
+# Waits until all batch job pods are running in the given namespace.
+# Parameters: $1 - namespace.
+function wait_until_batch_job_complete() {
+  echo -n "Waiting until all batch job pods in namespace $1 run to completion."
+  for i in {1..150}; do  # timeout after 5 minutes
+    local pods="$(kubectl get pods --selector=job-name --no-headers -n $1 2>/dev/null | grep -v '^[[:space:]]*$')"
+    # All pods must be complete
+    local not_complete=$(echo "${pods}" | grep -v Completed | wc -l)
+    if [[ ${not_complete} -eq 0 ]]; then
+      echo -e "\nAll pods are complete:\n${pods}"
+      return 0
+    fi
+    echo -n "."
+    sleep 2
+  done
+  echo -e "\n\nERROR: timeout waiting for pods to complete\n${pods}"
+  return 1
+}
+
 # Waits until the given service has an external address (IP/hostname).
 # Parameters: $1 - namespace.
 #             $2 - service name.
@@ -178,7 +197,7 @@ function wait_until_routable() {
   for i in {1..150}; do  # timeout after 5 minutes
     local val=$(curl -H "Host: $2" "http://$1" 2>/dev/null)
     if [[ -n "$val" ]]; then
-      echo "\nEndpoint is now routable"
+      echo -e "\nEndpoint is now routable"
       return 0
     fi
     echo -n "."
@@ -302,8 +321,9 @@ function report_go_test() {
 function start_latest_knative_serving() {
   header "Starting Knative Serving"
   subheader "Installing Istio"
-  echo "Installing Istio CRD from ${KNATIVE_ISTIO_CRD_YAML}"
+  echo "Running Istio CRD from ${KNATIVE_ISTIO_CRD_YAML}"
   kubectl apply -f ${KNATIVE_ISTIO_CRD_YAML} || return 1
+  wait_until_batch_job_complete istio-system || return 1
   echo "Installing Istio from ${KNATIVE_ISTIO_YAML}"
   kubectl apply -f ${KNATIVE_ISTIO_YAML} || return 1
   wait_until_pods_running istio-system || return 1
@@ -312,15 +332,6 @@ function start_latest_knative_serving() {
   echo "Installing Serving from ${KNATIVE_SERVING_RELEASE}"
   kubectl apply -f ${KNATIVE_SERVING_RELEASE} || return 1
   wait_until_pods_running knative-serving || return 1
-}
-
-# Install the latest stable Knative/build in the current cluster.
-function start_latest_knative_build() {
-  header "Starting Knative Build"
-  subheader "Installing Knative Build"
-  echo "Installing Build from ${KNATIVE_BUILD_RELEASE}"
-  kubectl apply -f ${KNATIVE_BUILD_RELEASE} || return 1
-  wait_until_pods_running knative-build || return 1
 }
 
 # Run a go tool, installing it first if necessary.
@@ -406,6 +417,33 @@ function is_int() {
 # Parameters: $1 - full GCR name, e.g. gcr.io/knative-foo-bar
 function is_protected_gcr() {
   [[ -n $1 && "$1" =~ "^gcr.io/knative-(releases|nightly)/?$" ]]
+}
+
+# Remove symlinks in a path that are broken or lead outside the repo.
+# Parameters: $1 - path name, e.g. vendor
+function remove_broken_symlinks() {
+  for link in $(find $1 -type l); do
+    # Remove broken symlinks
+    if [[ ! -e ${link} ]]; then
+      unlink ${link}
+      continue
+    fi
+    # Get canonical path to target, remove if outside the repo
+    local target="$(ls -l ${link})"
+    target="${target##* -> }"
+    [[ ${target} == /* ]] || target="./${target}"
+    target="$(cd `dirname ${link}` && cd ${target%/*} && echo $PWD/${target##*/})"
+    if [[ ${target} != *github.com/knative/* ]]; then
+      unlink ${link}
+      continue
+    fi
+  done
+}
+
+# Return whether the given parameter is knative-tests.
+# Parameters: $1 - project name
+function is_protected_project() {
+  [[ -n "$1" && "$1" == "knative-tests" ]]
 }
 
 # Returns the canonical path of a filesystem object.

--- a/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
@@ -22,6 +22,7 @@ source $(dirname ${BASH_SOURCE})/library.sh
 # Custom configuration of presubmit tests
 readonly DISABLE_MD_LINTING=${DISABLE_MD_LINTING:-0}
 readonly DISABLE_MD_LINK_CHECK=${DISABLE_MD_LINK_CHECK:-0}
+readonly PRESUBMIT_TEST_FAIL_FAST=${PRESUBMIT_TEST_FAIL_FAST:-0}
 
 # Extensions or file patterns that don't require presubmit tests.
 readonly NO_PRESUBMIT_FILES=(\.png \.gitignore \.gitattributes ^OWNERS ^OWNERS_ALIASES ^AUTHORS)
@@ -317,8 +318,14 @@ function main() {
   fi
 
   run_build_tests || failed=1
-  run_unit_tests || failed=1
-  run_integration_tests || failed=1
+  # If PRESUBMIT_TEST_FAIL_FAST is set to true, don't run unit tests if build tests failed
+  if (( ! PRESUBMIT_TEST_FAIL_FAST )) || (( ! failed )); then
+    run_unit_tests || failed=1
+  fi
+  # If PRESUBMIT_TEST_FAIL_FAST is set to true, don't run integration tests if build/unit tests failed
+  if (( ! PRESUBMIT_TEST_FAIL_FAST )) || (( ! failed )); then
+    run_integration_tests || failed=1
+  fi
 
   exit ${failed}
 }

--- a/vendor/github.com/knative/test-infra/scripts/release.sh
+++ b/vendor/github.com/knative/test-infra/scripts/release.sh
@@ -22,6 +22,10 @@ source $(dirname ${BASH_SOURCE})/library.sh
 # GitHub upstream.
 readonly KNATIVE_UPSTREAM="https://github.com/knative/${REPO_NAME}"
 
+# GCRs for Knative releases.
+readonly NIGHTLY_GCR="gcr.io/knative-nightly/github.com/knative/${REPO_NAME}"
+readonly RELEASE_GCR="gcr.io/knative-releases/github.com/knative/${REPO_NAME}"
+
 # Georeplicate images to {us,eu,asia}.gcr.io
 readonly GEO_REPLICATION=(us eu asia)
 
@@ -58,17 +62,21 @@ function publish_yamls() {
     local DEST="gs://${RELEASE_GCS_BUCKET}/$1/"
     shift
     echo "Publishing [$@] to ${DEST}"
-    gsutil cp $@ ${DEST}
+    gsutil -m cp $@ ${DEST}
   }
-  # Before publishing the YAML files, cleanup the `latest` dir.
-  echo "Cleaning up the `latest` directory first"
-  gsutil -m rm gs://${RELEASE_GCS_BUCKET}/latest/**
+  # Before publishing the YAML files, cleanup the `latest` dir if it exists.
+  local latest_dir="gs://${RELEASE_GCS_BUCKET}/latest"
+  if [[ -n "$(gsutil ls ${latest_dir} 2> /dev/null)" ]]; then
+    echo "Cleaning up '${latest_dir}' first"
+    gsutil -m rm ${latest_dir}/**
+  fi
   verbose_gsutil_cp latest $@
   [[ -n ${TAG} ]] && verbose_gsutil_cp previous/${TAG} $@
 }
 
 # These are global environment variables.
 SKIP_TESTS=0
+PRESUBMIT_TEST_FAIL_FAST=1
 TAG_RELEASE=0
 PUBLISH_RELEASE=0
 PUBLISH_TO_GITHUB=0
@@ -80,6 +88,8 @@ RELEASE_GCS_BUCKET=""
 KO_FLAGS=""
 VALIDATION_TESTS="./test/presubmit-tests.sh"
 YAMLS_TO_PUBLISH=""
+FROM_NIGHTLY_RELEASE=""
+FROM_NIGHTLY_RELEASE_GCS=""
 export KO_DOCKER_REPO=""
 export GITHUB_TOKEN=""
 
@@ -87,6 +97,14 @@ export GITHUB_TOKEN=""
 # Parameters: $1..$n - arguments to hub.
 function hub_tool() {
   run_go_tool github.com/github/hub hub $@
+}
+
+# Shortcut to "git push" that handles authentication.
+# Parameters: $1..$n - arguments to "git push <repo>".
+function git_push() {
+  local repo_url="${KNATIVE_UPSTREAM}"
+  [[ -n "${GITHUB_TOKEN}}" ]] && repo_url="${repo_url/:\/\//:\/\/${GITHUB_TOKEN}@}"
+  git push ${repo_url} $@
 }
 
 # Return the master version of a release.
@@ -104,6 +122,13 @@ function master_version() {
 function release_build_number() {
   local tokens=(${1//\./ })
   echo "${tokens[2]}"
+}
+
+# Return the short commit SHA from a release tag.
+# For example, "v20010101-deadbeef" returns "deadbeef".
+function hash_from_tag() {
+  local tokens=(${1//-/ })
+  echo "${tokens[1]}"
 }
 
 # Setup the repository upstream, if not set.
@@ -210,6 +235,86 @@ function prepare_dot_release() {
   fi
 }
 
+# Setup source nightly image for a release.
+function prepare_from_nightly_release() {
+  echo "Release from nightly requested"
+  SKIP_TESTS=1
+  if [[ "${FROM_NIGHTLY_RELEASE}" == "latest" ]]; then
+    echo "Finding the latest nightly release"
+    find_latest_nightly "${NIGHTLY_GCR}" || abort "cannot find the latest nightly release"
+    echo "Latest nightly is ${FROM_NIGHTLY_RELEASE}"
+  fi
+  readonly FROM_NIGHTLY_RELEASE_GCS="gs://knative-nightly/${REPO_NAME}/previous/${FROM_NIGHTLY_RELEASE}"
+  gsutil ls -d "${FROM_NIGHTLY_RELEASE_GCS}" > /dev/null \
+      || abort "nightly release ${FROM_NIGHTLY_RELEASE} doesn't exist"
+}
+
+# Build a release from an existing nightly one.
+function build_from_nightly_release() {
+  banner "Building the release"
+  echo "Fetching manifests from nightly"
+  local yamls_dir="$(mktemp -d)"
+  gsutil -m cp -r "${FROM_NIGHTLY_RELEASE_GCS}/*" "${yamls_dir}" || abort "error fetching manifests"
+  # Update references to release GCR
+  for yaml in ${yamls_dir}/*.yaml; do
+    sed -i -e "s#${NIGHTLY_GCR}#${RELEASE_GCR}#" "${yaml}"
+  done
+  YAMLS_TO_PUBLISH="$(find ${yamls_dir} -name '*.yaml' -printf '%p ')"
+  echo "Copying nightly images"
+  copy_nightly_images_to_release_gcr "${NIGHTLY_GCR}" "${FROM_NIGHTLY_RELEASE}"
+  # Create a release branch from the nightly release tag.
+  local commit="$(hash_from_tag ${FROM_NIGHTLY_RELEASE})"
+  echo "Creating release branch ${RELEASE_BRANCH} at commit ${commit}"
+  git checkout -b ${RELEASE_BRANCH} ${commit} || abort "cannot create branch"
+  git_push upstream ${RELEASE_BRANCH} || abort "cannot push branch"
+}
+
+# Build a release from source.
+function build_from_source() {
+  run_validation_tests ${VALIDATION_TESTS}
+  banner "Building the release"
+  build_release
+  # Do not use `||` above or any error will be swallowed.
+  if [[ $? -ne 0 ]]; then
+    abort "error building the release"
+  fi
+}
+
+# Copy tagged images from the nightly GCR to the release GCR, tagging them 'latest'.
+# This is a recursive function, first call must pass $NIGHTLY_GCR as first parameter.
+# Parameters: $1 - GCR to recurse into.
+#             $2 - tag to be used to select images to copy.
+function copy_nightly_images_to_release_gcr() {
+  for entry in $(gcloud --format="value(name)" container images list --repository="$1"); do
+    copy_nightly_images_to_release_gcr "${entry}" "$2"
+    # Copy each image with the given nightly tag
+    for x in $(gcloud --format="value(tags)" container images list-tags "${entry}" --filter="tags=$2" --limit=1); do
+      local path="${entry/${NIGHTLY_GCR}}"  # Image "path" (remove GCR part)
+      local dst="${RELEASE_GCR}${path}:latest"
+      gcloud container images add-tag "${entry}:$2" "${dst}" || abort "error copying image"
+    done
+  done
+}
+
+# Recurse into GCR and find the nightly tag of the first `latest` image found.
+# Parameters: $1 - GCR to recurse into.
+function find_latest_nightly() {
+  for entry in $(gcloud --format="value(name)" container images list --repository="$1"); do
+    find_latest_nightly "${entry}" && return 0
+    for tag in $(gcloud --format="value(tags)" container images list-tags "${entry}" \
+        --filter="tags=latest" --limit=1); do
+      local tags=( ${tag//,/ } )
+      # Skip if more than one nightly tag, as we don't know what's the latest.
+      if [[ ${#tags[@]} -eq 2 ]]; then
+        local nightly_tag="${tags[@]/latest}"  # Remove 'latest' tag
+        FROM_NIGHTLY_RELEASE="${nightly_tag// /}"  # Remove spaces
+        return 0
+      fi
+    done
+  done
+  return 1
+}
+
 # Parses flags and sets environment variables accordingly.
 function parse_flags() {
   TAG=""
@@ -220,6 +325,7 @@ function parse_flags() {
   KO_DOCKER_REPO="gcr.io/knative-nightly"
   RELEASE_GCS_BUCKET="knative-nightly/${REPO_NAME}"
   GITHUB_TOKEN=""
+  FROM_NIGHTLY_RELEASE=""
   local has_gcr_flag=0
   local has_gcs_flag=0
   local is_dot_release=0
@@ -236,6 +342,7 @@ function parse_flags() {
       --nopublish) PUBLISH_RELEASE=0 ;;
       --dot-release) is_dot_release=1 ;;
       --auto-release) is_auto_release=1 ;;
+      --from-latest-nightly) FROM_NIGHTLY_RELEASE=latest ;;
       *)
         [[ $# -ge 2 ]] || abort "missing parameter after $1"
         shift
@@ -266,6 +373,10 @@ function parse_flags() {
             [[ ! -f "$1" ]] && abort "file $1 doesn't exist"
             RELEASE_NOTES=$1
             ;;
+          --from-nightly)
+            [[ $1 =~ ^v[0-9]+-[0-9a-f]+$ ]] || abort "nightly tag must be 'vYYYYMMDD-commithash'"
+            FROM_NIGHTLY_RELEASE=$1
+            ;;
           *) abort "unknown option ${parameter}" ;;
         esac
     esac
@@ -274,14 +385,24 @@ function parse_flags() {
 
   # Do auto release unless release is forced
   if (( is_auto_release )); then
-
     (( is_dot_release )) && abort "cannot have both --dot-release and --auto-release set simultaneously"
-    [[ -n "${RELEASE_VERSION}" ]] &&  abort "cannot have both --version and --auto-release set simultaneously"
-    [[ -n "${RELEASE_BRANCH}" ]] &&  abort "cannot have both --branch and --auto-release set simultaneously"
-
+    [[ -n "${RELEASE_VERSION}" ]] && abort "cannot have both --version and --auto-release set simultaneously"
+    [[ -n "${RELEASE_BRANCH}" ]] && abort "cannot have both --branch and --auto-release set simultaneously"
+    [[ -n "${FROM_NIGHTLY_RELEASE}" ]] && abort "cannot have --auto-release with a nightly source"
     setup_upstream
     prepare_auto_release
+  fi
 
+  # Setup source nightly image
+  if [[ -n "${FROM_NIGHTLY_RELEASE}" ]]; then
+    (( is_dot_release )) && abort "dot releases are built from source"
+    [[ -z "${RELEASE_VERSION}" ]] && abort "release version must be specified with --version"
+    # TODO(adrcunha): "dot" releases from release branches require releasing nightlies
+    # for such branches, which we don't do yet.
+    [[ "${RELEASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.0$ ]] || abort "version format must be 'X.Y.0'"
+    RELEASE_BRANCH="release-$(master_version ${RELEASE_VERSION})"
+    prepare_from_nightly_release
+    setup_upstream
   fi
 
   # Setup dot releases
@@ -302,7 +423,7 @@ function parse_flags() {
   if (( TAG_RELEASE )); then
     # Get the commit, excluding any tags but keeping the "dirty" flag
     local commit="$(git describe --always --dirty --match '^$')"
-    [[ -n "${commit}" ]] || abort "Error getting the current commit"
+    [[ -n "${commit}" ]] || abort "error getting the current commit"
     # Like kubernetes, image tag is vYYYYMMDD-commit
     TAG="v$(date +%Y%m%d)-${commit}"
   fi
@@ -324,6 +445,7 @@ function parse_flags() {
   readonly RELEASE_GCS_BUCKET
   readonly KO_DOCKER_REPO
   readonly VALIDATION_TESTS
+  readonly FROM_NIGHTLY_RELEASE
 }
 
 # Run tests (unless --skip-tests was passed). Conveniently displays a banner indicating so.
@@ -346,6 +468,9 @@ function main() {
   parse_flags $@
   # Log what will be done and where.
   banner "Release configuration"
+  echo "- gcloud user: $(gcloud config get-value core/account)"
+  echo "- Go path: ${GOPATH}"
+  echo "- Repository root: ${REPO_ROOT_DIR}"
   echo "- Destination GCR: ${KO_DOCKER_REPO}"
   (( SKIP_TESTS )) && echo "- Tests will NOT be run" || echo "- Tests will be run"
   if (( TAG_RELEASE )); then
@@ -361,11 +486,16 @@ function main() {
   if (( PUBLISH_TO_GITHUB )); then
     echo "- Release WILL BE published to GitHub"
   fi
-  [[ -n "${RELEASE_BRANCH}" ]] && echo "- Release will be built from branch '${RELEASE_BRANCH}'"
+  if [[ -n "${FROM_NIGHTLY_RELEASE}" ]]; then
+    echo "- Release will be A COPY OF '${FROM_NIGHTLY_RELEASE}' nightly"
+  else
+    echo "- Release will be BUILT FROM SOURCE"
+    [[ -n "${RELEASE_BRANCH}" ]] && echo "- Release will be built from branch '${RELEASE_BRANCH}'"
+  fi
   [[ -n "${RELEASE_NOTES}" ]] && echo "- Release notes are generated from '${RELEASE_NOTES}'"
 
   # Checkout specific branch, if necessary
-  if [[ -n "${RELEASE_BRANCH}" ]]; then
+  if [[ -n "${RELEASE_BRANCH}" && -z "${FROM_NIGHTLY_RELEASE}" ]]; then
     setup_upstream
     setup_branch
     git checkout upstream/${RELEASE_BRANCH} || abort "cannot checkout branch ${RELEASE_BRANCH}"
@@ -374,20 +504,22 @@ function main() {
   set -o errexit
   set -o pipefail
 
-  run_validation_tests ${VALIDATION_TESTS}
-  banner "Building the release"
-  build_release
-  # Do not use `||` above or any error will be swallowed.
-  if [[ $? -ne 0 ]]; then
-    abort "error building the release"
+  if [[ -n "${FROM_NIGHTLY_RELEASE}" ]]; then
+    build_from_nightly_release
+  else
+    build_from_source
   fi
   [[ -z "${YAMLS_TO_PUBLISH}" ]] && abort "no manifests were generated"
+  # Ensure no empty YAML file will be published.
+  for yaml in ${YAMLS_TO_PUBLISH}; do
+    [[ -s ${yaml} ]] || abort "YAML file ${yaml} is empty"
+  done
   echo "New release built successfully"
   if (( PUBLISH_RELEASE )); then
     tag_images_in_yamls ${YAMLS_TO_PUBLISH}
     publish_yamls ${YAMLS_TO_PUBLISH}
     publish_to_github ${YAMLS_TO_PUBLISH}
-    echo "New release published successfully"
+    banner "New release published successfully"
   fi
 }
 
@@ -410,9 +542,7 @@ function publish_to_github() {
     cat ${RELEASE_NOTES} >> ${description}
   fi
   git tag -a ${TAG} -m "${title}"
-  local repo_url="${KNATIVE_UPSTREAM}"
-  [[ -n "${GITHUB_TOKEN}}" ]] && repo_url="${repo_url/:\/\//:\/\/${GITHUB_TOKEN}@}"
-  hub_tool push ${repo_url} tag ${TAG}
+  git_push tag ${TAG}
 
   [[ -n "${RELEASE_BRANCH}" ]] && commitish="--commitish=${RELEASE_BRANCH}"
   hub_tool release create \

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -45,13 +45,6 @@ github.com/google/go-cmp/cmp/internal/value
 github.com/google/go-containerregistry/pkg/name
 # github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf
 github.com/google/gofuzz
-# github.com/google/licenseclassifier v0.0.0-20190103191631-c2a262e3078a
-github.com/google/licenseclassifier
-github.com/google/licenseclassifier/internal/sets
-github.com/google/licenseclassifier/stringclassifier
-github.com/google/licenseclassifier/stringclassifier/searchset
-github.com/google/licenseclassifier/stringclassifier/internal/pq
-github.com/google/licenseclassifier/stringclassifier/searchset/tokenizer
 # github.com/googleapis/gnostic v0.2.0
 github.com/googleapis/gnostic/OpenAPIv2
 github.com/googleapis/gnostic/compiler
@@ -98,7 +91,7 @@ github.com/knative/serving/pkg/apis/networking/v1alpha1
 github.com/knative/serving/pkg/apis/serving
 github.com/knative/serving/pkg/apis/autoscaling/v1alpha1
 github.com/knative/serving/pkg/apis/networking
-# github.com/knative/test-infra v0.0.0-20190304225739-6bb6546d833a
+# github.com/knative/test-infra v0.0.0-20190404172656-4ce16d390c55
 github.com/knative/test-infra/scripts
 # github.com/magiconair/properties v1.8.0
 github.com/magiconair/properties
@@ -122,8 +115,6 @@ github.com/pelletier/go-toml
 github.com/peterbourgon/diskv
 # github.com/pkg/errors v0.8.1
 github.com/pkg/errors
-# github.com/sergi/go-diff v1.0.0
-github.com/sergi/go-diff/diffmatchpatch
 # github.com/spf13/afero v1.2.0
 github.com/spf13/afero
 github.com/spf13/afero/mem
@@ -276,6 +267,7 @@ k8s.io/cli-runtime/pkg/kustomize/k8sdeps/transformer/hash
 k8s.io/cli-runtime/pkg/kustomize/k8sdeps/transformer/patch
 # k8s.io/client-go v2.0.0-alpha.0.0.20181015214059-cbd9965a0e71+incompatible
 k8s.io/client-go/plugin/pkg/client/auth/gcp
+k8s.io/client-go/plugin/pkg/client/auth/oidc
 k8s.io/client-go/tools/clientcmd
 k8s.io/client-go/rest
 k8s.io/client-go/discovery


### PR DESCRIPTION
This updates the version of test-infra to use the new cluster_setup function added in https://github.com/knative/test-infra/pull/667.
    
It simplifies our e2e setup logic into one place instead of being split over presubmit-tests.sh and e2e-tests.sh.

This builds on top of #55 and I'll rebase this to remove the duplicated commits and take it off hold after that one gets merged. I opened this as a separate PR just in case the updating of test-infra causes other issues to not hold up getting the integration tests in.

/hold