### PR TITLE
Add rhuss and maximilien to OWNERS to increase approver speed.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,8 @@
 approvers:
 - sixolet
 - cppforlife
+- rhuss
+- maximilien
+# TOC members as a fallback
 - mattmoor
 - evankanderson


### PR DESCRIPTION
Top two committers in the last while who also participate in WG meetings regularly.