### PR TITLE
get a particular service and revision based on name parameter

### DIFF
--- a/docs/cmd/kn_revision_list.md
+++ b/docs/cmd/kn_revision_list.md
@@ -7,7 +7,7 @@ List available revisions.
 List revisions for a given service.
 
 ```
-kn revision list [flags]
+kn revision list [name] [flags]
 ```
 
 ### Examples
@@ -19,6 +19,12 @@ kn revision list [flags]
 
   # List revisions for a service 'svc1' in namespace 'myapp'
   kn revision list -s svc1 -n myapp
+
+  # List all revisions in JSON output format
+  kn revision list -o json
+  
+  # List revision 'web'
+  kn revision list web
 ```
 
 ### Options

--- a/docs/cmd/kn_service_list.md
+++ b/docs/cmd/kn_service_list.md
@@ -7,7 +7,21 @@ List available services.
 List available services.
 
 ```
-kn service list [flags]
+kn service list [name] [flags]
+```
+
+### Examples
+
+```
+
+  # List all services
+  kn service list
+
+  # List all services in JSON output format
+  kn service list -o json
+
+  # List service 'web'
+  kn service list web
 ```
 
 ### Options

--- a/pkg/kn/commands/service/service_list.go
+++ b/pkg/kn/commands/service/service_list.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 
 	"github.com/knative/client/pkg/kn/commands"
+	v1alpha12 "github.com/knative/client/pkg/serving/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/spf13/cobra"
 )
 
@@ -26,8 +28,17 @@ func NewServiceListCommand(p *commands.KnParams) *cobra.Command {
 	serviceListFlags := NewServiceListFlags()
 
 	serviceListCommand := &cobra.Command{
-		Use:   "list",
+		Use:   "list [name]",
 		Short: "List available services.",
+		Example: `
+  # List all services
+  kn service list
+
+  # List all services in JSON output format
+  kn service list -o json
+
+  # List service 'web'
+  kn service list web`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, err := p.GetNamespace(cmd)
 			if err != nil {
@@ -37,7 +48,7 @@ func NewServiceListCommand(p *commands.KnParams) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			serviceList, err := client.ListServices()
+			serviceList, err := getServiceInfo(args, client)
 			if err != nil {
 				return err
 			}
@@ -60,4 +71,20 @@ func NewServiceListCommand(p *commands.KnParams) *cobra.Command {
 	commands.AddNamespaceFlags(serviceListCommand.Flags(), true)
 	serviceListFlags.AddFlags(serviceListCommand)
 	return serviceListCommand
+}
+
+func getServiceInfo(args []string, client v1alpha12.KnClient) (*v1alpha1.ServiceList, error) {
+	var (
+		serviceList *v1alpha1.ServiceList
+		err         error
+	)
+	switch len(args) {
+	case 0:
+		serviceList, err = client.ListServices()
+	case 1:
+		serviceList, err = client.ListServices(v1alpha12.WithName(args[0]))
+	default:
+		return nil, fmt.Errorf("'kn service list' accepts maximum 1 argument")
+	}
+	return serviceList, err
 }


### PR DESCRIPTION
https://github.com/knative/client/issues/143

**current:**
```
kn service list -n test autoscale-go
NAME           DOMAIN                          GENERATION   AGE    CONDITIONS   READY     REASON
autoscale-go   autoscale-go.test.example.com   1            125m   0 OK / 3     Unknown   RevisionMissing : Configuration "autoscale-go" is waiting for a Revision to become ready.
test1          test1.test.example.com          1            119m   0 OK / 3     False     RevisionMissing : Configuration "test1" does not have any ready Revision.
```

**Expected:** Should list only that perticular service.
something like below
```
kn service list -n test autoscale-go
NAME           DOMAIN                          GENERATION   AGE    CONDITIONS   READY     REASON
autoscale-go   autoscale-go.test.example.com   1            125m   0 OK / 3     Unknown   RevisionMissing : Configuration "autoscale-go" is waiting for a Revision to become ready.
```
