### PR TITLE
fix: Update cli-runtime to include fix for cli options help

### DIFF
--- a/docs/cmd/kn_revision_describe.md
+++ b/docs/cmd/kn_revision_describe.md
@@ -16,7 +16,7 @@ kn revision describe NAME [flags]
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for describe
   -n, --namespace string              List the requested object(s) in given namespace.
-  -o, --output string                 Output format. One of: json|yaml|name|template|go-template|go-template-file|templatefile|jsonpath|jsonpath-file. (default "yaml")
+  -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file. (default "yaml")
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```
 

--- a/docs/cmd/kn_revision_get.md
+++ b/docs/cmd/kn_revision_get.md
@@ -17,7 +17,7 @@ kn revision get [flags]
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for get
   -n, --namespace string              List the requested object(s) in given namespace.
-  -o, --output string                 Output format. One of: json|yaml|name|template|go-template|go-template-file|templatefile|jsonpath|jsonpath-file.
+  -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```
 

--- a/docs/cmd/kn_service_describe.md
+++ b/docs/cmd/kn_service_describe.md
@@ -16,7 +16,7 @@ kn service describe NAME [flags]
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for describe
   -n, --namespace string              List the requested object(s) in given namespace.
-  -o, --output string                 Output format. One of: json|yaml|name|template|go-template|go-template-file|templatefile|jsonpath|jsonpath-file. (default "yaml")
+  -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file. (default "yaml")
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```
 

--- a/docs/cmd/kn_service_get.md
+++ b/docs/cmd/kn_service_get.md
@@ -17,7 +17,7 @@ kn service get [flags]
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for get
   -n, --namespace string              List the requested object(s) in given namespace.
-  -o, --output string                 Output format. One of: json|yaml|name|template|go-template|go-template-file|templatefile|jsonpath|jsonpath-file.
+  -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/api v0.0.0-20190226173710-145d52631d00
 	k8s.io/apimachinery v0.0.0-20190221084156-01f179d85dbc
-	k8s.io/cli-runtime v0.0.0-20190226180714-082c0831af2b
+	k8s.io/cli-runtime v0.0.0-20190325194458-f2b4781c3ae1
 	k8s.io/client-go v0.0.0-20190226174127-78295b709ec6
 	k8s.io/kube-openapi v0.0.0-20190510232812-a01b7d5d6c22 // indirect
 	sigs.k8s.io/yaml v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -346,6 +346,8 @@ k8s.io/apimachinery v0.0.0-20190221084156-01f179d85dbc h1:7z9/6jKWBqkK9GI1RRB0B5
 k8s.io/apimachinery v0.0.0-20190221084156-01f179d85dbc/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
 k8s.io/cli-runtime v0.0.0-20190226180714-082c0831af2b h1:AkeqbZbtHxFlkmXpAf/1DOyl3JLTn25RZxiFcI9QJys=
 k8s.io/cli-runtime v0.0.0-20190226180714-082c0831af2b/go.mod h1:qWnH3/b8sp/l7EvlDh7ulDU3UWA4P4N1NFbEEP791tM=
+k8s.io/cli-runtime v0.0.0-20190325194458-f2b4781c3ae1 h1:yIrGaL3GC1eoxtkSXoNMHKzF1QIbC0TLq07OApgVvc0=
+k8s.io/cli-runtime v0.0.0-20190325194458-f2b4781c3ae1/go.mod h1:qWnH3/b8sp/l7EvlDh7ulDU3UWA4P4N1NFbEEP791tM=
 k8s.io/client-go v0.0.0-20190226174127-78295b709ec6 h1:EqyY1rPCSXiJjwNtNuj9MwuCKpbcbYyha4HTZ+EihE4=
 k8s.io/client-go v0.0.0-20190226174127-78295b709ec6/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/jsonpath_flags.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/jsonpath_flags.go
@@ -19,6 +19,7 @@ package genericclioptions
 import (
 	"fmt"
 	"io/ioutil"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -49,6 +50,7 @@ func (f *JSONPathPrintFlags) AllowedFormats() []string {
 	for format := range jsonFormats {
 		formats = append(formats, format)
 	}
+	sort.Strings(formats)
 	return formats
 }
 

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/printers/json.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/printers/json.go
@@ -25,7 +25,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 // JSONPrinter is an implementation of ResourcePrinter which outputs an object as JSON.
@@ -68,10 +68,7 @@ func (p *JSONPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 // YAMLPrinter is an implementation of ResourcePrinter which outputs an object as YAML.
 // The input object is assumed to be in the internal version of an API and is converted
 // to the given version first.
-type YAMLPrinter struct {
-	version   string
-	converter runtime.ObjectConvertor
-}
+type YAMLPrinter struct{}
 
 // PrintObj prints the data as YAML.
 func (p *YAMLPrinter) PrintObj(obj runtime.Object, w io.Writer) error {

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/printers/jsonpath.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/printers/jsonpath.go
@@ -17,6 +17,7 @@ limitations under the License.
 package printers
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -136,10 +137,11 @@ func (j *JSONPathPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 	}
 
 	if err := j.JSONPath.Execute(w, queryObj); err != nil {
-		fmt.Fprintf(w, "Error executing template: %v. Printing more information for debugging the template:\n", err)
-		fmt.Fprintf(w, "\ttemplate was:\n\t\t%v\n", j.rawTemplate)
-		fmt.Fprintf(w, "\tobject given to jsonpath engine was:\n\t\t%#v\n\n", queryObj)
-		return fmt.Errorf("error executing jsonpath %q: %v\n", j.rawTemplate, err)
+		buf := bytes.NewBuffer(nil)
+		fmt.Fprintf(buf, "Error executing template: %v. Printing more information for debugging the template:\n", err)
+		fmt.Fprintf(buf, "\ttemplate was:\n\t\t%v\n", j.rawTemplate)
+		fmt.Fprintf(buf, "\tobject given to jsonpath engine was:\n\t\t%#v\n\n", queryObj)
+		return fmt.Errorf("error executing jsonpath %q: %v\n", j.rawTemplate, buf.String())
 	}
 	return nil
 }

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/builder.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/builder.go
@@ -1056,7 +1056,7 @@ func (b *Builder) visitByPaths() *Result {
 	if b.labelSelector != nil {
 		selector, err := labels.Parse(*b.labelSelector)
 		if err != nil {
-			return result.withError(fmt.Errorf("the provided selector %q is not valid: %v", b.labelSelector, err))
+			return result.withError(fmt.Errorf("the provided selector %q is not valid: %v", *b.labelSelector, err))
 		}
 		visitors = NewFilteredVisitor(visitors, FilterByLabelSelector(selector))
 	}
@@ -1089,9 +1089,10 @@ func (b *Builder) Do() *Result {
 	if b.requireObject {
 		helpers = append(helpers, RetrieveLazy)
 	}
-	r.visitor = NewDecoratedVisitor(r.visitor, helpers...)
 	if b.continueOnError {
-		r.visitor = ContinueOnErrorVisitor{r.visitor}
+		r.visitor = NewDecoratedVisitor(ContinueOnErrorVisitor{r.visitor}, helpers...)
+	} else {
+		r.visitor = NewDecoratedVisitor(r.visitor, helpers...)
 	}
 	return r
 }

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/template_flags.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/template_flags.go
@@ -19,6 +19,7 @@ package genericclioptions
 import (
 	"fmt"
 	"io/ioutil"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -51,6 +52,7 @@ func (f *GoTemplatePrintFlags) AllowedFormats() []string {
 	for format := range templateFormats {
 		formats = append(formats, format)
 	}
+	sort.Strings(formats)
 	return formats
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -244,7 +244,7 @@ k8s.io/apimachinery/pkg/util/framer
 k8s.io/apimachinery/pkg/util/mergepatch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/pkg/apis/meta/internalversion
-# k8s.io/cli-runtime v0.0.0-20190226180714-082c0831af2b
+# k8s.io/cli-runtime v0.0.0-20190325194458-f2b4781c3ae1
 k8s.io/cli-runtime/pkg/genericclioptions
 k8s.io/cli-runtime/pkg/genericclioptions/printers
 k8s.io/cli-runtime/pkg/genericclioptions/resource


### PR DESCRIPTION
The update to kubernetes-1.13.5 for cli-runtime introduces a fix for #135 (i.e. sorting the keys for the options)