### PR TITLE
Fixes `limits-memory` and `requests-memory` descriptions

### DIFF
--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -43,12 +43,12 @@ kn service create NAME --image IMAGE [flags]
   -h, --help                     help for create
       --image string             Image to run.
       --limits-cpu string        The limits on the requested CPU (e.g., 1000m).
-      --limits-memory string     The limits on the requested CPU (e.g., 1024Mi).
+      --limits-memory string     The limits on the requested memory (e.g., 1024Mi).
       --max-scale int            Maximal number of replicas.
       --min-scale int            Minimal number of replicas.
   -n, --namespace string         List the requested object(s) in given namespace.
       --requests-cpu string      The requested CPU (e.g., 250m).
-      --requests-memory string   The requested CPU (e.g., 64Mi).
+      --requests-memory string   The requested memory (e.g., 64Mi).
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -30,12 +30,12 @@ kn service update NAME [flags]
   -h, --help                     help for update
       --image string             Image to run.
       --limits-cpu string        The limits on the requested CPU (e.g., 1000m).
-      --limits-memory string     The limits on the requested CPU (e.g., 1024Mi).
+      --limits-memory string     The limits on the requested memory (e.g., 1024Mi).
       --max-scale int            Maximal number of replicas.
       --min-scale int            Minimal number of replicas.
   -n, --namespace string         List the requested object(s) in given namespace.
       --requests-cpu string      The requested CPU (e.g., 250m).
-      --requests-memory string   The requested CPU (e.g., 64Mi).
+      --requests-memory string   The requested memory (e.g., 64Mi).
 ```
 
 ### Options inherited from parent commands

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -47,9 +47,9 @@ func (p *ConfigurationEditFlags) AddUpdateFlags(command *cobra.Command) {
 		"Environment variable to set. NAME=value; you may provide this flag "+
 			"any number of times to set multiple environment variables.")
 	command.Flags().StringVar(&p.RequestsFlags.CPU, "requests-cpu", "", "The requested CPU (e.g., 250m).")
-	command.Flags().StringVar(&p.RequestsFlags.Memory, "requests-memory", "", "The requested CPU (e.g., 64Mi).")
+	command.Flags().StringVar(&p.RequestsFlags.Memory, "requests-memory", "", "The requested memory (e.g., 64Mi).")
 	command.Flags().StringVar(&p.LimitsFlags.CPU, "limits-cpu", "", "The limits on the requested CPU (e.g., 1000m).")
-	command.Flags().StringVar(&p.LimitsFlags.Memory, "limits-memory", "", "The limits on the requested CPU (e.g., 1024Mi).")
+	command.Flags().StringVar(&p.LimitsFlags.Memory, "limits-memory", "", "The limits on the requested memory (e.g., 1024Mi).")
 	command.Flags().IntVar(&p.MinScale, "min-scale", 0, "Minimal number of replicas.")
 	command.Flags().IntVar(&p.MaxScale, "max-scale", 0, "Maximal number of replicas.")
 	command.Flags().IntVar(&p.ConcurrencyTarget, "concurrency-target", 0, "Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to --concurrency-limit when given.")


### PR DESCRIPTION
Erroneously showed ‘CPU’ for ‘memory’ in description strings