### PR TITLE
Addresses issue #102

### DIFF
--- a/pkg/kn/commands/service_delete.go
+++ b/pkg/kn/commands/service_delete.go
@@ -53,7 +53,7 @@ func NewServiceDeleteCommand(p *KnParams) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Deleted %s in %s namespace.\n", args[0], namespace)
+			fmt.Fprintf(cmd.OutOrStdout(), "Deleted '%s' in '%s' namespace.\n", args[0], namespace)
 			return nil
 		},
 	}


### PR DESCRIPTION
Changes `service delete` output to be nicer to something like:

`Service 'hello' in namespace 'default' deleted`