### PR TITLE
fix(serving): Fix logic 'service create --force' and some bogus tests

### DIFF
--- a/pkg/kn/commands/service/service_create.go
+++ b/pkg/kn/commands/service/service_create.go
@@ -84,12 +84,17 @@ func NewServiceCreateCommand(p *commands.KnParams) *cobra.Command {
 				return err
 			}
 
-			serviceExists, err := serviceExists(client, service.Name, namespace)
+			serviceExists, err := serviceExists(client, name, namespace)
 			if err != nil {
 				return err
 			}
 
-			if editFlags.ForceCreate && serviceExists {
+			if serviceExists {
+				if !editFlags.ForceCreate {
+					return fmt.Errorf(
+						"cannot create service '%s' in namespace '%s' "+
+							"because the service already exists and no --force option was given", name, namespace)
+				}
 				err = replaceService(client, service, namespace, cmd.OutOrStdout())
 			} else {
 				err = createService(client, service, namespace, cmd.OutOrStdout())

--- a/pkg/kn/commands/service/service_create_test.go
+++ b/pkg/kn/commands/service/service_create_test.go
@@ -405,7 +405,7 @@ func TestServiceCreateImageExistsAndNoForce(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !strings.Contains(output, "foo") ||
-		!strings.Contains(output, "current") ||
+		!strings.Contains(output, commands.FakeNamespace) ||
 		!strings.Contains(output, "create") ||
 		!strings.Contains(output, "--force") {
 		t.Errorf("Invalid error output: '%s'", output)


### PR DESCRIPTION
Now a more meaningful error is returned when the user tries to create
a service that already exists. Until know the service is tried
to be created even if the client already knows that it exists.

Also some broken (broken in the sense that the test was nonsense) tests has been fixed.