### PR TITLE
Clean up e2e test assertion

### DIFF
--- a/test/e2e/basic_workflow_test.go
+++ b/test/e2e/basic_workflow_test.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/knative/client/pkg/util"
@@ -93,7 +94,13 @@ func testRevisionListForService(t *testing.T, k kn, serviceName string) {
 	out, err := k.RunWithOpts([]string{"revision", "list", "-s", serviceName}, runOpts{NoNamespace: false})
 	assert.NilError(t, err)
 
-	assert.Check(t, util.ContainsAll(out, serviceName, "True"))
+	outputLines := strings.Split(out, "\n")
+	// Ignore the last line because it is an empty string caused by splitting a line break
+	// at the end of the output string
+	for _, line := range outputLines[1 : len(outputLines)-1] {
+		// The last item is the revision status, which should be ready
+		assert.Check(t, util.ContainsAll(line, " "+serviceName+" ", "True"))
+	}
 }
 
 func testServiceDescribe(t *testing.T, k kn, serviceName string) {

--- a/test/e2e/basic_workflow_test.go
+++ b/test/e2e/basic_workflow_test.go
@@ -49,19 +49,45 @@ func TestBasicWorkflow(t *testing.T) {
 	teardown := Setup(t)
 	defer teardown(t)
 
-	testServiceListEmpty(t, k)
-	testServiceCreate(t, k, "hello")
-	testServiceList(t, k, "hello")
-	testServiceDescribe(t, k, "hello")
-	testServiceUpdate(t, k, "hello", []string{"--env", "TARGET=kn", "--port", "8888"})
-	testServiceCreate(t, k, "svc2")
-	testRevisionListForService(t, k, "hello")
-	testRevisionListForService(t, k, "svc2")
-	testRouteList(t, k)
-	testRouteListWithArgument(t, k, "hello")
-	testServiceDelete(t, k, "hello")
-	testServiceDelete(t, k, "svc2")
-	testServiceListEmpty(t, k)
+	t.Run("returns no service before running tests", func(t *testing.T) {
+		testServiceListEmpty(t, k)
+	})
+
+	t.Run("create hello service and returns no error", func(t *testing.T) {
+		testServiceCreate(t, k, "hello")
+	})
+
+	t.Run("returns valid info about hello service", func(t *testing.T) {
+		testServiceList(t, k, "hello")
+		testServiceDescribe(t, k, "hello")
+	})
+
+	t.Run("update hello service's configuration and returns no error", func(t *testing.T) {
+		testServiceUpdate(t, k, "hello", []string{"--env", "TARGET=kn", "--port", "8888"})
+	})
+
+	t.Run("create another service and returns no error", func(t *testing.T) {
+		testServiceCreate(t, k, "svc2")
+	})
+
+	t.Run("returns a list of revisions associated with hello and svc2 services", func(t *testing.T) {
+		testRevisionListForService(t, k, "hello")
+		testRevisionListForService(t, k, "svc2")
+	})
+
+	t.Run("returns a list of routes associated with hello and svc2 services", func(t *testing.T) {
+		testRouteList(t, k)
+		testRouteListWithArgument(t, k, "hello")
+	})
+
+	t.Run("delete hello and svc2 services and returns no error", func(t *testing.T) {
+		testServiceDelete(t, k, "hello")
+		testServiceDelete(t, k, "svc2")
+	})
+
+	t.Run("returns no service after completing tests", func(t *testing.T) {
+		testServiceListEmpty(t, k)
+	})
 }
 
 // Private test functions

--- a/test/e2e/revision_workflow_test.go
+++ b/test/e2e/revision_workflow_test.go
@@ -28,9 +28,17 @@ func TestRevisionWorkflow(t *testing.T) {
 	teardown := Setup(t)
 	defer teardown(t)
 
-	testServiceCreate(t, k, "hello")
-	testDeleteRevision(t, k, "hello")
-	testServiceDelete(t, k, "hello")
+	t.Run("create hello service and returns no error", func(t *testing.T) {
+		testServiceCreate(t, k, "hello")
+	})
+
+	t.Run("delete latest revision from hello service and returns no error", func(t *testing.T) {
+		testDeleteRevision(t, k, "hello")
+	})
+
+	t.Run("delete hello service and returns no error", func(t *testing.T) {
+		testServiceDelete(t, k, "hello")
+	})
 }
 
 func testDeleteRevision(t *testing.T, k kn, serviceName string) {

--- a/test/e2e/revision_workflow_test.go
+++ b/test/e2e/revision_workflow_test.go
@@ -35,15 +35,13 @@ func TestRevisionWorkflow(t *testing.T) {
 
 func testDeleteRevision(t *testing.T, k kn, serviceName string) {
 	revName, err := k.RunWithOpts([]string{"revision", "list", "-o=jsonpath={.items[0].metadata.name}"}, runOpts{})
-	if err != nil {
-		t.Errorf("Error executing 'revision list -o' command. Error: %s", err.Error())
-	}
+	assert.NilError(t, err)
 	if strings.Contains(revName, "No resources found.") {
 		t.Errorf("Could not find revision name.")
 	}
+
 	out, err := k.RunWithOpts([]string{"revision", "delete", revName}, runOpts{})
-	if err != nil {
-		t.Errorf("Error executing 'revision delete %s' command. Error: %s", revName, err.Error())
-	}
+	assert.NilError(t, err)
+
 	assert.Check(t, util.ContainsAll(out, "Revision", revName, "deleted", "namespace", k.namespace))
 }

--- a/test/e2e/service_options_test.go
+++ b/test/e2e/service_options_test.go
@@ -28,12 +28,26 @@ func TestServiceOptions(t *testing.T) {
 	teardown := Setup(t)
 	defer teardown(t)
 
-	testServiceCreateWithOptions(t, k, "hello", []string{"--concurrency-limit", "250", "--concurrency-target", "300"})
-	testServiceDescribeConcurrencyLimit(t, k, "hello", "250")
-	testServiceDescribeConcurrencyTarget(t, k, "hello", "300")
-	testServiceUpdate(t, k, "hello", []string{"--concurrency-limit", "300"})
-	testServiceDescribeConcurrencyLimit(t, k, "hello", "300")
-	testServiceDelete(t, k, "hello")
+	t.Run("create hello service with concurrency options and returns no error", func(t *testing.T) {
+		testServiceCreateWithOptions(t, k, "hello", []string{"--concurrency-limit", "250", "--concurrency-target", "300"})
+	})
+
+	t.Run("returns valid concurrency options for hello service", func(t *testing.T) {
+		testServiceDescribeConcurrencyLimit(t, k, "hello", "250")
+		testServiceDescribeConcurrencyTarget(t, k, "hello", "300")
+	})
+
+	t.Run("update concurrency limit for hello service and returns no error", func(t *testing.T) {
+		testServiceUpdate(t, k, "hello", []string{"--concurrency-limit", "300"})
+	})
+
+	t.Run("returns correct concurrency limit for hello service", func(t *testing.T) {
+		testServiceDescribeConcurrencyLimit(t, k, "hello", "300")
+	})
+
+	t.Run("delete hello service and returns no error", func(t *testing.T) {
+		testServiceDelete(t, k, "hello")
+	})
 }
 
 func testServiceCreateWithOptions(t *testing.T, k kn, serviceName string, options []string) {

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -17,8 +17,10 @@
 package e2e
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/knative/client/pkg/util"
+	"gotest.tools/assert"
 )
 
 func TestVersion(t *testing.T) {
@@ -27,7 +29,5 @@ func TestVersion(t *testing.T) {
 
 	out, _ := kn.RunWithOpts([]string{"version"}, runOpts{NoNamespace: true})
 
-	if !strings.Contains(out, "Version") {
-		t.Fatalf("Expected to find client version")
-	}
+	assert.Check(t, util.ContainsAll(out, "Version"))
 }


### PR DESCRIPTION
This is a follow-up PR of #256 . We should use assert package (and utils) for testing the output string to keep consistency between unit and e2e tests.
