### PR TITLE
Hide completion command from help.

### DIFF
--- a/pkg/kn/commands/completion.go
+++ b/pkg/kn/commands/completion.go
@@ -30,6 +30,7 @@ func NewCompletionCommand(p *KnParams) *cobra.Command {
 	completionCmd := &cobra.Command{
 		Use:   "completion",
 		Short: "Output shell completion code (default Bash)",
+		Hidden: true,  // Don't show this in help listing.
 		Run: func(cmd *cobra.Command, args []string) {
 			if completionFlags.Zsh {
 				cmd.Root().GenZshCompletion(os.Stdout)


### PR DESCRIPTION
<!--
/lint
-->

## Proposed Changes

* Hide the presence of the `kn completion` command so that users mostly see the active command surface.

```release-note
`kn completion` is no longer suggested by `kn help`. The command still exists
to enable command-line completion, but it should not be advertised in normal
usage.
```
