### PR TITLE
Adds --force flag to service create command (service replace)

### DIFF
--- a/pkg/kn/commands/configuration_edit_flags.go
+++ b/pkg/kn/commands/configuration_edit_flags.go
@@ -29,6 +29,7 @@ type ConfigurationEditFlags struct {
 	Image                      string
 	Env                        []string
 	RequestsFlags, LimitsFlags ResourceFlags
+	ForceCreate                bool
 }
 
 type ResourceFlags struct {
@@ -49,6 +50,7 @@ func (p *ConfigurationEditFlags) AddUpdateFlags(command *cobra.Command) {
 
 func (p *ConfigurationEditFlags) AddCreateFlags(command *cobra.Command) {
 	p.AddUpdateFlags(command)
+	command.Flags().BoolVar(&p.ForceCreate, "force", false, "Create service forcefully, replaces existing service if any.")
 	command.MarkFlagRequired("image")
 }
 

--- a/pkg/kn/commands/service_create.go
+++ b/pkg/kn/commands/service_create.go
@@ -84,15 +84,11 @@ func NewServiceCreateCommand(p *KnParams) *cobra.Command {
 				return err
 			}
 			var serviceExists bool = false
-			// check if --force flag is given
 			if editFlags.ForceCreate {
-				// --force flag is given, lets check if the service exists
 				existingService, err := client.Services(namespace).Get(args[0], v1.GetOptions{})
 				if err == nil {
 					serviceExists = true
-					// copy over the resource version
 					service.ResourceVersion = existingService.ResourceVersion
-					// lets update the service
 					_, err = client.Services(namespace).Update(&service)
 					if err != nil {
 						return err
@@ -100,7 +96,6 @@ func NewServiceCreateCommand(p *KnParams) *cobra.Command {
 					fmt.Fprintf(cmd.OutOrStdout(), "Service '%s' successfully replaced in namespace '%s'.\n", args[0], namespace)
 				}
 			}
-			// if service doesn't exist, perform a normal create operation
 			if !serviceExists {
 				_, err = client.Services(namespace).Create(&service)
 				if err != nil {

--- a/pkg/kn/commands/service_create.go
+++ b/pkg/kn/commands/service_create.go
@@ -22,6 +22,7 @@ import (
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NewServiceCreateCommand(p *KnParams) *cobra.Command {
@@ -35,7 +36,18 @@ func NewServiceCreateCommand(p *KnParams) *cobra.Command {
   kn service create mysvc --image dev.local/ns/image:latest
 
   # Create a service with multiple environment variables
-  kn service create mysvc --env KEY1=VALUE1 --env KEY2=VALUE2 --image dev.local/ns/image:latest`,
+  kn service create mysvc --env KEY1=VALUE1 --env KEY2=VALUE2 --image dev.local/ns/image:latest
+
+  # Replace a service 's1' with image dev.local/ns/image:v2 using --force flag
+  kn service create --force s1 --image dev.local/ns/image:v2
+
+  # Replace environment variables of service 's1' using --force flag
+  kn service create --force s1 --env KEY1=NEW_VALUE1 --env NEW_KEY2=NEW_VALUE2 --image dev.local/ns/image:v1
+
+  # Reset resources to default ones of a service 's1' using --force flag
+  # (earlier configured resource requests and limits will be replaced with default)
+  # (earlier configured environment variables will be cleared too if any)
+  kn service create --force s1 --image dev.local/ns/image:v1`,
 
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {
@@ -69,6 +81,12 @@ func NewServiceCreateCommand(p *KnParams) *cobra.Command {
 			client, err := p.ServingFactory()
 			if err != nil {
 				return err
+			}
+			// check if --force flag is given
+			if force, err := cmd.Flags().GetBool("force"); err != nil {
+				return err
+			} else if force {
+				client.Services(namespace).Delete(args[0], &v1.DeleteOptions{})
 			}
 			_, err = client.Services(namespace).Create(&service)
 			if err != nil {

--- a/pkg/kn/commands/service_create_test.go
+++ b/pkg/kn/commands/service_create_test.go
@@ -305,13 +305,12 @@ func TestServiceCreateImageForce(t *testing.T) {
 		t.Fatalf("Bad action %v", action)
 	}
 	conf, err := servinglib.GetConfiguration(created)
-	expectedOutput := "Service 'foo' is successfully created in namespace 'default'.\n"
 	if err != nil {
 		t.Fatal(err)
 	} else if conf.RevisionTemplate.Spec.Container.Image != "gcr.io/foo/bar:v2" {
 		t.Fatalf("wrong image set: %v", conf.RevisionTemplate.Spec.Container.Image)
-	} else if output != expectedOutput {
-		t.Fatalf("wrong output: %s, expected: %s", output, expectedOutput)
+	} else if !strings.Contains(output, "foo") || !strings.Contains(output, "default") {
+		t.Fatalf("wrong output: %s", output)
 	}
 }
 
@@ -339,8 +338,6 @@ func TestServiceCreateEnvForce(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	expectedOutput := "Service 'foo' is successfully created in namespace 'default'.\n"
 	if err != nil {
 		t.Fatal(err)
 	} else if conf.RevisionTemplate.Spec.Container.Image != "gcr.io/foo/bar:v2" {
@@ -349,7 +346,7 @@ func TestServiceCreateEnvForce(t *testing.T) {
 		actualEnvVars,
 		expectedEnvVars) {
 		t.Fatalf("wrong env vars:%v", conf.RevisionTemplate.Spec.Container.Env)
-	} else if output != expectedOutput {
-		t.Fatalf("wrong output: %s, expected: %s", output, expectedOutput)
+	} else if !strings.Contains(output, "foo") || !strings.Contains(output, "default") {
+		t.Fatalf("wrong output: %s", output)
 	}
 }


### PR DESCRIPTION
Fixes #13 

Note the `--force` flag
```
Examples:

  # Create a service 'mysvc' using image at dev.local/ns/image:latest
  kn service create mysvc --image dev.local/ns/image:latest

  # Create a service with multiple environment variables
  kn service create mysvc --env KEY1=VALUE1 --env KEY2=VALUE2 --image dev.local/ns/image:latest

  # Replace a service 's1' with image dev.local/ns/image:v2 using --force flag
  kn service create --force s1 --image dev.local/ns/image:v2

  # Replace environment variables of service 's1' using --force flag
  kn service create --force s1 --env KEY1=NEW_VALUE1 --env NEW_KEY2=NEW_VALUE2 --image dev.local/ns/image:v1

  # Reset resources to default ones of a service 's1' using --force flag
  # (earlier configured resource requests and limits will be replaced with default)
  # (earlier configured environment variables will be cleared too if any)
  kn service create --force s1 --image dev.local/ns/image:v1
```