### PR TITLE
Added changes to support container port information while creating/updating service

### DIFF
--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -27,6 +27,9 @@ kn service create NAME --image IMAGE [flags]
   # Create or replace environment variables of service 's1' using --force flag
   kn service create --force s1 --env KEY1=NEW_VALUE1 --env NEW_KEY2=NEW_VALUE2 --image dev.local/ns/image:v1
 
+  # Create service 'mysvc' with port 80
+  kn service create mysvc --port 80 --image dev.local/ns/image:latest
+
   # Create or replace default resources of a service 's1' using --force flag
   # (earlier configured resource requests and limits will be replaced with default)
   # (earlier configured environment variables will be cleared too if any)
@@ -47,6 +50,7 @@ kn service create NAME --image IMAGE [flags]
       --max-scale int            Maximal number of replicas.
       --min-scale int            Minimal number of replicas.
   -n, --namespace string         List the requested object(s) in given namespace.
+  -p, --port int32               The port where application listens on.
       --requests-cpu string      The requested CPU (e.g., 250m).
       --requests-memory string   The requested CPU (e.g., 64Mi).
 ```

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -17,6 +17,9 @@ kn service update NAME [flags]
   # Updates a service 'mysvc' with new environment variables
   kn service update mysvc --env KEY1=VALUE1 --env KEY2=VALUE2
 
+  # Update a service 'mysvc' with new port
+  kn service update mysvc --port 80
+
   # Updates a service 'mysvc' with new requests and limits parameters
   kn service update mysvc --requests-cpu 500m --limits-memory 1024Mi
 ```
@@ -34,6 +37,7 @@ kn service update NAME [flags]
       --max-scale int            Maximal number of replicas.
       --min-scale int            Minimal number of replicas.
   -n, --namespace string         List the requested object(s) in given namespace.
+  -p, --port int32               The port where application listens on.
       --requests-cpu string      The requested CPU (e.g., 250m).
       --requests-memory string   The requested CPU (e.g., 64Mi).
 ```

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -34,6 +34,7 @@ type ConfigurationEditFlags struct {
 	MaxScale                   int
 	ConcurrencyTarget          int
 	ConcurrencyLimit           int
+	Port                       int32
 }
 
 type ResourceFlags struct {
@@ -54,6 +55,7 @@ func (p *ConfigurationEditFlags) AddUpdateFlags(command *cobra.Command) {
 	command.Flags().IntVar(&p.MaxScale, "max-scale", 0, "Maximal number of replicas.")
 	command.Flags().IntVar(&p.ConcurrencyTarget, "concurrency-target", 0, "Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to --concurrency-limit when given.")
 	command.Flags().IntVar(&p.ConcurrencyLimit, "concurrency-limit", 0, "Hard Limit of concurrent requests to be processed by a single replica.")
+	command.Flags().Int32VarP(&p.Port, "port", "p", 0, "The port where application listens on.")
 }
 
 func (p *ConfigurationEditFlags) AddCreateFlags(command *cobra.Command) {
@@ -100,6 +102,13 @@ func (p *ConfigurationEditFlags) Apply(service *servingv1alpha1.Service, cmd *co
 	err = servinglib.UpdateResources(template, requestsResources, limitsResources)
 	if err != nil {
 		return err
+	}
+
+	if cmd.Flags().Changed("port") {
+		err = servinglib.UpdateContainerPort(template, p.Port)
+		if err != nil {
+			return err
+		}
 	}
 
 	servinglib.UpdateConcurrencyConfiguration(template, p.MinScale, p.MaxScale, p.ConcurrencyTarget, p.ConcurrencyLimit)

--- a/pkg/kn/commands/service/service_create.go
+++ b/pkg/kn/commands/service/service_create.go
@@ -46,6 +46,9 @@ func NewServiceCreateCommand(p *commands.KnParams) *cobra.Command {
   # Create or replace environment variables of service 's1' using --force flag
   kn service create --force s1 --env KEY1=NEW_VALUE1 --env NEW_KEY2=NEW_VALUE2 --image dev.local/ns/image:v1
 
+  # Create service 'mysvc' with port 80
+  kn service create mysvc --port 80 --image dev.local/ns/image:latest
+
   # Create or replace default resources of a service 's1' using --force flag
   # (earlier configured resource requests and limits will be replaced with default)
   # (earlier configured environment variables will be cleared too if any)

--- a/pkg/kn/commands/service/service_update.go
+++ b/pkg/kn/commands/service/service_update.go
@@ -33,6 +33,9 @@ func NewServiceUpdateCommand(p *commands.KnParams) *cobra.Command {
   # Updates a service 'mysvc' with new environment variables
   kn service update mysvc --env KEY1=VALUE1 --env KEY2=VALUE2
 
+  # Update a service 'mysvc' with new port
+  kn service update mysvc --port 80
+
   # Updates a service 'mysvc' with new requests and limits parameters
   kn service update mysvc --requests-cpu 500m --limits-memory 1024Mi`,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/pkg/serving/config_changes.go
