### PR TITLE
Fix auto releases of Knative Client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/knative/build v0.5.0 // indirect
 	github.com/knative/pkg v0.0.0-20190329155329-916205998db9
 	github.com/knative/serving v0.5.2
-	github.com/knative/test-infra v0.0.0-20190516041915-e83cf0ab6b1d
+	github.com/knative/test-infra v0.0.0-20190517181617-d1bb39bbca6e
 	github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/modern-go/reflect2 v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/knative/test-infra v0.0.0-20190509163238-a721698dbe49 h1:TEv7xkUjVofC
 github.com/knative/test-infra v0.0.0-20190509163238-a721698dbe49/go.mod h1:l77IWBscEV5T4sYb64/9iwRCVY4UXEIqMcAppsblHW4=
 github.com/knative/test-infra v0.0.0-20190516041915-e83cf0ab6b1d h1:o0QEmZJb46wFefSHgM8k3JtINpAH/KN5oe2bsFkDVOI=
 github.com/knative/test-infra v0.0.0-20190516041915-e83cf0ab6b1d/go.mod h1:l77IWBscEV5T4sYb64/9iwRCVY4UXEIqMcAppsblHW4=
+github.com/knative/test-infra v0.0.0-20190517181617-d1bb39bbca6e h1:Is4Ki1oQhYD3Twfdzpk2U/vI/5hSPh9277bI1AK+28o=
+github.com/knative/test-infra v0.0.0-20190517181617-d1bb39bbca6e/go.mod h1:l77IWBscEV5T4sYb64/9iwRCVY4UXEIqMcAppsblHW4=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -17,18 +17,11 @@
 source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/release.sh
 
 function build_release() {
-  local now="$(date -u '+%Y-%m-%d %H:%M:%S')"
-  local rev="$(git rev-parse --short HEAD)"
   local pkg="github.com/knative/client/pkg/kn/commands"
   local version="${TAG}"
-  # Use vYYYYMMDD-local-<hash> for the version string, if not passed.
-  if [[ -z "${version}" ]]; then
-    # Get the commit, excluding any tags but keeping the "dirty" flag
-    local commit="$(git describe --always --dirty --match '^$')"
-    [[ -n "${commit}" ]] || abort "error getting the current commit"
-    version="v$(date +%Y%m%d)-local-${commit}"
-  fi
-  local ld_flags="-X '${pkg}.BuildDate=${now}' -X ${pkg}.Version=${version} -X ${pkg}.GitRevision=${rev}"
+  # Use vYYYYMMDD-<hash>-local for the version string, if not passed.
+  [[ -z "${version}" ]] && version="v${BUILD_TAG}-local"
+  local ld_flags="-X '${pkg}.BuildDate=${BUILD_TIMESTAMP}' -X ${pkg}.Version=${version} -X ${pkg}.GitRevision=${BUILD_COMMIT_HASH}"
 
   export GO111MODULE=on
   export CGO_ENABLED=0

--- a/vendor/github.com/knative/test-infra/scripts/README.md
+++ b/vendor/github.com/knative/test-infra/scripts/README.md
@@ -108,10 +108,13 @@ This is a helper script for Knative E2E test scripts. To use it:
    if the default values don't fit your needs:
 
    - `E2E_CLUSTER_REGION`: Cluster region, defaults to `us-central1`.
-   - `E2E_CLUSTER_BACKUP_REGIONS`: Space-separated list of regions to retry test cluster creation in case of stockout. Defaults to `us-west1 us-east1`.
+   - `E2E_CLUSTER_BACKUP_REGIONS`: Space-separated list of regions to retry test
+     cluster creation in case of stockout. Defaults to `us-west1 us-east1`.
    - `E2E_CLUSTER_ZONE`: Cluster zone (e.g., `a`), defaults to none (i.e. use a regional
      cluster).
-   - `E2E_CLUSTER_BACKUP_ZONES`: Space-separated list of zones to retry test cluster creation in case of stockout. If defined, `E2E_CLUSTER_BACKUP_REGIONS` will be ignored thus it defaults to none.
+   - `E2E_CLUSTER_BACKUP_ZONES`: Space-separated list of zones to retry test cluster
+     creation in case of stockout. If defined, `E2E_CLUSTER_BACKUP_REGIONS` will be
+     ignored thus it defaults to none.
    - `E2E_CLUSTER_MACHINE`: Cluster node machine type, defaults to `n1-standard-4}`.
    - `E2E_MIN_CLUSTER_NODES`: Minimum number of nodes in the cluster when autoscaling,
      defaults to 1.
@@ -241,14 +244,20 @@ This is a helper script for Knative release scripts. To use it:
    - `RELEASE_GCS_BUCKET`: contains the GCS bucket name to store the manifests if
      `--release-gcs` was passed, otherwise the default value `knative-nightly/<repo>`
      will be used. It is empty if `--publish` was not passed.
+   - `BUILD_COMMIT_HASH`: the commit short hash for the current repo. If the current
+     git tree is dirty, it will have `-dirty` appended to it.
+   - `BUILD_YYYYMMDD`: current UTC date in `YYYYMMDD` format.
+   - `BUILD_TIMESTAMP`: human-readable UTC timestamp in `YYYY-MM-DD HH:MM:SS` format.
+   - `BUILD_TAG`: a tag in the form `v$BUILD_YYYYMMDD-$BUILD_COMMIT_HASH`.
    - `KO_DOCKER_REPO`: contains the GCR to store the images if `--release-gcr` was
      passed, otherwise the default value `gcr.io/knative-nightly` will be used. It
      is set to `ko.local` if `--publish` was not passed.
    - `SKIP_TESTS`: true if `--skip-tests` was passed. This is handled automatically.
    - `TAG_RELEASE`: true if `--tag-release` was passed. In this case, the environment
-     variable `TAG` will contain the release tag in the form `vYYYYMMDD-<commit_short_hash>`.
+     variable `TAG` will contain the release tag in the form `v$BUILD_TAG`.
    - `PUBLISH_RELEASE`: true if `--publish` was passed. In this case, the environment
-     variable `KO_FLAGS` will be updated with the `-L` option.
+     variable `KO_FLAGS` will be updated with the `-L` option and `TAG` will contain
+     the release tag in the form `v$RELEASE_VERSION`.
    - `PUBLISH_TO_GITHUB`: true if `--version`, `--branch` and `--publish-release`
      were passed.
 

--- a/vendor/github.com/knative/test-infra/scripts/library.sh
+++ b/vendor/github.com/knative/test-infra/scripts/library.sh
@@ -36,6 +36,20 @@ readonly IS_PROW
 readonly REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 readonly REPO_NAME="$(basename ${REPO_ROOT_DIR})"
 
+# Useful flags about the current OS
+IS_LINUX=0
+IS_OSX=0
+IS_WINDOWS=0
+case "${OSTYPE}" in
+  darwin*) IS_OSX=1 ;;
+  linux*) IS_LINUX=1 ;;
+  msys*) IS_WINDOWS=1 ;;
+  *) echo "** Internal error in library.sh, unknown OS '${OSTYPE}'" ; exit 1 ;;
+esac
+readonly IS_LINUX
+readonly IS_OSX
+readonly IS_WINDOWS
+
 # Set ARTIFACTS to an empty temp dir if unset
 if [[ -z "${ARTIFACTS:-}" ]]; then
   export ARTIFACTS="$(mktemp -d)"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -80,7 +80,7 @@ github.com/knative/serving/pkg/apis/networking/v1alpha1
 github.com/knative/serving/pkg/client/clientset/versioned/scheme
 github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1/fake
 github.com/knative/serving/pkg/apis/autoscaling/v1alpha1
-# github.com/knative/test-infra v0.0.0-20190516041915-e83cf0ab6b1d
+# github.com/knative/test-infra v0.0.0-20190517181617-d1bb39bbca6e
 github.com/knative/test-infra/scripts
 # github.com/magiconair/properties v1.8.0
 github.com/magiconair/properties


### PR DESCRIPTION
This requires updating test-infra to deal with a repo that has no releases yet.

Also use hash and dates from the helper, to keep the binary and the GCS dirs in sync.