### PR TITLE
Add hack/verify-codegen.sh so CI verifies vendor/ doesn't drift

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -1,4 +1,23 @@
+#!/usr/bin/env bash
 
-#!/bin/bash
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-go mod vendor
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# GO111MODULE used so that it works no matter if someone has this repo
+# cloned under $GOPATH or not
+GO111MODULE=on go mod vendor

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/library.sh
+
+readonly TMP_DIFFROOT="$(mktemp -d ${REPO_ROOT_DIR}/tmpdiffroot.XXXXXX)"
+
+cleanup() {
+  rm -rf "${TMP_DIFFROOT}"
+}
+
+trap "cleanup" EXIT SIGINT
+
+cleanup
+
+# Save working tree state
+mkdir -p "${TMP_DIFFROOT}/vendor"
+cp -aR "${REPO_ROOT_DIR}/go.sum" "${REPO_ROOT_DIR}/vendor" "${TMP_DIFFROOT}"
+
+"${REPO_ROOT_DIR}/hack/update-deps.sh"
+echo "Diffing ${REPO_ROOT_DIR} against freshly update dependencies"
+ret=0
+diff -Naupr --no-dereference "${REPO_ROOT_DIR}/vendor" "${TMP_DIFFROOT}/vendor" || ret=1
+
+# Restore working tree state
+rm -fr "${REPO_ROOT_DIR}/go.sum" "${REPO_ROOT_DIR}/vendor"
+cp -aR "${TMP_DIFFROOT}"/* "${REPO_ROOT_DIR}"
+
+if [[ $ret -eq 0 ]]
+then
+  echo "${REPO_ROOT_DIR} up to date."
+else
+  echo "ERROR: ${REPO_ROOT_DIR} is out of date. Please run ./hack/update-deps.sh"
+  exit 1
+fi


### PR DESCRIPTION
Yes, the file is called verify-codegen.sh, and yes in the other
Knative projects it both verifies generated code and verifies vendored
dependencies are up-to-date. For client, it just verifies vendored
dependencies don't drift.

The test-infra scripts specifically look for a file with this name. If
we'd prefer to call this something else, we'll also need to update
test-infra to look for that something else.