### PR TITLE
feat(build.sh): Enable goimports + cleanup imports in source files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	golang.org/x/net v0.0.0-20190514140710-3ec191127204 // indirect
 	golang.org/x/oauth2 v0.0.0-20190517181255-950ef44c6e07 // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
+	golang.org/x/tools v0.0.0-20190613204242-ed0dc450797f // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/api v0.0.0-20190226173710-145d52631d00
 	k8s.io/apimachinery v0.0.0-20190221084156-01f179d85dbc

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	golang.org/x/net v0.0.0-20190514140710-3ec191127204 // indirect
 	golang.org/x/oauth2 v0.0.0-20190517181255-950ef44c6e07 // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
-	golang.org/x/tools v0.0.0-20190613204242-ed0dc450797f // indirect
+	golang.org/x/tools v0.0.0-20190628034336-212fb13d595e // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/api v0.0.0-20190226173710-145d52631d00
 	k8s.io/apimachinery v0.0.0-20190221084156-01f179d85dbc

--- a/go.sum
+++ b/go.sum
@@ -330,6 +330,8 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190613204242-ed0dc450797f h1:+zypR5600WBcnJgA2nzZAsBlM8cArEGa8dhhiNE4u3w=
 golang.org/x/tools v0.0.0-20190613204242-ed0dc450797f/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/tools v0.0.0-20190628034336-212fb13d595e h1:ZlQjfVdpDxeqxRfmO30CdqWWzTvgRCj0MxaUVfxEG1k=
+golang.org/x/tools v0.0.0-20190628034336-212fb13d595e/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/api v0.3.2 h1:iTp+3yyl/KOtxa/d1/JUE0GGSoR6FuW5udver22iwpw=
 google.golang.org/api v0.3.2/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=

--- a/go.sum
+++ b/go.sum
@@ -301,6 +301,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FY
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 h1:bjcUS9ztw9kFmmIxJInhon/0Is3p+EHBKNgquIzo1OI=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -327,6 +328,8 @@ golang.org/x/tools v0.0.0-20181011042414-1f849cf54d09/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190613204242-ed0dc450797f h1:+zypR5600WBcnJgA2nzZAsBlM8cArEGa8dhhiNE4u3w=
+golang.org/x/tools v0.0.0-20190613204242-ed0dc450797f/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/api v0.3.2 h1:iTp+3yyl/KOtxa/d1/JUE0GGSoR6FuW5udver22iwpw=
 google.golang.org/api v0.3.2/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -152,7 +152,7 @@ check_license() {
 
 
 update_deps() {
-  echo "🕸️ Update"
+  echo "🕸️ ${S}Update"
   go mod vendor
 }
 

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -54,20 +54,10 @@ run() {
     update_deps
   fi
 
-  # Run build
-  go_build
-
-  # Run tests
-  if  $(has_flag --test -t) || ! $(has_flag --fast -f); then
-    go_test
-  fi
-
   if ! $(has_flag --fast -f); then
-    # Format source code
-    go_fmt
 
-    # Cleanup imports
-    go_imports
+    # Format source code and cleanup imports
+    source_format
 
     # Generate docs
     # Check for license headers
@@ -75,6 +65,14 @@ run() {
 
     # Auto generate cli docs
     generate_docs
+  fi
+
+  # Run build
+  go_build
+
+  # Run tests
+  if  $(has_flag --test -t) || ! $(has_flag --fast -f); then
+    go_test
   fi
 
   echo "────────────────────────────────────────────"
@@ -86,15 +84,18 @@ go_fmt() {
   go fmt ./cmd/... ./pkg/...
 }
 
-go_imports() {
+source_format() {
   set +e
   which goimports >/dev/null 2>&1
   if [ $? -ne 0 ]; then
      echo "✋ No 'goimports' found. Please use"
      echo "✋   go get golang.org/x/tools/cmd/goimports"
      echo "✋ to enable import cleanup. Import cleanup skipped."
+
+     # Run go fmt insteat
+     go_fmt
   else
-     echo "🧽  Imports"
+     echo "🧽 ${S}Format"
      goimports -w cmd pkg
   fi
   set -e

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -66,6 +66,10 @@ run() {
     # Format source code
     go_fmt
 
+    # Cleanup imports
+    go_imports
+
+    # Generate docs
     # Check for license headers
     check_license
 
@@ -80,6 +84,20 @@ run() {
 go_fmt() {
   echo "🧹 ${S}Format"
   go fmt ./cmd/... ./pkg/...
+}
+
+go_imports() {
+  set +e
+  which goimports >/dev/null 2>&1
+  if [ $? -ne 0 ]; then
+     echo "✋ No 'goimports' found. Please use"
+     echo "✋   go get golang.org/x/tools/cmd/goimports"
+     echo "✋ to enable import cleanup. Import cleanup skipped."
+  else
+     echo "🧽  Imports"
+     goimports -w cmd pkg
+  fi
+  set -e
 }
 
 go_build() {
@@ -220,6 +238,7 @@ with the following options:
 
 -f  --fast                    Only compile (without formatting, testing, doc generation)
 -t  --test                    Run tests when used with --fast or --watch
+-i  --imports                 Organize and cleanup imports
 -u  --update                  Update dependencies before compiling
 -w  --watch                   Watch for source changes and recompile in fast mode
 -h  --help                    Display this help message

--- a/pkg/kn/commands/namespaced_test.go
+++ b/pkg/kn/commands/namespaced_test.go
@@ -15,8 +15,9 @@
 package commands
 
 import (
-	"github.com/spf13/cobra"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 // testCommandGenerator generates a test cobra command

--- a/pkg/kn/commands/revision/revision_list.go
+++ b/pkg/kn/commands/revision/revision_list.go
@@ -20,7 +20,7 @@ import (
 	"github.com/knative/client/pkg/kn/commands"
 	"github.com/knative/serving/pkg/apis/serving"
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )

--- a/pkg/printers/tableprinter.go
+++ b/pkg/printers/tableprinter.go
@@ -22,9 +22,10 @@ import (
 	"reflect"
 	"strings"
 
+	"text/tabwriter"
+
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"text/tabwriter"
 )
 
 var _ ResourcePrinter = &HumanReadablePrinter{}

--- a/pkg/serving/config_changes_test.go
+++ b/pkg/serving/config_changes_test.go
@@ -15,9 +15,10 @@
 package serving
 
 import (
-	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 	"reflect"
 	"testing"
+
+	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
Much like 'go fmt' for cleaning up go source, 'goimports' can help
in properly formatting and grouping imports. See https://goinbigdata.com/goimports-vs-gofmt/
for a quick overview.

This commit also cleansup imports on existing files.