### PR TITLE
feat(build.sh): Adding options and running tests

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -71,10 +71,10 @@ $ hack/build.sh
 
 You can link that script into a directory within your search `$PATH`. This allows you to build `kn` from any working directory. There are several options to support various development flows:
 
-* `build.sh`  Compile, test, generate docs and format source code
-* `build.sh -f` - Only compile
+* `build.sh` - Compile, test, generate docs and format source code
+* `build.sh -f` - Compile only
 * `build.sh -f -t` - Compile & test
-* `build.sh -u` - Update dependencies
+* `build.sh -u` - Update dependencies before compiling
 
 See `build.sh --help` for a full list of options and usage examples.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -71,7 +71,7 @@ $ hack/build.sh
 
 You can link that script into a directory within your search `$PATH`. This allows you to build `kn` from any working directory. There are several options to support various development flows:
 
-* `build.sh`  Compile, test, generated docs and format source code
+* `build.sh`  Compile, test, generate docs and format source code
 * `build.sh -f` - Only compile
 * `build.sh -f -t` - Compile & test
 * `build.sh -u` - Update dependencies

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -69,7 +69,16 @@ Once you've [setup your development environment](#prerequisites), let's build
 $ hack/build.sh
 ```
 
-It builds `kn` binary in your current directory. You can start playing with it.
+You can link that script into a directory within your search `$PATH`. This allows you to build `kn` from any working directory. There are several options to support various development flows:
+
+* `build.sh`  Compile, test, generated docs and format source code
+* `build.sh -f` - Only compile
+* `build.sh -f -t` - Compile & test
+* `build.sh -u` - Update dependencies
+
+See `build.sh --help` for a full list of options and usage examples.
+
+At the end, the build results in `kn` binary in your current directory, which can be directly executed.
 
 **Notes:**
 

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -72,7 +72,7 @@ go_fmt() {
 go_build() {
   echo "🚧 Compile"
   source "./hack/build-flags.sh"
-  go build -mod=vendor -ldflags "$(build_flags .)" -o ./kn ./cmd/...
+  go build -mod=vendor -ldflags "$(build_flags .)" -o kn ./cmd/...
 }
 
 go_test() {
@@ -153,7 +153,7 @@ Usage: $(basename $BASH_SOURCE) [... options ...]
 
 with the following options:
 
--f  --fast                    Only compile (without formatting, testing, code generation)
+-f  --fast                    Only compile (without formatting, testing, doc generation)
 -t  --test                    Run tests when used with --fast
 -u  --update                  Update dependencies before compiling
 -h  --help                    Display this help message

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -15,47 +15,167 @@
 # limitations under the License.
 
 set -o pipefail
+
+# Store for later
+if [ -z "$1" ]; then
+    ARGS=("")
+else
+    ARGS=("$@")
+fi
+
 set -eu
 
 # Run build
 run() {
   export GO111MODULE=on
 
-  go_fmt
+  # Jump in/out project directory
+  pushd $(basedir) >/dev/null 2>&1
+  trap "popd >/dev/null 2>&1" EXIT
+
+  if $(has_flag --help -h); then
+    display_help
+    exit 0
+  fi
+
+  # Switch on modules unconditionally
+  export GO111MODULE=on
+
+  if $(has_flag -u --update); then
+    # Update dependencies
+    update_deps
+  fi
+
+  # Run build
   go_build
-  generate_docs
 
-  echo "🌞 Success"
+  # Run tests
+  if  $(has_flag --test -t) || ! $(has_flag --fast -f); then
+    go_test
+  fi
 
-  $(basedir)/kn version
+  if ! $(has_flag --fast -f); then
+    # Format source code
+    go_fmt
+
+    # Generate docs
+    generate_docs
+  fi
+
+  echo "────────────────────────────────────────────"
+  ./kn version
 }
 
 go_fmt() {
-  local base=$(basedir)
-  echo "📋 Formatting"
-  go fmt "${base}/cmd/..." "${base}/pkg/..."
+  echo "🧹  Format"
+  go fmt ./cmd/... ./pkg/...
 }
 
 go_build() {
-  local base=$(basedir)
-  echo "🚧 Building"
-  source "${base}/hack/build-flags.sh"
-  go build -mod=vendor -ldflags "$(build_flags ${base})" -o ${base}/kn ${base}/cmd/...
+  echo "🚧 Compile"
+  source "./hack/build-flags.sh"
+  go build -mod=vendor -ldflags "$(build_flags .)" -o ./kn ./cmd/...
 }
 
+go_test() {
+  local test_output=$(mktemp /tmp/kn-client-test-output.XXXXXX)
+  local red="[31m"
+  local reset="[39m"
+
+  echo "🧪  Test"
+  set +e
+  go test -v ./pkg/... >$test_output 2>&1
+  local err=$?
+  if [ $err -ne 0 ]; then
+    echo "🔥 ${red}Failure${reset}"
+    cat $test_output | sed -e "s/^.*\(FAIL.*\)$/$red\1$reset/"
+    rm $test_output
+    exit $err
+  fi
+  rm $test_output
+}
+
+update_deps() {
+  echo "🕸️  Update"
+  go mod vendor
+}
 generate_docs() {
-  local base=$(basedir)
-  echo "📑 Generating docs"
-  rm -rf "${base}/docs/cmd"
-  mkdir -p "${base}/docs/cmd"
-
-  go run "${base}/hack/generate-docs.go" "${base}"
+  echo "📖 Docs"
+  rm -rf "./docs/cmd"
+  mkdir -p "./docs/cmd"
+  go run "./hack/generate-docs.go" "."
 }
 
+# Dir where this script is located
 basedir() {
-  dir=$(dirname "${BASH_SOURCE[0]}")
-  base=$(cd "$dir/.." && pwd)
-  echo ${base}
+    # Default is current directory
+    local script=${BASH_SOURCE[0]}
+
+    # Resolve symbolic links
+    if [ -L $script ]; then
+        if readlink -f $script >/dev/null 2>&1; then
+            script=$(readlink -f $script)
+        elif readlink $script >/dev/null 2>&1; then
+            script=$(readlink $script)
+        elif realpath $script >/dev/null 2>&1; then
+            script=$(realpath $script)
+        else
+            echo "ERROR: Cannot resolve symbolic link $script"
+            exit 1
+        fi
+    fi
+
+    local dir=$(dirname "$script")
+    local full_dir=$(cd "${dir}/.." && pwd)
+    echo ${full_dir}
 }
+
+# Checks if a flag is present in the arguments.
+has_flag() {
+    filters="$@"
+    for var in "${ARGS[@]}"; do
+        for filter in $filters; do
+          if [ "$var" = "$filter" ]; then
+              echo 'true'
+              return
+          fi
+        done
+    done
+    echo 'false'
+}
+
+# Display a help message.
+display_help() {
+    local command="${1:-}"
+    cat <<EOT
+Knative Client Build Script
+
+Usage: $(basename $BASH_SOURCE) [... options ...]
+
+with the following options:
+
+-f  --fast                    Only build (without formatting, testing, code generation)
+-t  --test                    Run tests even when used with --fast
+-u  --update                  Update dependencies
+-h  --help                    Display this help message
+    --verbose                 Verbose script output (set -x)
+
+You can add a symbolic link to this build script into your PATH so that it can be
+called from everywhere. E.g.:
+
+ln -s $(basedir)/hack/build.sh /usr/local/bin/kn_build.sh
+
+Examples:
+
+* Compile, format, tests, docs:  build.sh
+* Compile only:                  build.sh --fast
+* Compile with tests:            build.sh -f -t
+EOT
+}
+
+if $(has_flag --verbose); then
+    export PS4='+($(basename ${BASH_SOURCE[0]}):${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+    set -x
+fi
 
 run $*

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -27,19 +27,17 @@ set -eu
 
 # Run build
 run() {
+  # Switch on modules unconditionally
   export GO111MODULE=on
 
-  # Jump in/out project directory
+  # Jump into project directory
   pushd $(basedir) >/dev/null 2>&1
-  trap "popd >/dev/null 2>&1" EXIT
 
+  # Print help if requested
   if $(has_flag --help -h); then
     display_help
     exit 0
   fi
-
-  # Switch on modules unconditionally
-  export GO111MODULE=on
 
   if $(has_flag -u --update); then
     # Update dependencies
@@ -99,6 +97,7 @@ update_deps() {
   echo "🕸️  Update"
   go mod vendor
 }
+
 generate_docs() {
   echo "📖 Docs"
   rm -rf "./docs/cmd"
@@ -148,15 +147,15 @@ has_flag() {
 display_help() {
     local command="${1:-}"
     cat <<EOT
-Knative Client Build Script
+Knative client build script
 
 Usage: $(basename $BASH_SOURCE) [... options ...]
 
 with the following options:
 
--f  --fast                    Only build (without formatting, testing, code generation)
--t  --test                    Run tests even when used with --fast
--u  --update                  Update dependencies
+-f  --fast                    Only compile (without formatting, testing, code generation)
+-t  --test                    Run tests when used with --fast
+-u  --update                  Update dependencies before compiling
 -h  --help                    Display this help message
     --verbose                 Verbose script output (set -x)
 


### PR DESCRIPTION
* Added running unit tests to the script
* Added options to support different development flows (see help message below)
* Allow symlinking to /usr/local/bin so that the script can be called from anywhere

Usage message:

```
Knative Client Build Script

Usage: hack/build.sh [... options ...]

with the following options:

-f  --fast                    Only build (without formatting, testing, code generation)
-t  --test                    Run tests even when used with --fast
-u  --update                  Update dependencies
-h  --help                    Display this help message
    --verbose                 Verbose script output (set -x)

You can add a symbolic link to this build script into your PATH so that it can be
called from everywhere. E.g.:

ln -s .../hack/build.sh /usr/local/bin/kn_build.sh

Examples:

* Compile, format, tests, docs:       build.sh
* Compile only:                       build.sh --fast
* Compile with tests:                 build.sh -f -t
```