### PR TITLE
Improve links in development docs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -31,8 +31,7 @@ You must install these tools:
 
 ### Create a cluster
 
-1. [Set up a Knative](https://www.knative.dev/docs/install/)
-   - You can also setup using limited install guides for eg: Minikube/Minishift.
+1. [Set up a Knative](https://www.knative.dev/docs/install/), You can also setup using limited install guides like [Minikube](https://knative.dev/docs/install/knative-with-minikube/) or [Minishift](https://knative.dev/docs/install/knative-with-minishift/).
 
 ### Checkout your fork
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ describe get
 # Developers
 
 If you'd like to contribute, please see
-[CONTRIBUTING](https://github.com/knative/docs/blob/master/contributing/CONTRIBUTING.md)
+[CONTRIBUTING](https://knative.dev/contributing/)
 for more information.
 
 To build `kn`, see our [Development](DEVELOPMENT.md) guide.


### PR DESCRIPTION
* Link to >1 install doc, depending on situation
* Link to official site for knative-wide developer info