### PR TITLE
Add the support to test against specified release of Knative serving

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -24,6 +24,10 @@
 # project $PROJECT_ID, start Knative serving, run the tests and delete
 # the cluster.
 
+# If you call this script after configuring the environment variable
+# $KNATIVE_VERSION with a valid release, e.g. 0.6.0, Knative serving
+# of this specified version will be installed in the Kubernetes cluster, and
+# all the tests will run against Knative serving of this specific version.
 source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
 
 # Helper functions.
@@ -35,17 +39,25 @@ function cluster_setup() {
 }
 
 function knative_setup() {
-  start_latest_knative_serving
+  local version=${KNATIVE_VERSION:-latest}
+  header "Installing Knative serving (${version})"
+
+  if [ "${version}" = "latest" ]; then
+    start_latest_knative_serving
+  else
+    start_release_knative_serving "${version}"
+  fi
 }
 
 # Add local dir to have access to built kn
 export PATH=$PATH:${REPO_ROOT_DIR}
+export KNATIVE_VERSION=${KNATIVE_VERSION:-latest}
 
 # Script entry point.
 
 initialize $@
 
-header "Running tests"
+header "Running tests for Knative serving $KNATIVE_VERSION"
 
 go_test_e2e ./test/e2e || fail_test
 

--- a/test/presubmit-integration-tests-latest-release.sh
+++ b/test/presubmit-integration-tests-latest-release.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used in Knative/test-infra as a custom prow job to run the
+# integration tests against Knative serving of a specific version. We
+# currently take 0.6.0 as the latest release version.
+
+export KNATIVE_VERSION="0.6.0"
+$(dirname $0)/presubmit-tests.sh --integration-tests

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -24,9 +24,15 @@
 # Markdown linting failures don't show up properly in Gubernator resulting
 # in a net-negative contributor experience.
 # Tracked by https://github.com/knative/test-infra/issues/428
+
+# If you call this script after configuring the environment variable
+# $KNATIVE_VERSION with a valid release, e.g. 0.6.0, Knative serving
+# of this specified version will be installed in the Kubernetes cluster, and
+# all the tests will run against Knative serving of this specific version.
 export DISABLE_MD_LINTING=1
 
 export GO111MODULE=on
+export KNATIVE_VERSION=${KNATIVE_VERSION:-latest}
 source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
 
 # We use the default build, unit and integration test runners.


### PR DESCRIPTION
This PR adds an environment variable $KNATIVE_VERSION for both e2e-tests.sh and presubmit-tests.sh, in order to specify the version of Knative serving to be installed.

Closes: #168 