### PR TITLE
Added support for limits and requests of CPU and memory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.5 // indirect
+	github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024 // indirect
 	github.com/knative/build v0.3.0 // indirect
 	github.com/knative/pkg v0.0.0-20190110005142-b6044a7d1795 // indirect
 	github.com/knative/serving v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/json-iterator/go v1.1.5 h1:gL2yXlmiIo4+t+y32d4WGwOjKGYcGOuyrg46vadswDE=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
+github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024 h1:rBMNdlhTLzJjJSDIjNEXX1Pz3Hmwmz91v+zycvx9PJc=
+github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/knative/build v0.3.0 h1:WRWGzJZmFxBPjehIEcsa0pgsKE6j5BGuDqvFRJRQt8I=
 github.com/knative/build v0.3.0/go.mod h1:/sU74ZQkwlYA5FwYDJhYTy61i/Kn+5eWfln2jDbw3Qo=
 github.com/knative/pkg v0.0.0-20190110005142-b6044a7d1795 h1:mTaIClRJEjRuTFOc4Gsicdqe/OwEla0Ano9cllUNoU0=

--- a/pkg/kn/commands/configuration_edit_flags.go
+++ b/pkg/kn/commands/configuration_edit_flags.go
@@ -18,14 +18,30 @@ import (
 	"fmt"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+
 	servinglib "github.com/knative/client/pkg/serving"
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 type ConfigurationEditFlags struct {
-	Image string
-	Env   []string
+	Image         string
+	Env           []string
+	RequestsFlags RequestsFlags
+	LimitsFlags   LimitsFlags
+}
+
+type RequestsFlags struct {
+	CPU    string
+	Memory string
+}
+
+type LimitsFlags struct {
+	CPU    string
+	Memory string
 }
 
 func (p *ConfigurationEditFlags) AddFlags(command *cobra.Command) {
@@ -33,6 +49,10 @@ func (p *ConfigurationEditFlags) AddFlags(command *cobra.Command) {
 	command.Flags().StringArrayVarP(&p.Env, "env", "e", []string{},
 		"Environment variable to set. NAME=value; you may provide this flag "+
 			"any number of times to set multiple environment variables.")
+	command.Flags().StringVar(&p.RequestsFlags.CPU, "requests-cpu", "", "The requested CPU (e.g., 250m).")
+	command.Flags().StringVar(&p.RequestsFlags.Memory, "requests-memory", "", "The requested CPU (e.g., 64Mi).")
+	command.Flags().StringVar(&p.LimitsFlags.CPU, "limits-cpu", "", "The limits on the requested CPU (e.g., 1000m)..")
+	command.Flags().StringVar(&p.LimitsFlags.Memory, "limits-memory", "", "The limits on the requested CPU (e.g., 1024Mi).")
 	command.MarkFlagRequired("image")
 }
 
@@ -55,5 +75,72 @@ func (p *ConfigurationEditFlags) Apply(config *servingv1alpha1.ConfigurationSpec
 	if err != nil {
 		return err
 	}
+	limitsResources, err := p.computeLimitsResources(config)
+	if err != nil {
+		return err
+	}
+	requestsResources, err := p.computeRequestsResources(config)
+	if err != nil {
+		return err
+	}
+	err = servinglib.UpdateResources(config, requestsResources, limitsResources)
+	if err != nil {
+		return err
+	}
 	return nil
+}
+
+func (p *ConfigurationEditFlags) computeRequestsResources(config *servingv1alpha1.ConfigurationSpec) (corev1.ResourceList, error) {
+	var err error
+	var requestsCPU, requestsMemory resource.Quantity
+	if p.RequestsFlags.CPU != "" {
+		requestsCPU, err = resource.ParseQuantity(p.RequestsFlags.CPU)
+		if err != nil {
+			return corev1.ResourceList{}, err
+		}		
+	} else {
+		requestsCPU = config.RevisionTemplate.Spec.Container.Resources.Requests[corev1.ResourceCPU]
+	}
+	
+	if p.RequestsFlags.Memory != "" {
+		requestsMemory, err = resource.ParseQuantity(p.RequestsFlags.Memory)
+		if err != nil {
+			return corev1.ResourceList{}, err
+		}
+	} else {
+		requestsMemory = config.RevisionTemplate.Spec.Container.Resources.Requests[corev1.ResourceMemory]
+	}
+
+	return corev1.ResourceList{
+		corev1.ResourceCPU:    requestsCPU,
+		corev1.ResourceMemory: requestsMemory,
+	}, nil
+}
+
+func (p *ConfigurationEditFlags) computeLimitsResources(config *servingv1alpha1.ConfigurationSpec) (corev1.ResourceList, error) {
+	var err error
+	var limitsCPU, limitsMemory resource.Quantity
+
+	if p.LimitsFlags.CPU != "" {
+		limitsCPU, err = resource.ParseQuantity(p.LimitsFlags.CPU)
+		if err != nil {
+			return corev1.ResourceList{}, err
+		}
+	} else {
+		limitsCPU = config.RevisionTemplate.Spec.Container.Resources.Limits[corev1.ResourceCPU]
+	}	
+
+	if p.LimitsFlags.Memory != "" {
+		limitsMemory, err = resource.ParseQuantity(p.LimitsFlags.Memory)
+		if err != nil {
+			return corev1.ResourceList{}, err
+		}
+	} else {
+		limitsMemory = config.RevisionTemplate.Spec.Container.Resources.Limits[corev1.ResourceMemory]
+	}
+
+	return corev1.ResourceList{
+		corev1.ResourceCPU:    limitsCPU,
+		corev1.ResourceMemory: limitsMemory,
+	}, nil
 }

--- a/pkg/kn/commands/service_create.go
+++ b/pkg/kn/commands/service_create.go
@@ -17,12 +17,10 @@ package commands
 import (
 	"errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
-
 	serving_lib "github.com/knative/client/pkg/serving"
+	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NewServiceCreateCommand(p *KnParams) *cobra.Command {

--- a/pkg/kn/commands/service_create_test.go
+++ b/pkg/kn/commands/service_create_test.go
@@ -21,13 +21,15 @@ import (
 	"reflect"
 	"testing"
 
-	servinglib "github.com/knative/client/pkg/serving"
-
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	serving "github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
 	"github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	servinglib "github.com/knative/client/pkg/serving"
+	serving "github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
 	client_testing "k8s.io/client-go/testing"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func fakeServiceCreate(args []string) (
@@ -112,7 +114,7 @@ func TestServiceCreateEnv(t *testing.T) {
 	}
 }
 
-func TestServiceCreateRequests(t *testing.T) {
+func TestServiceCreateWithRequests(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
 		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--requests-cpu", "250m", "--requests-memory", "64Mi"})
 
@@ -122,16 +124,15 @@ func TestServiceCreateRequests(t *testing.T) {
 		t.Fatalf("Bad action %v", action)
 	}
 
-	expectedRequestsVars := map[string]string{
-		"cpu":    "250m",
-		"memory": "64Mi"}
+	expectedRequestsVars := corev1.ResourceList{
+		corev1.ResourceCPU:    parseQuantity(t, "250m"),
+		corev1.ResourceMemory: parseQuantity(t, "64Mi"),
+	}
 
 	conf, err := servinglib.GetConfiguration(created)
 
 	if err != nil {
 		t.Fatal(err)
-	} else if conf.RevisionTemplate.Spec.Container.Image != "gcr.io/foo/bar:baz" {
-		t.Fatalf("wrong image set: %v", conf.RevisionTemplate.Spec.Container.Image)
 	} else if !reflect.DeepEqual(
 		conf.RevisionTemplate.Spec.Container.Resources.Requests,
 		expectedRequestsVars) {
@@ -139,7 +140,7 @@ func TestServiceCreateRequests(t *testing.T) {
 	}
 }
 
-func TestServiceCreateLimits(t *testing.T) {
+func TestServiceCreateWithLimits(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
 		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--limits-cpu", "1000m", "--limits-memory", "1024Mi"})
 
@@ -149,19 +150,141 @@ func TestServiceCreateLimits(t *testing.T) {
 		t.Fatalf("Bad action %v", action)
 	}
 
-	expectedLimitsVars := map[string]string{
-		"cpu":    "1000m",
-		"memory": "1024Mi"}
+	expectedLimitsVars := corev1.ResourceList{
+		corev1.ResourceCPU:    parseQuantity(t, "1000m"),
+		corev1.ResourceMemory: parseQuantity(t, "1024Mi"),
+	}
 
 	conf, err := servinglib.GetConfiguration(created)
 
 	if err != nil {
 		t.Fatal(err)
-	} else if conf.RevisionTemplate.Spec.Container.Image != "gcr.io/foo/bar:baz" {
-		t.Fatalf("wrong image set: %v", conf.RevisionTemplate.Spec.Container.Image)
 	} else if !reflect.DeepEqual(
 		conf.RevisionTemplate.Spec.Container.Resources.Limits,
 		expectedLimitsVars) {
-		t.Fatalf("wrong limits vars %v", conf.RevisionTemplate.Spec.Container.Resources.Requests)
+		t.Fatalf("wrong limits vars %v", conf.RevisionTemplate.Spec.Container.Resources.Limits)
 	}
+}
+
+func TestServiceCreateRequestsLimitsCPU(t *testing.T) {
+	action, created, _, err := fakeServiceCreate([]string{
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--requests-cpu", "250m", "--limits-cpu", "1000m"})
+
+	if err != nil {
+		t.Fatal(err)
+	} else if !action.Matches("create", "services") {
+		t.Fatalf("Bad action %v", action)
+	}
+
+	expectedRequestsVars := corev1.ResourceList{
+		corev1.ResourceCPU:    parseQuantity(t, "250m"),
+	}
+
+	expectedLimitsVars := corev1.ResourceList{
+		corev1.ResourceCPU:    parseQuantity(t, "1000m"),
+	}
+
+	conf, err := servinglib.GetConfiguration(created)
+
+	if err != nil {
+		t.Fatal(err)
+	} else {
+		if !reflect.DeepEqual(
+			conf.RevisionTemplate.Spec.Container.Resources.Requests,
+			expectedRequestsVars) {
+			t.Fatalf("wrong requests vars %v", conf.RevisionTemplate.Spec.Container.Resources.Requests)
+		}
+		
+		if !reflect.DeepEqual(
+			conf.RevisionTemplate.Spec.Container.Resources.Limits,
+			expectedLimitsVars) {
+			t.Fatalf("wrong limits vars %v", conf.RevisionTemplate.Spec.Container.Resources.Limits)
+		}
+	}
+}
+
+func TestServiceCreateRequestsLimitsMemory(t *testing.T) {
+	action, created, _, err := fakeServiceCreate([]string{
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--requests-memory", "64Mi", "--limits-memory", "1024Mi"})
+
+	if err != nil {
+		t.Fatal(err)
+	} else if !action.Matches("create", "services") {
+		t.Fatalf("Bad action %v", action)
+	}
+
+	expectedRequestsVars := corev1.ResourceList{
+		corev1.ResourceMemory:    parseQuantity(t, "64Mi"),
+	}
+
+	expectedLimitsVars := corev1.ResourceList{
+		corev1.ResourceMemory:    parseQuantity(t, "1024Mi"),
+	}
+
+	conf, err := servinglib.GetConfiguration(created)
+
+	if err != nil {
+		t.Fatal(err)
+	} else {
+		if !reflect.DeepEqual(
+			conf.RevisionTemplate.Spec.Container.Resources.Requests,
+			expectedRequestsVars) {
+			t.Fatalf("wrong requests vars %v", conf.RevisionTemplate.Spec.Container.Resources.Requests)
+		}
+		
+		if !reflect.DeepEqual(
+			conf.RevisionTemplate.Spec.Container.Resources.Limits,
+			expectedLimitsVars) {
+			t.Fatalf("wrong limits vars %v", conf.RevisionTemplate.Spec.Container.Resources.Limits)
+		}
+	}
+}
+
+func TestServiceCreateRequestsLimitsCPUMemory(t *testing.T) {
+	action, created, _, err := fakeServiceCreate([]string{
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", 
+		"--requests-cpu", "250m", "--limits-cpu", "1000m",
+		"--requests-memory", "64Mi", "--limits-memory", "1024Mi"})
+
+	if err != nil {
+		t.Fatal(err)
+	} else if !action.Matches("create", "services") {
+		t.Fatalf("Bad action %v", action)
+	}
+
+	expectedRequestsVars := corev1.ResourceList{
+		corev1.ResourceCPU:    parseQuantity(t, "250m"),
+		corev1.ResourceMemory:    parseQuantity(t, "64Mi"),
+	}
+
+	expectedLimitsVars := corev1.ResourceList{
+		corev1.ResourceCPU:    parseQuantity(t, "1000m"),
+		corev1.ResourceMemory:    parseQuantity(t, "1024Mi"),
+	}
+
+	conf, err := servinglib.GetConfiguration(created)
+
+	if err != nil {
+		t.Fatal(err)
+	} else {
+		if !reflect.DeepEqual(
+			conf.RevisionTemplate.Spec.Container.Resources.Requests,
+			expectedRequestsVars) {
+			t.Fatalf("wrong requests vars %v", conf.RevisionTemplate.Spec.Container.Resources.Requests)
+		}
+		
+		if !reflect.DeepEqual(
+			conf.RevisionTemplate.Spec.Container.Resources.Limits,
+			expectedLimitsVars) {
+			t.Fatalf("wrong limits vars %v", conf.RevisionTemplate.Spec.Container.Resources.Limits)
+		}
+	}
+}
+
+func parseQuantity(t *testing.T, quantityString string) resource.Quantity {
+	quantity, err := resource.ParseQuantity(quantityString)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return quantity
 }

--- a/pkg/kn/commands/service_create_test.go
+++ b/pkg/kn/commands/service_create_test.go
@@ -23,13 +23,12 @@ import (
 
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1/fake"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/api/resource"
-
+	"k8s.io/apimachinery/pkg/runtime"
 	servinglib "github.com/knative/client/pkg/serving"
 	serving "github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
-	client_testing "k8s.io/client-go/testing"
 	corev1 "k8s.io/api/core/v1"
+	client_testing "k8s.io/client-go/testing"
 )
 
 func fakeServiceCreate(args []string) (
@@ -177,11 +176,11 @@ func TestServiceCreateRequestsLimitsCPU(t *testing.T) {
 	}
 
 	expectedRequestsVars := corev1.ResourceList{
-		corev1.ResourceCPU:    parseQuantity(t, "250m"),
+		corev1.ResourceCPU: parseQuantity(t, "250m"),
 	}
 
 	expectedLimitsVars := corev1.ResourceList{
-		corev1.ResourceCPU:    parseQuantity(t, "1000m"),
+		corev1.ResourceCPU: parseQuantity(t, "1000m"),
 	}
 
 	conf, err := servinglib.GetConfiguration(created)
@@ -194,7 +193,7 @@ func TestServiceCreateRequestsLimitsCPU(t *testing.T) {
 			expectedRequestsVars) {
 			t.Fatalf("wrong requests vars %v", conf.RevisionTemplate.Spec.Container.Resources.Requests)
 		}
-		
+
 		if !reflect.DeepEqual(
 			conf.RevisionTemplate.Spec.Container.Resources.Limits,
 			expectedLimitsVars) {
@@ -214,11 +213,11 @@ func TestServiceCreateRequestsLimitsMemory(t *testing.T) {
 	}
 
 	expectedRequestsVars := corev1.ResourceList{
-		corev1.ResourceMemory:    parseQuantity(t, "64Mi"),
+		corev1.ResourceMemory: parseQuantity(t, "64Mi"),
 	}
 
 	expectedLimitsVars := corev1.ResourceList{
-		corev1.ResourceMemory:    parseQuantity(t, "1024Mi"),
+		corev1.ResourceMemory: parseQuantity(t, "1024Mi"),
 	}
 
 	conf, err := servinglib.GetConfiguration(created)
@@ -231,7 +230,7 @@ func TestServiceCreateRequestsLimitsMemory(t *testing.T) {
 			expectedRequestsVars) {
 			t.Fatalf("wrong requests vars %v", conf.RevisionTemplate.Spec.Container.Resources.Requests)
 		}
-		
+
 		if !reflect.DeepEqual(
 			conf.RevisionTemplate.Spec.Container.Resources.Limits,
 			expectedLimitsVars) {
@@ -242,7 +241,7 @@ func TestServiceCreateRequestsLimitsMemory(t *testing.T) {
 
 func TestServiceCreateRequestsLimitsCPUMemory(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", 
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
 		"--requests-cpu", "250m", "--limits-cpu", "1000m",
 		"--requests-memory", "64Mi", "--limits-memory", "1024Mi"})
 
@@ -254,12 +253,12 @@ func TestServiceCreateRequestsLimitsCPUMemory(t *testing.T) {
 
 	expectedRequestsVars := corev1.ResourceList{
 		corev1.ResourceCPU:    parseQuantity(t, "250m"),
-		corev1.ResourceMemory:    parseQuantity(t, "64Mi"),
+		corev1.ResourceMemory: parseQuantity(t, "64Mi"),
 	}
 
 	expectedLimitsVars := corev1.ResourceList{
 		corev1.ResourceCPU:    parseQuantity(t, "1000m"),
-		corev1.ResourceMemory:    parseQuantity(t, "1024Mi"),
+		corev1.ResourceMemory: parseQuantity(t, "1024Mi"),
 	}
 
 	conf, err := servinglib.GetConfiguration(created)
@@ -272,7 +271,7 @@ func TestServiceCreateRequestsLimitsCPUMemory(t *testing.T) {
 			expectedRequestsVars) {
 			t.Fatalf("wrong requests vars %v", conf.RevisionTemplate.Spec.Container.Resources.Requests)
 		}
-		
+
 		if !reflect.DeepEqual(
 			conf.RevisionTemplate.Spec.Container.Resources.Limits,
 			expectedLimitsVars) {

--- a/pkg/kn/commands/service_create_test.go
+++ b/pkg/kn/commands/service_create_test.go
@@ -110,5 +110,58 @@ func TestServiceCreateEnv(t *testing.T) {
 		expectedEnvVars) {
 		t.Fatalf("wrong env vars %v", conf.RevisionTemplate.Spec.Container.Env)
 	}
+}
 
+func TestServiceCreateRequests(t *testing.T) {
+	action, created, _, err := fakeServiceCreate([]string{
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--requests-cpu", "250m", "--requests-memory", "64Mi"})
+
+	if err != nil {
+		t.Fatal(err)
+	} else if !action.Matches("create", "services") {
+		t.Fatalf("Bad action %v", action)
+	}
+
+	expectedRequestsVars := map[string]string{
+		"cpu":    "250m",
+		"memory": "64Mi"}
+
+	conf, err := servinglib.GetConfiguration(created)
+
+	if err != nil {
+		t.Fatal(err)
+	} else if conf.RevisionTemplate.Spec.Container.Image != "gcr.io/foo/bar:baz" {
+		t.Fatalf("wrong image set: %v", conf.RevisionTemplate.Spec.Container.Image)
+	} else if !reflect.DeepEqual(
+		conf.RevisionTemplate.Spec.Container.Resources.Requests,
+		expectedRequestsVars) {
+		t.Fatalf("wrong requests vars %v", conf.RevisionTemplate.Spec.Container.Resources.Requests)
+	}
+}
+
+func TestServiceCreateLimits(t *testing.T) {
+	action, created, _, err := fakeServiceCreate([]string{
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--limits-cpu", "1000m", "--limits-memory", "1024Mi"})
+
+	if err != nil {
+		t.Fatal(err)
+	} else if !action.Matches("create", "services") {
+		t.Fatalf("Bad action %v", action)
+	}
+
+	expectedLimitsVars := map[string]string{
+		"cpu":    "1000m",
+		"memory": "1024Mi"}
+
+	conf, err := servinglib.GetConfiguration(created)
+
+	if err != nil {
+		t.Fatal(err)
+	} else if conf.RevisionTemplate.Spec.Container.Image != "gcr.io/foo/bar:baz" {
+		t.Fatalf("wrong image set: %v", conf.RevisionTemplate.Spec.Container.Image)
+	} else if !reflect.DeepEqual(
+		conf.RevisionTemplate.Spec.Container.Resources.Limits,
+		expectedLimitsVars) {
+		t.Fatalf("wrong limits vars %v", conf.RevisionTemplate.Spec.Container.Resources.Requests)
+	}
 }

--- a/pkg/serving/config_changes.go
+++ b/pkg/serving/config_changes.go
@@ -67,3 +67,11 @@ func UpdateImage(config *servingv1alpha1.ConfigurationSpec, image string) error 
 	config.RevisionTemplate.Spec.Container.Image = image
 	return nil
 }
+
+func UpdateResources(config *servingv1alpha1.ConfigurationSpec, requestsResourceList corev1.ResourceList, limitsResourceList corev1.ResourceList) error {
+	config.RevisionTemplate.Spec.Container.Resources = corev1.ResourceRequirements{
+		Requests: requestsResourceList,
+		Limits:   limitsResourceList,
+	}
+	return nil
+}

--- a/pkg/serving/config_changes.go
+++ b/pkg/serving/config_changes.go
@@ -17,9 +17,8 @@ package serving
 import (
 	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
-
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // Give the configuration all the env var values listed in the given map of
@@ -69,9 +68,21 @@ func UpdateImage(config *servingv1alpha1.ConfigurationSpec, image string) error 
 }
 
 func UpdateResources(config *servingv1alpha1.ConfigurationSpec, requestsResourceList corev1.ResourceList, limitsResourceList corev1.ResourceList) error {
-	config.RevisionTemplate.Spec.Container.Resources = corev1.ResourceRequirements{
-		Requests: requestsResourceList,
-		Limits:   limitsResourceList,
+	if config.RevisionTemplate.Spec.Container.Resources.Requests == nil {
+		config.RevisionTemplate.Spec.Container.Resources.Requests = corev1.ResourceList{}
 	}
+
+	for k, v := range requestsResourceList {
+		config.RevisionTemplate.Spec.Container.Resources.Requests[k] = v
+	}
+
+	if config.RevisionTemplate.Spec.Container.Resources.Limits == nil {
+		config.RevisionTemplate.Spec.Container.Resources.Limits = corev1.ResourceList{}
+	}
+
+	for k, v := range limitsResourceList {
+		config.RevisionTemplate.Spec.Container.Resources.Limits[k] = v
+	}
+
 	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -208,6 +208,7 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apimachinery v0.0.0-20190104073114-849b284f3b75
+k8s.io/apimachinery/pkg/api/resource
 k8s.io/apimachinery/pkg/apis/meta/v1
 k8s.io/apimachinery/pkg/runtime/schema
 k8s.io/apimachinery/pkg/api/equality
@@ -218,7 +219,6 @@ k8s.io/apimachinery/pkg/util/validation
 k8s.io/apimachinery/pkg/runtime/serializer
 k8s.io/apimachinery/pkg/types
 k8s.io/apimachinery/pkg/watch
-k8s.io/apimachinery/pkg/api/resource
 k8s.io/apimachinery/pkg/conversion
 k8s.io/apimachinery/pkg/fields
 k8s.io/apimachinery/pkg/labels


### PR DESCRIPTION
Examples:

* `kn service create mysvc --image dev.local/ns/image:latest --request-cpu 100m --requests-memory 64Mi`
* `kn service create mysvc --image dev.local/ns/image:latest --limits-cpu 1000m --limits-memory 1024Mi`

You can also include and/or omit the requests and limits. So the following should also work:
`kn service create mysvc --image dev.local/ns/image:latest  --request-cpu 1000m --limits-memory 1024Mi`