### PR TITLE
Update contribution link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ describe get
 
 # Developers
 
-If you'd like to contribute, please see
-[CONTRIBUTING](https://github.com/knative/docs/blob/master/contributing/CONTRIBUTING.md)
+If you'd like to contribute, please see our
+[contribution guidelines](https://knative.dev/contributing/)
 for more information.
 
 To build `kn`, see our [Development](DEVELOPMENT.md) guide.


### PR DESCRIPTION
The contribution doc referenced in this project's README was removed from the docs project by https://github.com/knative/docs/pull/1291. This PR changes it to reference the new community page.