### PR TITLE
feat(service create/update): Add support of minScale/maxScale/target

### DIFF
--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -36,12 +36,16 @@ kn service create NAME --image IMAGE [flags]
 ### Options
 
 ```
+      --concurrency-limit int    Hard Limit of concurrent requests to be processed by a single replica.
+      --concurrency-target int   Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to --concurrency-limit when given.
   -e, --env stringArray          Environment variable to set. NAME=value; you may provide this flag any number of times to set multiple environment variables.
       --force                    Create service forcefully, replaces existing service if any.
   -h, --help                     help for create
       --image string             Image to run.
       --limits-cpu string        The limits on the requested CPU (e.g., 1000m).
       --limits-memory string     The limits on the requested CPU (e.g., 1024Mi).
+      --max-scale int            Maximal number of replicas.
+      --min-scale int            Minimal number of replicas.
   -n, --namespace string         List the requested object(s) in given namespace.
       --requests-cpu string      The requested CPU (e.g., 250m).
       --requests-memory string   The requested CPU (e.g., 64Mi).

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -24,11 +24,15 @@ kn service update NAME [flags]
 ### Options
 
 ```
+      --concurrency-limit int    Hard Limit of concurrent requests to be processed by a single replica.
+      --concurrency-target int   Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to --concurrency-limit when given.
   -e, --env stringArray          Environment variable to set. NAME=value; you may provide this flag any number of times to set multiple environment variables.
   -h, --help                     help for update
       --image string             Image to run.
       --limits-cpu string        The limits on the requested CPU (e.g., 1000m).
       --limits-memory string     The limits on the requested CPU (e.g., 1024Mi).
+      --max-scale int            Maximal number of replicas.
+      --min-scale int            Minimal number of replicas.
   -n, --namespace string         List the requested object(s) in given namespace.
       --requests-cpu string      The requested CPU (e.g., 250m).
       --requests-memory string   The requested CPU (e.g., 64Mi).

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -30,6 +30,10 @@ type ConfigurationEditFlags struct {
 	Env                        []string
 	RequestsFlags, LimitsFlags ResourceFlags
 	ForceCreate                bool
+	MinScale                   int
+	MaxScale                   int
+	ConcurrencyTarget          int
+	ConcurrencyLimit           int
 }
 
 type ResourceFlags struct {
@@ -46,6 +50,10 @@ func (p *ConfigurationEditFlags) AddUpdateFlags(command *cobra.Command) {
 	command.Flags().StringVar(&p.RequestsFlags.Memory, "requests-memory", "", "The requested CPU (e.g., 64Mi).")
 	command.Flags().StringVar(&p.LimitsFlags.CPU, "limits-cpu", "", "The limits on the requested CPU (e.g., 1000m).")
 	command.Flags().StringVar(&p.LimitsFlags.Memory, "limits-memory", "", "The limits on the requested CPU (e.g., 1024Mi).")
+	command.Flags().IntVar(&p.MinScale, "min-scale", 0, "Minimal number of replicas.")
+	command.Flags().IntVar(&p.MaxScale, "max-scale", 0, "Maximal number of replicas.")
+	command.Flags().IntVar(&p.ConcurrencyTarget, "concurrency-target", 0, "Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to --concurrency-limit when given.")
+	command.Flags().IntVar(&p.ConcurrencyLimit, "concurrency-limit", 0, "Hard Limit of concurrent requests to be processed by a single replica.")
 }
 
 func (p *ConfigurationEditFlags) AddCreateFlags(command *cobra.Command) {
@@ -93,6 +101,9 @@ func (p *ConfigurationEditFlags) Apply(service *servingv1alpha1.Service, cmd *co
 	if err != nil {
 		return err
 	}
+
+	servinglib.UpdateConcurrencyConfiguration(template, p.MinScale, p.MaxScale, p.ConcurrencyTarget, p.ConcurrencyLimit)
+
 	return nil
 }
 

--- a/pkg/serving/config_changes_test.go
+++ b/pkg/serving/config_changes_test.go
@@ -23,6 +23,24 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+func TestUpdateAutoscalingAnnotations(t *testing.T) {
+	template := &servingv1alpha1.RevisionTemplateSpec{}
+	UpdateConcurrencyConfiguration(template, 10, 100, 1000, 1000)
+	annos := template.Annotations
+	if annos["autoscaling.knative.dev/minScale"] != "10" {
+		t.Error("minScale failed")
+	}
+	if annos["autoscaling.knative.dev/maxScale"] != "100" {
+		t.Error("maxScale failed")
+	}
+	if annos["autoscaling.knative.dev/target"] != "1000" {
+		t.Error("target failed")
+	}
+	if template.Spec.ContainerConcurrency != 1000 {
+		t.Error("limit failed")
+	}
+}
+
 func TestUpdateEnvVarsNew(t *testing.T) {
 	template, container := getV1alpha1RevisionTemplateWithOldFields()
 	testUpdateEnvVarsNew(t, template, container)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -77,13 +77,13 @@ github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1
 github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1/fake
 github.com/knative/serving/pkg/apis/serving
 github.com/knative/serving/pkg/apis/serving/v1alpha1
+github.com/knative/serving/pkg/apis/serving/v1beta1
 github.com/knative/serving/pkg/client/clientset/versioned/scheme
 github.com/knative/serving/pkg/apis/autoscaling
 github.com/knative/serving/pkg/apis/networking
 github.com/knative/serving/pkg/apis/networking/v1alpha1
-github.com/knative/serving/pkg/apis/serving/v1beta1
-github.com/knative/serving/pkg/apis/autoscaling/v1alpha1
 github.com/knative/serving/pkg/apis/config
+github.com/knative/serving/pkg/apis/autoscaling/v1alpha1
 # github.com/knative/test-infra v0.0.0-20190531180034-a3c073a2fea1
 github.com/knative/test-infra/scripts
 # github.com/magiconair/properties v1.8.0


### PR DESCRIPTION
Autoscaler annotations are added to the revision template if
--min-scale / --max-scale / --target are provided to `kn service create` or
`kn service update`

Fixes #151

~This PR builds on top of #156 but can be back-ported on master if desired.
For review I recommend to look at commit efb23b778cf2104337fc6e4dc7d7e2b67d084465 first, which contains the delta.~

The PR is now based on upstream master only.