### PR TITLE
Make image flag mandatory for service create command

### DIFF
--- a/pkg/kn/commands/configuration_edit_flags.go
+++ b/pkg/kn/commands/configuration_edit_flags.go
@@ -33,6 +33,7 @@ func (p *ConfigurationEditFlags) AddFlags(command *cobra.Command) {
 	command.Flags().StringArrayVarP(&p.Env, "env", "e", []string{},
 		"Environment variable to set. NAME=value; you may provide this flag "+
 			"any number of times to set multiple environment variables.")
+	command.MarkFlagRequired("image")
 }
 
 func (p *ConfigurationEditFlags) Apply(config *servingv1alpha1.ConfigurationSpec) error {

--- a/pkg/kn/commands/service_create.go
+++ b/pkg/kn/commands/service_create.go
@@ -29,11 +29,14 @@ func NewServiceCreateCommand(p *KnParams) *cobra.Command {
 	var editFlags ConfigurationEditFlags
 
 	serviceCreateCommand := &cobra.Command{
-		Use:   "create NAME",
+		Use:   "create NAME --image IMAGE",
 		Short: "Create a service.",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {
 				return errors.New("requires the service name.")
+			}
+			if editFlags.Image == "" {
+				return errors.New("requires the image name to run.")
 			}
 
 			namespace := cmd.Flag("namespace").Value.String()


### PR DESCRIPTION
Although `service create` command always requires and specify `--image` to run,
there are no validation atm.

This patch changes:
- Add validation check if image is empty or not.
- Add image to `MarkFlagRequired()`.
- to add `--image IMAGE` in help message