### PR TITLE
fix(service): Show URL (external) instead of Address (internal) when listing service

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,11 +11,15 @@
 |===
 ////
 
-## v0.2.0 (2019-07-09)
+## v0.2.0 (2019-07-10)
 
 [cols="1,10,3", options="header", width="100%"]
 |===
 | | Description | PR
+
+| 🐛
+| Show URL instead of address when listing services
+| https://github.com/knative/client/pull/247[#247]
 
 | 🎁
 | Add `kn service list <svc-name>` and `kn revision list <rev-name>`

--- a/pkg/kn/commands/service/human_readable_flags.go
+++ b/pkg/kn/commands/service/human_readable_flags.go
@@ -26,7 +26,7 @@ import (
 func ServiceListHandlers(h hprinters.PrintHandler) {
 	kServiceColumnDefinitions := []metav1beta1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Description: "Name of the Knative service."},
-		{Name: "Address", Type: "string", Description: "Address of the Knative service."},
+		{Name: "Url", Type: "string", Description: "URL of the Knative service."},
 		//{Name: "LastCreatedRevision", Type: "string", Description: "Name of last revision created."},
 		//{Name: "LastReadyRevision", Type: "string", Description: "Name of last ready revision."},
 		{Name: "Generation", Type: "integer", Description: "Sequence number of 'Generation' of the service that was last processed by the controller."},
@@ -57,7 +57,7 @@ func printKServiceList(kServiceList *servingv1alpha1.ServiceList, options hprint
 // printKService populates the knative service table rows
 func printKService(kService *servingv1alpha1.Service, options hprinters.PrintOptions) ([]metav1beta1.TableRow, error) {
 	name := kService.Name
-	url := kService.Status.RouteStatusFields.Address.URL
+	url := kService.Status.URL
 	//lastCreatedRevision := kService.Status.LatestCreatedRevisionName
 	//lastReadyRevision := kService.Status.LatestReadyRevisionName
 	generation := kService.Status.ObservedGeneration

--- a/pkg/kn/commands/service/human_readable_flags.go
+++ b/pkg/kn/commands/service/human_readable_flags.go
@@ -25,8 +25,8 @@ import (
 // ServiceListHandlers adds print handlers for service list command
 func ServiceListHandlers(h hprinters.PrintHandler) {
 	kServiceColumnDefinitions := []metav1beta1.TableColumnDefinition{
-		{Name: "Name", Type: "string", Description: "Name of the knative service."},
-		{Name: "Domain", Type: "string", Description: "Domain name of the knative service."},
+		{Name: "Name", Type: "string", Description: "Name of the Knative service."},
+		{Name: "Address", Type: "string", Description: "Address of the Knative service."},
 		//{Name: "LastCreatedRevision", Type: "string", Description: "Name of last revision created."},
 		//{Name: "LastReadyRevision", Type: "string", Description: "Name of last ready revision."},
 		{Name: "Generation", Type: "integer", Description: "Sequence number of 'Generation' of the service that was last processed by the controller."},
@@ -57,7 +57,7 @@ func printKServiceList(kServiceList *servingv1alpha1.ServiceList, options hprint
 // printKService populates the knative service table rows
 func printKService(kService *servingv1alpha1.Service, options hprinters.PrintOptions) ([]metav1beta1.TableRow, error) {
 	name := kService.Name
-	domain := kService.Status.RouteStatusFields.DeprecatedDomain
+	url := kService.Status.RouteStatusFields.Address.URL
 	//lastCreatedRevision := kService.Status.LatestCreatedRevisionName
 	//lastReadyRevision := kService.Status.LatestReadyRevisionName
 	generation := kService.Status.ObservedGeneration
@@ -71,7 +71,7 @@ func printKService(kService *servingv1alpha1.Service, options hprinters.PrintOpt
 	}
 	row.Cells = append(row.Cells,
 		name,
-		domain,
+		url,
 		//lastCreatedRevision,
 		//lastReadyRevision,
 		generation,

--- a/pkg/kn/commands/service/service_list_test.go
+++ b/pkg/kn/commands/service/service_list_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/knative/pkg/apis"
-	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	duckv1beta1 "github.com/knative/pkg/apis/duck/v1beta1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"gotest.tools/assert"
@@ -77,8 +76,8 @@ func TestGetEmpty(t *testing.T) {
 }
 
 func TestServiceListDefaultOutput(t *testing.T) {
-	service1 := createMockServiceWithParams("foo", "foo.default.example.com", 1)
-	service2 := createMockServiceWithParams("bar", "bar.default.example.com", 2)
+	service1 := createMockServiceWithParams("foo", "http://foo.default.example.com", 1)
+	service2 := createMockServiceWithParams("bar", "http://bar.default.example.com", 2)
 	serviceList := &v1alpha1.ServiceList{Items: []v1alpha1.Service{*service1, *service2}}
 	action, output, err := fakeServiceList([]string{"service", "list"}, serviceList)
 	if err != nil {
@@ -89,7 +88,7 @@ func TestServiceListDefaultOutput(t *testing.T) {
 	} else if !action.Matches("list", "services") {
 		t.Errorf("Bad action %v", action)
 	}
-	assert.Check(t, util.ContainsAll(output[0], "NAME", "ADDRESS", "GENERATION", "AGE", "CONDITIONS", "READY", "REASON"))
+	assert.Check(t, util.ContainsAll(output[0], "NAME", "URL", "GENERATION", "AGE", "CONDITIONS", "READY", "REASON"))
 	assert.Check(t, util.ContainsAll(output[1], "foo", "foo.default.example.com", "1"))
 	assert.Check(t, util.ContainsAll(output[2], "bar", "bar.default.example.com", "2"))
 }
@@ -117,8 +116,8 @@ func TestServiceGetWithTwoSrvName(t *testing.T) {
 	assert.ErrorContains(t, err, "'kn service list' accepts maximum 1 argument")
 }
 
-func createMockServiceWithParams(name, domain string, generation int64) *v1alpha1.Service {
-	url, _ := apis.ParseURL(domain)
+func createMockServiceWithParams(name, urlS string, generation int64) *v1alpha1.Service {
+	url, _ := apis.ParseURL(urlS)
 	service := &v1alpha1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",
@@ -135,7 +134,7 @@ func createMockServiceWithParams(name, domain string, generation int64) *v1alpha
 			Status: duckv1beta1.Status{
 				ObservedGeneration: generation},
 			RouteStatusFields: v1alpha1.RouteStatusFields{
-				Address: &duckv1alpha1.Addressable{Addressable: duckv1beta1.Addressable{URL: url}},
+				URL: url,
 			},
 		},
 	}

--- a/pkg/kn/commands/service/service_list_test.go
+++ b/pkg/kn/commands/service/service_list_test.go
@@ -18,14 +18,17 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/knative/client/pkg/kn/commands"
-	"github.com/knative/client/pkg/util"
+	"github.com/knative/pkg/apis"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	duckv1beta1 "github.com/knative/pkg/apis/duck/v1beta1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"gotest.tools/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	client_testing "k8s.io/client-go/testing"
+
+	"github.com/knative/client/pkg/kn/commands"
+	"github.com/knative/client/pkg/util"
 )
 
 func fakeServiceList(args []string, response *v1alpha1.ServiceList) (action client_testing.Action, output []string, err error) {
@@ -86,7 +89,7 @@ func TestServiceListDefaultOutput(t *testing.T) {
 	} else if !action.Matches("list", "services") {
 		t.Errorf("Bad action %v", action)
 	}
-	assert.Check(t, util.ContainsAll(output[0], "NAME", "DOMAIN", "GENERATION", "AGE", "CONDITIONS", "READY", "REASON"))
+	assert.Check(t, util.ContainsAll(output[0], "NAME", "ADDRESS", "GENERATION", "AGE", "CONDITIONS", "READY", "REASON"))
 	assert.Check(t, util.ContainsAll(output[1], "foo", "foo.default.example.com", "1"))
 	assert.Check(t, util.ContainsAll(output[2], "bar", "bar.default.example.com", "2"))
 }
@@ -115,6 +118,7 @@ func TestServiceGetWithTwoSrvName(t *testing.T) {
 }
 
 func createMockServiceWithParams(name, domain string, generation int64) *v1alpha1.Service {
+	url, _ := apis.ParseURL(domain)
 	service := &v1alpha1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",
@@ -131,7 +135,7 @@ func createMockServiceWithParams(name, domain string, generation int64) *v1alpha
 			Status: duckv1beta1.Status{
 				ObservedGeneration: generation},
 			RouteStatusFields: v1alpha1.RouteStatusFields{
-				DeprecatedDomain: domain,
+				Address: &duckv1alpha1.Addressable{Addressable: duckv1beta1.Addressable{URL: url}},
 			},
 		},
 	}

--- a/pkg/kn/commands/service/service_list_test.go
+++ b/pkg/kn/commands/service/service_list_test.go
@@ -105,7 +105,7 @@ func TestServiceGetOneOutput(t *testing.T) {
 	} else if !action.Matches("list", "services") {
 		t.Errorf("Bad action %v", action)
 	}
-	assert.Check(t, util.ContainsAll(output[0], "NAME", "DOMAIN", "GENERATION", "AGE", "CONDITIONS", "READY", "REASON"))
+	assert.Check(t, util.ContainsAll(output[0], "NAME", "URL", "GENERATION", "AGE", "CONDITIONS", "READY", "REASON"))
 	assert.Check(t, util.ContainsAll(output[1], "foo", "foo.default.example.com", "1"))
 }
 


### PR DESCRIPTION
Starting with 0.7.0 old fields are not populated anymore. Let's switch to the new fields then.

This fix should work with 0.6.0, too as the new fields already have been populated back then.

So we can unconditionally pick status.address.url which is accordance with
our policy to support the latest release and the release before.

Fixes #246.