### PR TITLE
Adds service delete command

### DIFF
--- a/pkg/kn/commands/service.go
+++ b/pkg/kn/commands/service.go
@@ -27,5 +27,6 @@ func NewServiceCommand(p *KnParams) *cobra.Command {
 	serviceCmd.AddCommand(NewServiceListCommand(p))
 	serviceCmd.AddCommand(NewServiceDescribeCommand(p))
 	serviceCmd.AddCommand(NewServiceCreateCommand(p))
+	serviceCmd.AddCommand(NewServiceDeleteCommand(p))
 	return serviceCmd
 }

--- a/pkg/kn/commands/service_delete.go
+++ b/pkg/kn/commands/service_delete.go
@@ -1,0 +1,63 @@
+// Copyright © 2018 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"github.com/spf13/cobra"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NewServiceDeleteCommand represent 'service delete' command
+func NewServiceDeleteCommand(p *KnParams) *cobra.Command {
+
+	serviceDeleteCommand := &cobra.Command{
+		Use:     "delete <SERVICE_NAME>",
+		Aliases: []string{"del", "d"},
+		Short:   "Delete a service",
+		Example: `
+  # Delete a service 'svc1' in default namespace
+  kn service delete svc1
+
+  # Delete a service 'svc2' in 'ns1' namespace
+  kn service delete svc2 -n ns1`,
+		// check for arg length == 1
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errors.New("requires one service name.")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := p.ServingFactory()
+
+			if err != nil {
+				return err
+			}
+
+			namespace := cmd.Flag("namespace").Value.String()
+			err = client.Services(namespace).Delete(args[0], &v1.DeleteOptions{})
+
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Deleted %s in %s namespace.\n", args[0], namespace)
+			return nil
+		},
+	}
+	return serviceDeleteCommand
+}

--- a/pkg/kn/commands/service_delete.go
+++ b/pkg/kn/commands/service_delete.go
@@ -23,38 +23,32 @@ import (
 
 // NewServiceDeleteCommand represent 'service delete' command
 func NewServiceDeleteCommand(p *KnParams) *cobra.Command {
-
 	serviceDeleteCommand := &cobra.Command{
-		Use:     "delete <SERVICE_NAME>",
-		Aliases: []string{"del", "d"},
-		Short:   "Delete a service",
+		Use:   "delete NAME",
+		Short: "Delete a service.",
 		Example: `
   # Delete a service 'svc1' in default namespace
   kn service delete svc1
 
   # Delete a service 'svc2' in 'ns1' namespace
   kn service delete svc2 -n ns1`,
-		// check for arg length == 1
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				return errors.New("requires one service name.")
-			}
-			return nil
-		},
+
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errors.New("requires the service name.")
+			}
 			client, err := p.ServingFactory()
-
 			if err != nil {
 				return err
 			}
-
 			namespace := cmd.Flag("namespace").Value.String()
-			err = client.Services(namespace).Delete(args[0], &v1.DeleteOptions{})
-
+			err = client.Services(namespace).Delete(
+				args[0],
+				&v1.DeleteOptions{},
+			)
 			if err != nil {
 				return err
 			}
-
 			fmt.Fprintf(cmd.OutOrStdout(), "Deleted %s in %s namespace.\n", args[0], namespace)
 			return nil
 		},


### PR DESCRIPTION
 This chageset adds `service delete` command, able to delete a service
 at a time.

 Fixes #49

```
kn service delete --help
Delete a service

Usage:
  kn service delete <SERVICE_NAME> [flags]

Aliases:
  delete, del, d

Examples:

  # Delete a service 'svc1' in default namespace
  kn service delete svc1

  # Delete a service 'svc2' in 'ns1' namespace
  kn service delete svc2 -n ns1
```