### PR TITLE
Add custom comparison for checking multiple substrings

### DIFF
--- a/docs/cmd/kn_route.md
+++ b/docs/cmd/kn_route.md
@@ -6,6 +6,10 @@ Route command group
 
 Route command group
 
+```
+kn route [flags]
+```
+
 ### Options
 
 ```

--- a/pkg/kn/commands/compare_utils.go
+++ b/pkg/kn/commands/compare_utils.go
@@ -1,0 +1,40 @@
+// Copyright © 2019 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"gotest.tools/assert/cmp"
+)
+
+// ContainsMultipleSubstring is a comparison utility, compares given substrings against
+// target string and returns the gotest.tools/assert/cmp.Comaprison function.
+// Provide message to form an error message of format 'Missing $message: $missing_elements'
+func ContainsMultipleSubstrings(target string, substrings []string, message string) cmp.Comparison {
+	return func() cmp.Result {
+		var missing []string
+		for _, sub := range substrings {
+			if !strings.Contains(target, sub) {
+				missing = append(missing, sub)
+			}
+		}
+		if len(missing) > 0 {
+			return cmp.ResultFailure(fmt.Sprintf("Missing %s: %s", message, strings.Join(missing[:], ", ")))
+		}
+		return cmp.ResultSuccess
+	}
+}

--- a/pkg/kn/commands/revision/delete_test.go
+++ b/pkg/kn/commands/revision/delete_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/knative/client/pkg/kn/commands"
+	"gotest.tools/assert"
 	"k8s.io/apimachinery/pkg/runtime"
 	client_testing "k8s.io/client-go/testing"
 )
@@ -55,5 +56,5 @@ func TestRevisionDelete(t *testing.T) {
 	} else if name != revName {
 		t.Errorf("Bad revision name returned after delete.")
 	}
-	commands.TestContains(t, output, []string{"Revision", revName, "deleted", "namespace", commands.FakeNamespace}, "word in output")
+	assert.Check(t, commands.ContainsMultipleSubstrings(output, []string{"Revision", revName, "deleted", "namespace", commands.FakeNamespace}, "word in output"))
 }

--- a/pkg/kn/commands/revision/delete_test.go
+++ b/pkg/kn/commands/revision/delete_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/knative/client/pkg/kn/commands"
+	"github.com/knative/client/pkg/util"
 	"gotest.tools/assert"
 	"k8s.io/apimachinery/pkg/runtime"
 	client_testing "k8s.io/client-go/testing"
@@ -56,5 +57,5 @@ func TestRevisionDelete(t *testing.T) {
 	} else if name != revName {
 		t.Errorf("Bad revision name returned after delete.")
 	}
-	assert.Check(t, commands.ContainsMultipleSubstrings(output, []string{"Revision", revName, "deleted", "namespace", commands.FakeNamespace}, "word in output"))
+	assert.Check(t, util.ContainsAll(output, "Revision", revName, "deleted", "namespace", commands.FakeNamespace))
 }

--- a/pkg/kn/commands/revision/revision_list_test.go
+++ b/pkg/kn/commands/revision/revision_list_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/knative/client/pkg/kn/commands"
+	"github.com/knative/client/pkg/util"
 	serving "github.com/knative/serving/pkg/apis/serving"
 	v1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"gotest.tools/assert"
@@ -72,9 +73,9 @@ func TestRevisionListDefaultOutput(t *testing.T) {
 	} else if !action.Matches("list", "revisions") {
 		t.Errorf("Bad action %v", action)
 	}
-	assert.Check(t, commands.ContainsMultipleSubstrings(output[0], []string{"NAME", "SERVICE", "AGE", "CONDITIONS", "READY", "REASON"}, "column header"))
-	assert.Check(t, commands.ContainsMultipleSubstrings(output[1], []string{"foo-abcd", "foo"}, "value"))
-	assert.Check(t, commands.ContainsMultipleSubstrings(output[2], []string{"bar-wxyz", "bar"}, "value"))
+	assert.Check(t, util.ContainsAll(output[0], "NAME", "SERVICE", "AGE", "CONDITIONS", "READY", "REASON"))
+	assert.Check(t, util.ContainsAll(output[1], "foo-abcd", "foo"))
+	assert.Check(t, util.ContainsAll(output[2], "bar-wxyz", "bar"))
 }
 
 func TestRevisionListForService(t *testing.T) {
@@ -92,9 +93,9 @@ func TestRevisionListForService(t *testing.T) {
 	} else if !action.Matches("list", "revisions") {
 		t.Errorf("Bad action %v", action)
 	}
-	assert.Check(t, commands.ContainsMultipleSubstrings(output[0], []string{"NAME", "SERVICE", "AGE", "CONDITIONS", "READY", "REASON"}, "column header"))
-	assert.Check(t, commands.ContainsMultipleSubstrings(output[1], []string{"foo-abcd", "svc1"}, "value"))
-	assert.Check(t, commands.ContainsMultipleSubstrings(output[2], []string{"bar-wxyz", "svc1"}, "value"))
+	assert.Check(t, util.ContainsAll(output[0], "NAME", "SERVICE", "AGE", "CONDITIONS", "READY", "REASON"))
+	assert.Check(t, util.ContainsAll(output[1], "foo-abcd", "svc1"))
+	assert.Check(t, util.ContainsAll(output[2], "bar-wxyz", "svc1"))
 	action, output, err = fakeRevisionList([]string{"revision", "list", "-s", "svc2"}, RevisionList)
 	if err != nil {
 		t.Fatal(err)
@@ -104,9 +105,9 @@ func TestRevisionListForService(t *testing.T) {
 	} else if !action.Matches("list", "revisions") {
 		t.Errorf("Bad action %v", action)
 	}
-	assert.Check(t, commands.ContainsMultipleSubstrings(output[0], []string{"NAME", "SERVICE", "AGE", "CONDITIONS", "READY", "REASON"}, "column header"))
-	assert.Check(t, commands.ContainsMultipleSubstrings(output[1], []string{"foo-abcd", "svc2"}, "value"))
-	assert.Check(t, commands.ContainsMultipleSubstrings(output[2], []string{"bar-wxyz", "svc2"}, "value"))
+	assert.Check(t, util.ContainsAll(output[0], "NAME", "SERVICE", "AGE", "CONDITIONS", "READY", "REASON"))
+	assert.Check(t, util.ContainsAll(output[1], "foo-abcd", "svc2"))
+	assert.Check(t, util.ContainsAll(output[2], "bar-wxyz", "svc"))
 	//test for non existent service
 	action, output, err = fakeRevisionList([]string{"revision", "list", "-s", "svc3"}, RevisionList)
 	if err != nil {

--- a/pkg/kn/commands/revision/revision_list_test.go
+++ b/pkg/kn/commands/revision/revision_list_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/knative/client/pkg/kn/commands"
 	serving "github.com/knative/serving/pkg/apis/serving"
 	v1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"gotest.tools/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	client_testing "k8s.io/client-go/testing"
@@ -71,9 +72,9 @@ func TestRevisionListDefaultOutput(t *testing.T) {
 	} else if !action.Matches("list", "revisions") {
 		t.Errorf("Bad action %v", action)
 	}
-	testContains(t, output[0], []string{"NAME", "SERVICE", "AGE", "CONDITIONS", "READY", "REASON"}, "column header")
-	testContains(t, output[1], []string{"foo-abcd", "foo"}, "value")
-	testContains(t, output[2], []string{"bar-wxyz", "bar"}, "value")
+	assert.Check(t, commands.ContainsMultipleSubstrings(output[0], []string{"NAME", "SERVICE", "AGE", "CONDITIONS", "READY", "REASON"}, "column header"))
+	assert.Check(t, commands.ContainsMultipleSubstrings(output[1], []string{"foo-abcd", "foo"}, "value"))
+	assert.Check(t, commands.ContainsMultipleSubstrings(output[2], []string{"bar-wxyz", "bar"}, "value"))
 }
 
 func TestRevisionListForService(t *testing.T) {
@@ -91,9 +92,9 @@ func TestRevisionListForService(t *testing.T) {
 	} else if !action.Matches("list", "revisions") {
 		t.Errorf("Bad action %v", action)
 	}
-	testContains(t, output[0], []string{"NAME", "SERVICE", "AGE", "CONDITIONS", "READY", "REASON"}, "column header")
-	testContains(t, output[1], []string{"foo-abcd", "svc1"}, "value")
-	testContains(t, output[2], []string{"bar-wxyz", "svc1"}, "value")
+	assert.Check(t, commands.ContainsMultipleSubstrings(output[0], []string{"NAME", "SERVICE", "AGE", "CONDITIONS", "READY", "REASON"}, "column header"))
+	assert.Check(t, commands.ContainsMultipleSubstrings(output[1], []string{"foo-abcd", "svc1"}, "value"))
+	assert.Check(t, commands.ContainsMultipleSubstrings(output[2], []string{"bar-wxyz", "svc1"}, "value"))
 	action, output, err = fakeRevisionList([]string{"revision", "list", "-s", "svc2"}, RevisionList)
 	if err != nil {
 		t.Fatal(err)
@@ -103,9 +104,9 @@ func TestRevisionListForService(t *testing.T) {
 	} else if !action.Matches("list", "revisions") {
 		t.Errorf("Bad action %v", action)
 	}
-	testContains(t, output[0], []string{"NAME", "SERVICE", "AGE", "CONDITIONS", "READY", "REASON"}, "column header")
-	testContains(t, output[1], []string{"foo-abcd", "svc2"}, "value")
-	testContains(t, output[2], []string{"bar-wxyz", "svc2"}, "value")
+	assert.Check(t, commands.ContainsMultipleSubstrings(output[0], []string{"NAME", "SERVICE", "AGE", "CONDITIONS", "READY", "REASON"}, "column header"))
+	assert.Check(t, commands.ContainsMultipleSubstrings(output[1], []string{"foo-abcd", "svc2"}, "value"))
+	assert.Check(t, commands.ContainsMultipleSubstrings(output[2], []string{"bar-wxyz", "svc2"}, "value"))
 	//test for non existent service
 	action, output, err = fakeRevisionList([]string{"revision", "list", "-s", "svc3"}, RevisionList)
 	if err != nil {
@@ -117,14 +118,6 @@ func TestRevisionListForService(t *testing.T) {
 		t.Errorf("Bad action %v", action)
 	} else if !strings.Contains(output[0], "No resources found.") {
 		t.Errorf("Bad output %s", output[0])
-	}
-}
-
-func testContains(t *testing.T, output string, sub []string, element string) {
-	for _, each := range sub {
-		if !strings.Contains(output, each) {
-			t.Errorf("Missing %s: %s", element, each)
-		}
 	}
 }
 

--- a/pkg/kn/commands/route/list_test.go
+++ b/pkg/kn/commands/route/list_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/knative/client/pkg/kn/commands"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
+	"gotest.tools/assert"
 	"k8s.io/apimachinery/pkg/runtime"
 	client_testing "k8s.io/client-go/testing"
 )
@@ -70,9 +71,9 @@ func TestRouteListDefaultOutput(t *testing.T) {
 	} else if !action.Matches("list", "routes") {
 		t.Errorf("Bad action %v", action)
 	}
-	commands.TestContains(t, output[0], []string{"NAME", "URL", "AGE", "CONDITIONS", "TRAFFIC"}, "column header")
-	commands.TestContains(t, output[1], []string{"foo", "100% -> foo-01234"}, "value")
-	commands.TestContains(t, output[2], []string{"bar", "100% -> bar-98765"}, "value")
+	assert.Check(t, commands.ContainsMultipleSubstrings(output[0], []string{"NAME", "URL", "AGE", "CONDITIONS", "TRAFFIC"}, "column header"))
+	assert.Check(t, commands.ContainsMultipleSubstrings(output[1], []string{"foo", "100% -> foo-01234"}, "value"))
+	assert.Check(t, commands.ContainsMultipleSubstrings(output[2], []string{"bar", "100% -> bar-98765"}, "value"))
 }
 
 func TestRouteListWithTwoTargetsOutput(t *testing.T) {
@@ -87,8 +88,8 @@ func TestRouteListWithTwoTargetsOutput(t *testing.T) {
 	} else if !action.Matches("list", "routes") {
 		t.Errorf("Bad action %v", action)
 	}
-	commands.TestContains(t, output[0], []string{"NAME", "URL", "AGE", "CONDITIONS", "TRAFFIC"}, "column header")
-	commands.TestContains(t, output[1], []string{"foo", "20% -> foo-01234, 80% -> foo-98765"}, "value")
+	assert.Check(t, commands.ContainsMultipleSubstrings(output[0], []string{"NAME", "URL", "AGE", "CONDITIONS", "TRAFFIC"}, "column header"))
+	assert.Check(t, commands.ContainsMultipleSubstrings(output[1], []string{"foo", "20% -> foo-01234, 80% -> foo-98765"}, "value"))
 }
 
 func createMockRouteMeta(name string) *v1alpha1.Route {

--- a/pkg/kn/commands/route/list_test.go
+++ b/pkg/kn/commands/route/list_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/knative/client/pkg/kn/commands"
+	"github.com/knative/client/pkg/util"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 	"gotest.tools/assert"
@@ -71,9 +72,9 @@ func TestRouteListDefaultOutput(t *testing.T) {
 	} else if !action.Matches("list", "routes") {
 		t.Errorf("Bad action %v", action)
 	}
-	assert.Check(t, commands.ContainsMultipleSubstrings(output[0], []string{"NAME", "URL", "AGE", "CONDITIONS", "TRAFFIC"}, "column header"))
-	assert.Check(t, commands.ContainsMultipleSubstrings(output[1], []string{"foo", "100% -> foo-01234"}, "value"))
-	assert.Check(t, commands.ContainsMultipleSubstrings(output[2], []string{"bar", "100% -> bar-98765"}, "value"))
+	assert.Check(t, util.ContainsAll(output[0], "NAME", "URL", "AGE", "CONDITIONS", "TRAFFIC"))
+	assert.Check(t, util.ContainsAll(output[1], "foo", "100% -> foo-01234"))
+	assert.Check(t, util.ContainsAll(output[2], "bar", "100% -> bar-98765"))
 }
 
 func TestRouteListWithTwoTargetsOutput(t *testing.T) {
@@ -88,8 +89,8 @@ func TestRouteListWithTwoTargetsOutput(t *testing.T) {
 	} else if !action.Matches("list", "routes") {
 		t.Errorf("Bad action %v", action)
 	}
-	assert.Check(t, commands.ContainsMultipleSubstrings(output[0], []string{"NAME", "URL", "AGE", "CONDITIONS", "TRAFFIC"}, "column header"))
-	assert.Check(t, commands.ContainsMultipleSubstrings(output[1], []string{"foo", "20% -> foo-01234, 80% -> foo-98765"}, "value"))
+	assert.Check(t, util.ContainsAll(output[0], "NAME", "URL", "AGE", "CONDITIONS", "TRAFFIC"))
+	assert.Check(t, util.ContainsAll(output[1], "foo", "20% -> foo-01234, 80% -> foo-98765"))
 }
 
 func createMockRouteMeta(name string) *v1alpha1.Route {

--- a/pkg/kn/commands/service/service_list_test.go
+++ b/pkg/kn/commands/service/service_list_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/knative/client/pkg/kn/commands"
+	"github.com/knative/client/pkg/util"
 	duckv1beta1 "github.com/knative/pkg/apis/duck/v1beta1"
 	v1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"gotest.tools/assert"
@@ -72,9 +73,9 @@ func TestServiceListDefaultOutput(t *testing.T) {
 	} else if !action.Matches("list", "services") {
 		t.Errorf("Bad action %v", action)
 	}
-	assert.Check(t, commands.ContainsMultipleSubstrings(output[0], []string{"NAME", "DOMAIN", "GENERATION", "AGE", "CONDITIONS", "READY", "REASON"}, "column header"))
-	assert.Check(t, commands.ContainsMultipleSubstrings(output[1], []string{"foo", "foo.default.example.com", "1"}, "value"))
-	assert.Check(t, commands.ContainsMultipleSubstrings(output[2], []string{"bar", "bar.default.example.com", "2"}, "value"))
+	assert.Check(t, util.ContainsAll(output[0], "NAME", "DOMAIN", "GENERATION", "AGE", "CONDITIONS", "READY", "REASON"))
+	assert.Check(t, util.ContainsAll(output[1], "foo", "foo.default.example.com", "1"))
+	assert.Check(t, util.ContainsAll(output[2], "bar", "bar.default.example.com", "2"))
 }
 
 func createMockServiceWithParams(name, domain string, generation int64) *v1alpha1.Service {

--- a/pkg/kn/commands/service/service_list_test.go
+++ b/pkg/kn/commands/service/service_list_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/knative/client/pkg/kn/commands"
 	duckv1beta1 "github.com/knative/pkg/apis/duck/v1beta1"
 	v1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"gotest.tools/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	client_testing "k8s.io/client-go/testing"
@@ -71,17 +72,9 @@ func TestServiceListDefaultOutput(t *testing.T) {
 	} else if !action.Matches("list", "services") {
 		t.Errorf("Bad action %v", action)
 	}
-	testContains(t, output[0], []string{"NAME", "DOMAIN", "GENERATION", "AGE", "CONDITIONS", "READY", "REASON"}, "column header")
-	testContains(t, output[1], []string{"foo", "foo.default.example.com", "1"}, "value")
-	testContains(t, output[2], []string{"bar", "bar.default.example.com", "2"}, "value")
-}
-
-func testContains(t *testing.T, output string, sub []string, element string) {
-	for _, each := range sub {
-		if !strings.Contains(output, each) {
-			t.Errorf("Missing %s: %s", element, each)
-		}
-	}
+	assert.Check(t, commands.ContainsMultipleSubstrings(output[0], []string{"NAME", "DOMAIN", "GENERATION", "AGE", "CONDITIONS", "READY", "REASON"}, "column header"))
+	assert.Check(t, commands.ContainsMultipleSubstrings(output[1], []string{"foo", "foo.default.example.com", "1"}, "value"))
+	assert.Check(t, commands.ContainsMultipleSubstrings(output[2], []string{"bar", "bar.default.example.com", "2"}, "value"))
 }
 
 func createMockServiceWithParams(name, domain string, generation int64) *v1alpha1.Service {

--- a/pkg/kn/commands/test_helper.go
+++ b/pkg/kn/commands/test_helper.go
@@ -17,8 +17,6 @@ package commands
 import (
 	"bytes"
 	"flag"
-	"strings"
-	"testing"
 
 	serving "github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
 	"github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1/fake"
@@ -68,14 +66,4 @@ Eventing: Manage event subscriptions and channels. Connect up event sources.`,
 	// For glog parse error.
 	flag.CommandLine.Parse([]string{})
 	return rootCmd
