### PR TITLE
Fix issue #205 to add route describe feature and test

### DIFF
--- a/docs/cmd/kn_route.md
+++ b/docs/cmd/kn_route.md
@@ -26,5 +26,6 @@ kn route [flags]
 ### SEE ALSO
 
 * [kn](kn.md)	 - Knative client
+* [kn route describe](kn_route_describe.md)	 - Describe available route.
 * [kn route list](kn_route_list.md)	 - List available routes.
 

--- a/docs/cmd/kn_route_describe.md
+++ b/docs/cmd/kn_route_describe.md
@@ -1,0 +1,33 @@
+## kn route describe
+
+Describe available route.
+
+### Synopsis
+
+Describe available route.
+
+```
+kn route describe NAME [flags]
+```
+
+### Options
+
+```
+      --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
+  -h, --help                          help for describe
+  -n, --namespace string              List the requested object(s) in given namespace.
+  -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file. (default "yaml")
+      --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+```
+
+### SEE ALSO
+
+* [kn route](kn_route.md)	 - Route command group
+

--- a/pkg/kn/commands/route/route.go
+++ b/pkg/kn/commands/route/route.go
@@ -25,5 +25,6 @@ func NewRouteCommand(p *commands.KnParams) *cobra.Command {
 		Short: "Route command group",
 	}
 	routeCmd.AddCommand(NewRouteListCommand(p))
+	routeCmd.AddCommand(NewRouteDescribeCommand(p))
 	return routeCmd
 }

--- a/pkg/kn/commands/route/route_describe.go
+++ b/pkg/kn/commands/route/route_describe.go
@@ -1,0 +1,64 @@
+// Copyright © 2019 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package route
+
+import (
+	"errors"
+
+	"github.com/knative/client/pkg/kn/commands"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+// NewRouteDescribeCommand represents 'kn route describe' command
+func NewRouteDescribeCommand(p *commands.KnParams) *cobra.Command {
+	routeDescribePrintFlags := genericclioptions.NewPrintFlags("").WithDefaultOutput("yaml")
+	routeDescribeCommand := &cobra.Command{
+		Use:   "describe NAME",
+		Short: "Describe available route.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("requires the route name.")
+			}
+			namespace, err := p.GetNamespace(cmd)
+			if err != nil {
+				return err
+			}
+
+			client, err := p.NewClient(namespace)
+			if err != nil {
+				return err
+			}
+
+			describeRoute, err := client.GetRoute(args[0])
+			if err != nil {
+				return err
+			}
+
+			printer, err := routeDescribePrintFlags.ToPrinter()
+			if err != nil {
+				return err
+			}
+			err = printer.PrintObj(describeRoute, cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	commands.AddNamespaceFlags(routeDescribeCommand.Flags(), false)
+	routeDescribePrintFlags.AddFlags(routeDescribeCommand)
+	return routeDescribeCommand
+}

--- a/pkg/kn/commands/route/route_describe_test.go
+++ b/pkg/kn/commands/route/route_describe_test.go
@@ -1,0 +1,130 @@
+// Copyright © 2019 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package route
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/knative/client/pkg/kn/commands"
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"gotest.tools/assert"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	client_testing "k8s.io/client-go/testing"
+	"sigs.k8s.io/yaml"
+)
+
+func fakeRouteDescribe(args []string, response *v1alpha1.Route) (action client_testing.Action, output string, err error) {
+	knParams := &commands.KnParams{}
+	cmd, fakeRoute, buf := commands.CreateTestKnCommand(NewRouteCommand(knParams), knParams)
+	fakeRoute.AddReactor("*", "*",
+		func(a client_testing.Action) (bool, runtime.Object, error) {
+			action = a
+			return true, response, nil
+		})
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	if err != nil {
+		return
+	}
+	output = buf.String()
+	return
+}
+
+func TestCompletion(t *testing.T) {
+	var expectedRoute v1alpha1.Route
+
+	setup := func(t *testing.T) {
+		expectedRoute = v1alpha1.Route{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Route",
+				APIVersion: "knative.dev/v1alpha1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "default",
+			},
+		}
+	}
+
+	t.Run("requires the route name", func(t *testing.T) {
+		_, _, err := fakeRouteDescribe([]string{"route", "describe"}, &v1alpha1.Route{})
+		assert.Assert(t, err != nil)
+		assert.Assert(t, strings.Contains(err.Error(), "requires the route name."))
+	})
+
+	t.Run("describe a valid route with default output", func(t *testing.T) {
+		setup(t)
+
+		action, output, err := fakeRouteDescribe([]string{"route", "describe", "foo"}, &expectedRoute)
+		assert.Assert(t, err == nil)
+		assert.Assert(t, action != nil)
+		assert.Assert(t, action.Matches("get", "routes"))
+
+		jsonData, err := yaml.YAMLToJSON([]byte(output))
+		assert.Assert(t, err == nil)
+
+		var returnedRoute v1alpha1.Route
+		err = json.Unmarshal(jsonData, &returnedRoute)
+		assert.Assert(t, err == nil)
+		assert.Assert(t, equality.Semantic.DeepEqual(expectedRoute, returnedRoute))
+	})
+
+	t.Run("describe a valid route with special output", func(t *testing.T) {
+		t.Run("yaml", func(t *testing.T) {
+			setup(t)
+
+			action, output, err := fakeRouteDescribe([]string{"route", "describe", "foo", "-oyaml"}, &expectedRoute)
+			assert.Assert(t, err == nil)
+			assert.Assert(t, action != nil)
+			assert.Assert(t, action.Matches("get", "routes"))
+
+			jsonData, err := yaml.YAMLToJSON([]byte(output))
+			assert.Assert(t, err == nil)
+
+			var returnedRoute v1alpha1.Route
+			err = json.Unmarshal(jsonData, &returnedRoute)
+			assert.Assert(t, err == nil)
+			assert.Assert(t, equality.Semantic.DeepEqual(expectedRoute, returnedRoute))
+		})
+
+		t.Run("json", func(t *testing.T) {
+			setup(t)
+
+			action, output, err := fakeRouteDescribe([]string{"route", "describe", "foo", "-ojson"}, &expectedRoute)
+			assert.Assert(t, err == nil)
+			assert.Assert(t, action != nil)
+			assert.Assert(t, action.Matches("get", "routes"))
+
+			var returnedRoute v1alpha1.Route
+			err = json.Unmarshal([]byte(output), &returnedRoute)
+			assert.Assert(t, err == nil)
+			assert.Assert(t, equality.Semantic.DeepEqual(expectedRoute, returnedRoute))
+		})
+
+		t.Run("name", func(t *testing.T) {
+			setup(t)
+
+			action, output, err := fakeRouteDescribe([]string{"route", "describe", "foo", "-oname"}, &expectedRoute)
+			assert.Assert(t, err == nil)
+			assert.Assert(t, action != nil)
+			assert.Assert(t, action.Matches("get", "routes"))
+			assert.Assert(t, strings.Contains(output, expectedRoute.Name))
+		})
+	})
+}

