### PR TITLE
Remove unused value CfgFile

### DIFF
--- a/pkg/kn/commands/test_helper.go
+++ b/pkg/kn/commands/test_helper.go
@@ -55,7 +55,6 @@ Eventing: Manage event subscriptions and channels. Connect up event sources.`,
 	if params.Output != nil {
 		rootCmd.SetOutput(params.Output)
 	}
-	rootCmd.PersistentFlags().StringVar(&CfgFile, "config", "", "config file (default is $HOME/.kn.yaml)")
 	rootCmd.PersistentFlags().StringVar(&KubeCfgFile, "kubeconfig", "", "kubectl config file (default is $HOME/.kube/config)")
 
 	rootCmd.AddCommand(subCommand)

--- a/pkg/kn/commands/types.go
+++ b/pkg/kn/commands/types.go
@@ -21,9 +21,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// CfgFile is Kn's config file is the path for the Kubernetes config
-var CfgFile string
-
 // KubeCfgFile is the path for the Kubernetes config
 var KubeCfgFile string
 


### PR DESCRIPTION
This patch removes unused `CfgFile` value from codes.

Related to https://github.com/knative/client/pull/139