### PR TITLE
Removes pausing between e2e smoke tests

### DIFF
--- a/test/e2e-smoke-tests.sh
+++ b/test/e2e-smoke-tests.sh
@@ -57,9 +57,11 @@ kubectl create ns $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 ./kn revision list -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 ./kn service list -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 ./kn service describe hello -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
+./kn service describe svc1 -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 ./kn service delete hello -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 ./kn service delete foo -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
-
+./kn service list -n $KN_E2E_SMOKE_TESTS_NAMESPACE | grep -q svc1 || fail_test
+./kn service delete svc1 -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 kubectl delete ns $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 
 success

--- a/test/e2e-smoke-tests.sh
+++ b/test/e2e-smoke-tests.sh
@@ -46,16 +46,14 @@ header "Running smoke tests"
 
 kubectl create ns $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 
+./kn service create svc1 --async --image gcr.io/knative-samples/helloworld-go -e TARGET=Knative -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 ./kn service create hello --image gcr.io/knative-samples/helloworld-go -e TARGET=Knative -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
-sleep 5
 ./kn service list hello -n $KN_E2E_SMOKE_TESTS_NAMESPACE -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 ./kn service update hello --env TARGET=kn -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
-sleep 3
 ./kn revision list hello -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 ./kn service list -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 ./kn service create hello --force --image gcr.io/knative-samples/helloworld-go -e TARGET=Awesome -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 ./kn service create foo --force --image gcr.io/knative-samples/helloworld-go -e TARGET=foo -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
-sleep 5
 ./kn revision list -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 ./kn service list -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 ./kn service describe hello -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test


### PR DESCRIPTION
 Removes time.Sleep as by default service create waits for it to
 become ready. Also adds a command to create service in --async mode.

Update:
Checks if service created in async mode is ready,
also describes the async mode service and finally deletes it.
