### PR TITLE
fix(release.sh): Point to proper directory to extract the serving version

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -18,7 +18,7 @@ source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/release.sh
 source $(dirname $0)/build-flags.sh
 
 function build_release() {
-  local ld_flags="$(build_flags $(dirname $0))"
+  local ld_flags="$(build_flags $(dirname $0)/..)"
   local pkg="github.com/knative/client/pkg/kn/commands"
   local version="${TAG}"
   # Use vYYYYMMDD-<hash>-local for the version string, if not passed.


### PR DESCRIPTION
The argument to build_flags.sh must point to the basedirectory where
go.mod is located.

Fixes #212