--- a/pkg/serving/v1alpha1/client.go
+++ b/pkg/serving/v1alpha1/client.go
@@ -63,6 +63,9 @@ type KnClient interface {
 	// Delete a revision
 	DeleteRevision(name string) error
 
+	// Get a route by its unique name
+	GetRoute(name string) (*v1alpha1.Route, error)
+
 	// List routes
 	ListRoutes(opts ...ListConfig) (*v1alpha1.RouteList, error)
 }
@@ -217,6 +220,19 @@ func (cl *knClient) ListRevisions(config ...ListConfig) (*v1alpha1.RevisionList,
 		return nil, err
 	}
 	return updateServingGvkForRevisionList(revisionList)
+}
+
+// Get a route by its unique name
+func (cl *knClient) GetRoute(name string) (*v1alpha1.Route, error) {
+	route, err := cl.client.Routes(cl.namespace).Get(name, v1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	err = serving.UpdateGroupVersionKind(route, v1alpha1.SchemeGroupVersion)
+	if err != nil {
+		return nil, err
+	}
+	return route, nil
 }
 
 // List routes


### PR DESCRIPTION
1, Implement kn route describe command with required parameters:
```
✔ $ go run cmd/kn/main.go route describe --help
Describe available route.

Usage:
  kn route describe NAME [flags]

Flags:
      --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
  -h, --help                          help for describe
  -n, --namespace string              List the requested object(s) in given namespace.
  -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file. (default "yaml")
      --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].

Global Flags:
      --config string       config file (default is $HOME/.kn/config.yaml)
      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
```

2, Add `gotest.tools` tests for kn route describe commands:
 - test without route name
 - test route describe with the default output
 - test route describe with the YAML output
 - test route describe with the JSON output
 - test route describe with the name output

Also rebased from master and change to use new knClient.

For issue: #205 