### PR TITLE
Add gofmt simplify code option in hack/build.sh

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -16,6 +16,8 @@
 
 set -o pipefail
 
+source_dirs="cmd pkg test"
+
 # Store for later
 if [ -z "$1" ]; then
     ARGS=("")
@@ -81,7 +83,7 @@ run() {
 
 go_fmt() {
   echo "🧹 ${S}Format"
-  go fmt ./cmd/... ./pkg/...
+  find $(echo $source_dirs) -name "*.go" -print0 | xargs -0 gofmt -s -w
 }
 
 source_format() {
@@ -92,11 +94,12 @@ source_format() {
      echo "✋   go get golang.org/x/tools/cmd/goimports"
      echo "✋ to enable import cleanup. Import cleanup skipped."
 
-     # Run go fmt insteat
+     # Run go fmt instead
      go_fmt
   else
      echo "🧽 ${S}Format"
-     goimports -w cmd pkg
+     goimports -w $(echo $source_dirs)
+     find $(echo $source_dirs) -name "*.go" -print0 | xargs -0 gofmt -s -w
   fi
   set -e
 }

--- a/pkg/serving/config_changes.go
+++ b/pkg/serving/config_changes.go
@@ -146,7 +146,7 @@ func extractContainer(template *servingv1alpha1.RevisionTemplateSpec) (*corev1.C
 
 func updateEnvVarsFromMap(env []corev1.EnvVar, vars map[string]string) []corev1.EnvVar {
 	set := make(map[string]bool)
-	for i, _ := range env {
+	for i := range env {
 		envVar := &env[i]
 		value, present := vars[envVar.Name]
 		if present {

--- a/pkg/serving/config_changes_test.go
+++ b/pkg/serving/config_changes_test.go
@@ -118,7 +118,7 @@ func TestUpdateEnvVarsModify(t *testing.T) {
 
 func testUpdateEnvVarsModify(t *testing.T, revision *servingv1alpha1.RevisionTemplateSpec, container *corev1.Container) {
 	container.Env = []corev1.EnvVar{
-		corev1.EnvVar{Name: "a", Value: "foo"}}
+		{Name: "a", Value: "foo"}}
 	env := map[string]string{
 		"a": "fancy",
 	}
@@ -176,8 +176,8 @@ func TestUpdateEnvVarsBoth(t *testing.T) {
 
 func testUpdateEnvVarsBoth(t *testing.T, template *servingv1alpha1.RevisionTemplateSpec, container *corev1.Container) {
 	container.Env = []corev1.EnvVar{
-		corev1.EnvVar{Name: "a", Value: "foo"},
-		corev1.EnvVar{Name: "c", Value: "caroline"}}
+		{Name: "a", Value: "foo"},
+		{Name: "c", Value: "caroline"}}
 	env := map[string]string{
 		"a": "fancy",
 		"b": "boo",


### PR DESCRIPTION
-  Adds step to simplify code along with goimports
-  Runs goimports on all packages except vendor dir and filter on only *.go files
-  Runs gofmt on all dirs except vendor and filters on *.go files, also writes the results instead of printing diff
- Fixes typo s/insteat/insead
- Adds the changes after adding simply code step in hack/build.sh