+++ b/pkg/serving/config_changes.go
@@ -86,6 +86,18 @@ func UpdateImage(template *servingv1alpha1.RevisionTemplateSpec, image string) e
 	return nil
 }
 
+// UpdateContainerPort updates container with a give port
+func UpdateContainerPort(template *servingv1alpha1.RevisionTemplateSpec, port int32) error {
+	container, err := extractContainer(template)
+	if err != nil {
+		return err
+	}
+	container.Ports = []corev1.ContainerPort{{
+		ContainerPort: port,
+	}}
+	return nil
+}
+
 func UpdateResources(template *servingv1alpha1.RevisionTemplateSpec, requestsResourceList corev1.ResourceList, limitsResourceList corev1.ResourceList) error {
 	container, err := extractContainer(template)
 	if err != nil {

--- a/pkg/serving/config_changes_test.go
+++ b/pkg/serving/config_changes_test.go
@@ -139,6 +139,30 @@ func testUpdateEnvVarsModify(t *testing.T, revision *servingv1alpha1.RevisionTem
 	}
 }
 
+func TestUpdateContainerPort(t *testing.T) {
+	template, _ := getV1alpha1Config()
+	err := UpdateContainerPort(template, 8888)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Verify update is successful or not
+	checkPortUpdate(t, template, 8888)
+	// update template with container port info
+	template.Spec.Containers[0].Ports[0].ContainerPort = 9090
+	err = UpdateContainerPort(template, 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Verify that given port overrides the existing container port
+	checkPortUpdate(t, template, 80)
+}
+
+func checkPortUpdate(t *testing.T, template *servingv1alpha1.RevisionTemplateSpec, port int32) {
+	if len(template.Spec.Containers) != 1 || template.Spec.Containers[0].Ports[0].ContainerPort != port {
+		t.Error("Failed to update the container port")
+	}
+}
+
 func TestUpdateEnvVarsBoth(t *testing.T) {
 	template, container := getV1alpha1RevisionTemplateWithOldFields()
 	testUpdateEnvVarsBoth(t, template, container)

--- a/test/e2e/basic_workflow_test.go
+++ b/test/e2e/basic_workflow_test.go
@@ -50,7 +50,7 @@ func TestBasicWorkflow(t *testing.T) {
 	testServiceCreate(t, k, "hello")
 	testServiceList(t, k, "hello")
 	testServiceDescribe(t, k, "hello")
-	testServiceUpdate(t, k, "hello", []string{"--env", "TARGET=kn"})
+	testServiceUpdate(t, k, "hello", []string{"--env", "TARGET=kn", "--port", "8888"})
 	testServiceCreate(t, k, "svc2")
 	testRevisionListForService(t, k, "hello")
 	testRevisionListForService(t, k, "svc2")


### PR DESCRIPTION
Issue: https://github.com/knative/client/issues/142

Description:
When someone writes application which listens on port other than 8080(default port in knative-serving) then deploy using **cli(kn)** then there is no way to specify the port.

**Current:** 
Supported flags are
```
Flags:
      --concurrency-limit int    Hard Limit of concurrent requests to be processed by a single replica.
      --concurrency-target int   Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to --concurrency-limit when given.
  -e, --env stringArray          Environment variable to set. NAME=value; you may provide this flag any number of times to set multiple environment variables.
      --force                    Create service forcefully, replaces existing service if any.
  -h, --help                     help for create
      --image string             Image to run.
      --limits-cpu string        The limits on the requested CPU (e.g., 1000m).
      --limits-memory string     The limits on the requested CPU (e.g., 1024Mi).
      --max-scale int            Maximal number of replicas.
      --min-scale int            Minimal number of replicas.
  -n, --namespace string         List the requested object(s) in given namespace.
      --requests-cpu string      The requested CPU (e.g., 250m).
      --requests-memory string   The requested CPU (e.g., 64Mi).
```
**Expected:** 
Along with current flags it should support **port** flag so that user can specify port at which application is running.

ex: something like below
```
Flags:
   ...
  -p, --port int32               The port that the application should run. (default 8080)
   ...
```

**Usage:**
```
kn service create mysvc --port 80 --image dev.local/ns/image:latest
```
```
kn service update mysvc --port 80
```