-}
-
-// TestContains is a test helper function, checking if a substring is present in given
-// output string
-func TestContains(t *testing.T, output string, sub []string, element string) {
-	for _, each := range sub {
-		if !strings.Contains(output, each) {
-			t.Errorf("Missing %s: %s", element, each)
-		}
-	}
 }

--- a/pkg/util/compare.go
+++ b/pkg/util/compare.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package commands
+package util
 
 import (
 	"fmt"
@@ -21,10 +21,10 @@ import (
 	"gotest.tools/assert/cmp"
 )
 
-// ContainsMultipleSubstring is a comparison utility, compares given substrings against
+// ContainsAll is a comparison utility, compares given substrings against
 // target string and returns the gotest.tools/assert/cmp.Comaprison function.
-// Provide message to form an error message of format 'Missing $message: $missing_elements'
-func ContainsMultipleSubstrings(target string, substrings []string, message string) cmp.Comparison {
+// Provide target string as first arg, followed by any number of substring as args
+func ContainsAll(target string, substrings ...string) cmp.Comparison {
 	return func() cmp.Result {
 		var missing []string
 		for _, sub := range substrings {
@@ -33,7 +33,7 @@ func ContainsMultipleSubstrings(target string, substrings []string, message stri
 			}
 		}
 		if len(missing) > 0 {
-			return cmp.ResultFailure(fmt.Sprintf("Missing %s: %s", message, strings.Join(missing[:], ", ")))
+			return cmp.ResultFailure(fmt.Sprintf("\nActual output: %s\nMissing strings: %s", target, strings.Join(missing[:], ", ")))
 		}
 		return cmp.ResultSuccess
 	}

--- a/pkg/util/compare_test.go
+++ b/pkg/util/compare_test.go
@@ -1,0 +1,70 @@
+// Copyright © 2019 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"gotest.tools/assert/cmp"
+)
+
+type containsAllTestCase struct {
+	target     string
+	substrings []string
+	success    bool
+	missing    []string
+}
+
+func TestContainsAll(t *testing.T) {
+	for i, tc := range []containsAllTestCase{
+		{
+			target:     "NAME SERVICE AGE CONDITIONS READY REASON",
+			substrings: []string{"REASON", "AGE"},
+			success:    true,
+		},
+		{
+			"No resources found.",
+			[]string{"NAME", "AGE"},
+			false,
+			[]string{"NAME", "AGE"},
+		},
+		{
+			"NAME SERVICE AGE CONDITIONS READY REASON",
+			[]string{"NAME", "URL", "DOMAIN", "READY"},
+			false,
+			[]string{"URL", "DOMAIN"},
+		},
+		{
+			target:     "Sword!",
+			substrings: []string{},
+			success:    true,
+		},
+	} {
+		comparison := ContainsAll(tc.target, tc.substrings...)
+		result := comparison()
+		if result.Success() != tc.success {
+			t.Errorf("%d: Expecting %s to contain %s", i, tc.target, tc.substrings)
+		}
+		if !tc.success {
+			message := fmt.Sprintf("\nActual output: %s\nMissing strings: %s", tc.target, strings.Join(tc.missing[:], ", "))
+			if !reflect.DeepEqual(result, cmp.ResultFailure(message)) {
+				t.Errorf("%d: Incorrect error message returned\nExpecting: %s", i, message)
+			}
+		}
+	}
+}

--- a/test/e2e/revision_workflow_test.go
+++ b/test/e2e/revision_workflow_test.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/knative/client/pkg/kn/commands"
+	"github.com/knative/client/pkg/util"
 	"gotest.tools/assert"
 )
 
@@ -45,5 +45,5 @@ func testDeleteRevision(t *testing.T, k kn, serviceName string) {
 	if err != nil {
 		t.Errorf("Error executing 'revision delete %s' command. Error: %s", revName, err.Error())
 	}
-	assert.Check(t, commands.ContainsMultipleSubstrings(out, []string{"Revision", revName, "deleted", "namespace", k.namespace}, "word in output"))
+	assert.Check(t, util.ContainsAll(out, "Revision", revName, "deleted", "namespace", k.namespace))
 }

--- a/test/e2e/revision_workflow_test.go
+++ b/test/e2e/revision_workflow_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/knative/client/pkg/kn/commands"
+	"gotest.tools/assert"
 )
 
 func TestRevisionWorkflow(t *testing.T) {
@@ -44,5 +45,5 @@ func testDeleteRevision(t *testing.T, k kn, serviceName string) {
 	if err != nil {
 		t.Errorf("Error executing 'revision delete %s' command. Error: %s", revName, err.Error())
 	}
-	commands.TestContains(t, out, []string{"Revision", revName, "deleted", "namespace", k.namespace}, "word in output")
+	assert.Check(t, commands.ContainsMultipleSubstrings(out, []string{"Revision", revName, "deleted", "namespace", k.namespace}, "word in output"))
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -167,8 +167,8 @@ gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.2.2
 gopkg.in/yaml.v2
 # gotest.tools v2.2.0+incompatible
-gotest.tools/assert
 gotest.tools/assert/cmp
+gotest.tools/assert
 gotest.tools/internal/format
 gotest.tools/internal/source
 gotest.tools/internal/difflib


### PR DESCRIPTION
 This changeset introduces custom comparison for checking if a target
 string has given multiple substrings, namely `ContainsMultipleSubstrings`.

 Also removes `commands.TestContains` function and replaces all references
 of `commands.TestContains` with `gotest.tools/assert.Check` function and
 uses `ContainsMultipleSubstrings` as comparison function.