### PR TITLE
added tests to `$kn service update ...` with --requests/limits-cpu/memory and removed required --image

### DIFF
--- a/pkg/kn/commands/configuration_edit_flags.go
+++ b/pkg/kn/commands/configuration_edit_flags.go
@@ -36,7 +36,7 @@ type ResourceFlags struct {
 	Memory string
 }
 
-func (p *ConfigurationEditFlags) AddFlags(command *cobra.Command) {
+func (p *ConfigurationEditFlags) AddUpdateFlags(command *cobra.Command) {
 	command.Flags().StringVar(&p.Image, "image", "", "Image to run.")
 	command.Flags().StringArrayVarP(&p.Env, "env", "e", []string{},
 		"Environment variable to set. NAME=value; you may provide this flag "+
@@ -45,6 +45,10 @@ func (p *ConfigurationEditFlags) AddFlags(command *cobra.Command) {
 	command.Flags().StringVar(&p.RequestsFlags.Memory, "requests-memory", "", "The requested CPU (e.g., 64Mi).")
 	command.Flags().StringVar(&p.LimitsFlags.CPU, "limits-cpu", "", "The limits on the requested CPU (e.g., 1000m).")
 	command.Flags().StringVar(&p.LimitsFlags.Memory, "limits-memory", "", "The limits on the requested CPU (e.g., 1024Mi).")
+}
+
+func (p *ConfigurationEditFlags) AddCreateFlags(command *cobra.Command) {
+	p.AddUpdateFlags(command)
 	command.MarkFlagRequired("image")
 }
 

--- a/pkg/kn/commands/service_create.go
+++ b/pkg/kn/commands/service_create.go
@@ -78,6 +78,6 @@ func NewServiceCreateCommand(p *KnParams) *cobra.Command {
 		},
 	}
 	AddNamespaceFlags(serviceCreateCommand.Flags(), false)
-	editFlags.AddFlags(serviceCreateCommand)
+	editFlags.AddCreateFlags(serviceCreateCommand)
 	return serviceCreateCommand
 }

--- a/pkg/kn/commands/service_create_test.go
+++ b/pkg/kn/commands/service_create_test.go
@@ -21,13 +21,13 @@ import (
 	"reflect"
 	"testing"
 
+	servinglib "github.com/knative/client/pkg/serving"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	serving "github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
 	"github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1/fake"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
-	servinglib "github.com/knative/client/pkg/serving"
-	serving "github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	client_testing "k8s.io/client-go/testing"
 )
 

--- a/pkg/kn/commands/service_update.go
+++ b/pkg/kn/commands/service_update.go
@@ -28,6 +28,12 @@ func NewServiceUpdateCommand(p *KnParams) *cobra.Command {
 	serviceUpdateCommand := &cobra.Command{
 		Use:   "update NAME",
 		Short: "Update a service.",
+		Example: `
+  # Updates a service 'mysvc' with new environment variables
+  kn service update mysvc --env KEY1=VALUE1 --env KEY2=VALUE2
+
+  # Updates a service 'mysvc' with new requests and limits parameters
+  kn service update mysvc --requests-cpu 500m --limits-memory 1024Mi`,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {
 				return errors.New("requires the service name.")
@@ -66,6 +72,6 @@ func NewServiceUpdateCommand(p *KnParams) *cobra.Command {
 		},
 	}
 	AddNamespaceFlags(serviceUpdateCommand.Flags(), false)
-	editFlags.AddFlags(serviceUpdateCommand)
+	editFlags.AddUpdateFlags(serviceUpdateCommand)
 	return serviceUpdateCommand
 }


### PR DESCRIPTION
* added tests for service update with variations of --requests/limits-cpu --requests/limits-memory
* made image optional on service update since that was not the case and image should be optional