### PR TITLE
feat(build.sh): Add a watch mode for automatic recompilation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -75,6 +75,8 @@ You can link that script into a directory within your search `$PATH`. This allow
 * `build.sh -f` - Compile only
 * `build.sh -f -t` - Compile & test
 * `build.sh -u` - Update dependencies before compiling
+* `build.sh -w` - Enter watch mode for automatic recompilation
+* `build.sh -w -t` - Enter watch mode for automatic recompilation & running tests
 
 See `build.sh --help` for a full list of options and usage examples.
 


### PR DESCRIPTION
This features uses and requires https://github.com/AgentCosmic/xnotify
and should work on any platform

Use it with

* Watch & compile: build.sh --watch
* Watch, compile, test: build.sh --watch --test
* Watch, compile, test & verbose output: build.sh --watch --test --verbose

(shortcuts -w && -t can be used, too)