### PR TITLE
Disable cgo extensions in build-binaries.sh

### DIFF
--- a/hack/build-binaries.sh
+++ b/hack/build-binaries.sh
@@ -22,7 +22,7 @@ source ${base}/hack/util/flags.sh
 
 ld_flags="$(ld_flags ${base}/hack)"
 export GO111MODULE=on
-
+export CGO_ENABLED=0
 echo "🚧 🐧 Building for Linux"
 GOOS=darwin GOARCH=amd64 go build -mod=vendor -ldflags "${ld_flags}" -o ${base}/kn-darwin-amd64 ${base}/cmd/...
 echo "🚧 🍏 Building for macOS"


### PR DESCRIPTION
Previously, we were running into errors on computers without cross-compilation C
headers. For simplicity of building, and because we don't need superperformant
net libs, disable cgo.