### PR TITLE
fix(build.sh): Reintroduced build-flags.sh

### DIFF
--- a/hack/build-flags.sh
+++ b/hack/build-flags.sh
@@ -1,0 +1,14 @@
+function build_flags() {
+ local now="$(date -u '+%Y-%m-%d %H:%M:%S')"
+  local rev="$(git rev-parse --short HEAD)"
+  local pkg="github.com/knative/client/pkg/kn/commands"
+  local version="${TAG:-}"
+  # Use vYYYYMMDD-local-<hash> for the version string, if not passed.
+  if [[ -z "${version}" ]]; then
+    # Get the commit, excluding any tags but keeping the "dirty" flag
+    local commit="$(git describe --always --dirty --match '^$')"
+    [[ -n "${commit}" ]] || abort "error getting the current commit"
+    version="v$(date +%Y%m%d)-local-${commit}"
+  fi
+  echo "-X '${pkg}.BuildDate=${now}' -X ${pkg}.Version=${version} -X ${pkg}.GitRevision=${rev}"
+}

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -19,16 +19,15 @@ set -eu
 
 dir=$(dirname "${BASH_SOURCE[0]}")
 base=$(cd "$dir/.." && pwd)
-source ${base}/hack/util/flags.sh
+source ${base}/hack/build-flags.sh
 
 export GO111MODULE=on
 
 echo "📋 Formatting"
 go fmt ${base}/cmd/... ${base}/pkg/...
 echo "🚧 Building"
-go build -mod=vendor -ldflags "$(ld_flags ${base}/hack)" -o ${base}/kn ${base}/cmd/...
+go build -mod=vendor -ldflags "$(build_flags)" -o ${base}/kn ${base}/cmd/...
 echo "🌞 Success"
-
 ${base}/hack/generate-docs.sh
 
 ${base}/kn version

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -15,20 +15,10 @@
 # limitations under the License.
 
 source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/release.sh
+source $(dirname $0)/build-flags.sh
 
 function build_release() {
-  local now="$(date -u '+%Y-%m-%d %H:%M:%S')"
-  local rev="$(git rev-parse --short HEAD)"
-  local pkg="github.com/knative/client/pkg/kn/commands"
-  local version="${TAG}"
-  # Use vYYYYMMDD-local-<hash> for the version string, if not passed.
-  if [[ -z "${version}" ]]; then
-    # Get the commit, excluding any tags but keeping the "dirty" flag
-    local commit="$(git describe --always --dirty --match '^$')"
-    [[ -n "${commit}" ]] || abort "error getting the current commit"
-    version="v$(date +%Y%m%d)-local-${commit}"
-  fi
-  local ld_flags="-X '${pkg}.BuildDate=${now}' -X ${pkg}.Version=${version} -X ${pkg}.GitRevision=${rev}"
+  local ld_flags="$(build_flags)"
 
   export GO111MODULE=on
   export CGO_ENABLED=0


### PR DESCRIPTION
so that it can be shared between build.sh and release.sh

Fixes #120