### PR TITLE
chore(wait): Fixes for Smoke Tests + help messages

### DIFF
--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -54,7 +54,7 @@ kn service create NAME --image IMAGE [flags]
   -p, --port int32               The port where application listens on.
       --requests-cpu string      The requested CPU (e.g., 250m).
       --requests-memory string   The requested memory (e.g., 64Mi).
-      --wait-timeout int         Seconds to wait before giving up on waiting for service to be ready (default: 60). (default 60)
+      --wait-timeout int         Seconds to wait before giving up on waiting for service to be ready. (default 60)
 ```
 
 ### Options inherited from parent commands

--- a/pkg/kn/commands/wait_flags.go
+++ b/pkg/kn/commands/wait_flags.go
@@ -36,6 +36,6 @@ func (p *WaitFlags) AddConditionWaitFlags(command *cobra.Command, waitTimeoutDef
 	waitUsage := fmt.Sprintf("Create %s and don't wait for it to become ready.", what)
 	command.Flags().BoolVar(&p.Async, "async", false, waitUsage)
 
-	timeoutUsage := fmt.Sprintf("Seconds to wait before giving up on waiting for %s to be ready (default: %d).", what, waitTimeoutDefault)
+	timeoutUsage := fmt.Sprintf("Seconds to wait before giving up on waiting for %s to be ready.", what)
 	command.Flags().IntVar(&p.TimeoutInSeconds, "wait-timeout", waitTimeoutDefault, timeoutUsage)
 }

--- a/test/e2e-smoke-tests.sh
+++ b/test/e2e-smoke-tests.sh
@@ -47,7 +47,7 @@ header "Running smoke tests"
 kubectl create ns $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 
 ./kn service create svc1 --async --image gcr.io/knative-samples/helloworld-go -e TARGET=Knative -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
-./kn service create hello --image gcr.io/knative-samples/helloworld-go -e TARGET=Knative -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
+./kn service create hello --image gcr.io/knative-samples/helloworld-go -e TARGET=Knative -n $KN_E2E_SMOKE_TESTS_NAMESPACE --wait-timeout 240 || fail_test
 ./kn service list hello -n $KN_E2E_SMOKE_TESTS_NAMESPACE -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 ./kn service update hello --env TARGET=kn -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 ./kn revision list hello -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test


### PR DESCRIPTION
* Increase wait timeout to 240s (to avoid test failures like in https://storage.googleapis.com/knative-prow/pr-logs/pull/knative_client/244/pull-knative-client-integration-tests-latest-release/1148472118510358531/build-log.txt)
* Fixed duplicate default help message for `kn service create --help`