### PR TITLE
Validate scale and container concurrency options when updating configuration resource

### DIFF
--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -51,10 +51,10 @@ func (p *ConfigurationEditFlags) AddUpdateFlags(command *cobra.Command) {
 	command.Flags().StringVar(&p.RequestsFlags.Memory, "requests-memory", "", "The requested memory (e.g., 64Mi).")
 	command.Flags().StringVar(&p.LimitsFlags.CPU, "limits-cpu", "", "The limits on the requested CPU (e.g., 1000m).")
 	command.Flags().StringVar(&p.LimitsFlags.Memory, "limits-memory", "", "The limits on the requested memory (e.g., 1024Mi).")
-	command.Flags().IntVar(&p.MinScale, "min-scale", -1, "Minimal number of replicas.")
-	command.Flags().IntVar(&p.MaxScale, "max-scale", -1, "Maximal number of replicas.")
+	command.Flags().IntVar(&p.MinScale, "min-scale", 0, "Minimal number of replicas.")
+	command.Flags().IntVar(&p.MaxScale, "max-scale", 0, "Maximal number of replicas.")
 	command.Flags().IntVar(&p.ConcurrencyTarget, "concurrency-target", 0, "Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to --concurrency-limit when given.")
-	command.Flags().IntVar(&p.ConcurrencyLimit, "concurrency-limit", -1, "Hard Limit of concurrent requests to be processed by a single replica.")
+	command.Flags().IntVar(&p.ConcurrencyLimit, "concurrency-limit", 0, "Hard Limit of concurrent requests to be processed by a single replica.")
 	command.Flags().Int32VarP(&p.Port, "port", "p", 0, "The port where application listens on.")
 }
 
@@ -111,7 +111,21 @@ func (p *ConfigurationEditFlags) Apply(service *servingv1alpha1.Service, cmd *co
 		}
 	}
 
-	servinglib.UpdateConcurrencyConfiguration(template, p.MinScale, p.MaxScale, p.ConcurrencyTarget, p.ConcurrencyLimit)
+	if cmd.Flags().Changed("min-scale") {
+		servinglib.UpdateMinScale(template, p.MinScale)
+	}
+
+	if cmd.Flags().Changed("max-scale") {
+		servinglib.UpdateMaxScale(template, p.MaxScale)
+	}
+
+	if cmd.Flags().Changed("concurrency-target") {
+		servinglib.UpdateConcurrencyTarget(template, p.ConcurrencyTarget)
+	}
+
+	if cmd.Flags().Changed("concurrency-limit") {
+		servinglib.UpdateConcurrencyLimit(template, p.ConcurrencyLimit)
+	}
 
 	return nil
 }

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -51,10 +51,10 @@ func (p *ConfigurationEditFlags) AddUpdateFlags(command *cobra.Command) {
 	command.Flags().StringVar(&p.RequestsFlags.Memory, "requests-memory", "", "The requested memory (e.g., 64Mi).")
 	command.Flags().StringVar(&p.LimitsFlags.CPU, "limits-cpu", "", "The limits on the requested CPU (e.g., 1000m).")
 	command.Flags().StringVar(&p.LimitsFlags.Memory, "limits-memory", "", "The limits on the requested memory (e.g., 1024Mi).")
-	command.Flags().IntVar(&p.MinScale, "min-scale", 0, "Minimal number of replicas.")
-	command.Flags().IntVar(&p.MaxScale, "max-scale", 0, "Maximal number of replicas.")
+	command.Flags().IntVar(&p.MinScale, "min-scale", -1, "Minimal number of replicas.")
+	command.Flags().IntVar(&p.MaxScale, "max-scale", -1, "Maximal number of replicas.")
 	command.Flags().IntVar(&p.ConcurrencyTarget, "concurrency-target", 0, "Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to --concurrency-limit when given.")
-	command.Flags().IntVar(&p.ConcurrencyLimit, "concurrency-limit", 0, "Hard Limit of concurrent requests to be processed by a single replica.")
+	command.Flags().IntVar(&p.ConcurrencyLimit, "concurrency-limit", -1, "Hard Limit of concurrent requests to be processed by a single replica.")
 	command.Flags().Int32VarP(&p.Port, "port", "p", 0, "The port where application listens on.")
 }
 

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -112,19 +112,31 @@ func (p *ConfigurationEditFlags) Apply(service *servingv1alpha1.Service, cmd *co
 	}
 
 	if cmd.Flags().Changed("min-scale") {
-		servinglib.UpdateMinScale(template, p.MinScale)
+		err = servinglib.UpdateMinScale(template, p.MinScale)
+		if err != nil {
+			return err
+		}
 	}
 
 	if cmd.Flags().Changed("max-scale") {
-		servinglib.UpdateMaxScale(template, p.MaxScale)
+		err = servinglib.UpdateMaxScale(template, p.MaxScale)
+		if err != nil {
+			return err
+		}
 	}
 
 	if cmd.Flags().Changed("concurrency-target") {
-		servinglib.UpdateConcurrencyTarget(template, p.ConcurrencyTarget)
+		err = servinglib.UpdateConcurrencyTarget(template, p.ConcurrencyTarget)
+		if err != nil {
+			return err
+		}
 	}
 
 	if cmd.Flags().Changed("concurrency-limit") {
-		servinglib.UpdateConcurrencyLimit(template, p.ConcurrencyLimit)
+		err = servinglib.UpdateConcurrencyLimit(template, p.ConcurrencyLimit)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/serving/config_changes.go
+++ b/pkg/serving/config_changes.go
@@ -52,7 +52,8 @@ func UpdateConcurrencyTarget(template *servingv1alpha1.RevisionTemplateSpec, tar
 	// TODO(toVersus): Remove the following validation once serving library is updated to v0.8.0
 	// and just rely on ValidateAnnotations method.
 	if target < autoscaling.TargetMin {
-		return fmt.Errorf("Invalid %s annotation value: must be an intger greater than 0", autoscaling.TargetAnnotationKey)
+		return fmt.Errorf("Invalid 'concurrency-target' value: must be an intger greater than 0: %s",
+			autoscaling.TargetAnnotationKey)
 	}
 
 	return UpdateAnnotation(template, autoscaling.TargetAnnotationKey, strconv.Itoa(target))
@@ -64,7 +65,7 @@ func UpdateConcurrencyLimit(template *servingv1alpha1.RevisionTemplateSpec, limi
 	// Validate input limit
 	ctx := context.Background()
 	if err := cc.Validate(ctx).ViaField("spec.containerConcurrency"); err != nil {
-		return fmt.Errorf("Invalid containerConcurrency revision spec: %s", err)
+		return fmt.Errorf("Invalid 'concurrency-limit' value: %s", err)
 	}
 	template.Spec.ContainerConcurrency = cc
 	return nil

--- a/pkg/serving/config_changes.go
+++ b/pkg/serving/config_changes.go
@@ -79,7 +79,8 @@ func UpdateAnnotation(template *servingv1alpha1.RevisionTemplateSpec, annotation
 		template.Annotations = annoMap
 	}
 
-	// Validate autoscaling annotations and returns the same value as before if input value is invalid
+	// Validate autoscaling annotations and returns error if invalid input provided
+	// without changing the existing spec
 	in := make(map[string]string)
 	in[annotation] = value
 	if err := autoscaling.ValidateAnnotations(in); err != nil {

--- a/pkg/serving/config_changes.go
+++ b/pkg/serving/config_changes.go
@@ -52,7 +52,7 @@ func UpdateConcurrencyTarget(template *servingv1alpha1.RevisionTemplateSpec, tar
 	// TODO(toVersus): Remove the following validation once serving library is updated to v0.8.0
 	// and just rely on ValidateAnnotations method.
 	if target < autoscaling.TargetMin {
-		return fmt.Errorf("Invalid 'concurrency-target' value: must be an intger greater than 0: %s",
+		return fmt.Errorf("Invalid 'concurrency-target' value: must be an integer greater than 0: %s",
 			autoscaling.TargetAnnotationKey)
 	}
 

--- a/pkg/serving/config_changes_test.go
+++ b/pkg/serving/config_changes_test.go
@@ -15,9 +15,10 @@
 package serving
 
 import (
-	"gotest.tools/assert"
 	"reflect"
 	"testing"
+
+	"gotest.tools/assert"
 
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"

--- a/pkg/serving/config_changes_test.go
+++ b/pkg/serving/config_changes_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestUpdateAutoscalingAnnotations(t *testing.T) {
 	template := &servingv1alpha1.RevisionTemplateSpec{}
-	UpdateConcurrencyConfiguration(template, 10, 100, 1000, 1000)
+	updateConcurrencyConfiguration(template, 10, 100, 1000, 1000)
 	annos := template.Annotations
 	if annos[autoscaling.MinScaleAnnotationKey] != "10" {
 		t.Error("minScale failed")
@@ -46,9 +46,9 @@ func TestUpdateAutoscalingAnnotations(t *testing.T) {
 
 func TestUpdateInvalidAutoscalingAnnotations(t *testing.T) {
 	template := &servingv1alpha1.RevisionTemplateSpec{}
-	UpdateConcurrencyConfiguration(template, 10, 100, 1000, 1000)
+	updateConcurrencyConfiguration(template, 10, 100, 1000, 1000)
 	// Update with invalid concurrency options
-	UpdateConcurrencyConfiguration(template, -1, -1, 0, -1)
+	updateConcurrencyConfiguration(template, -1, -1, 0, -1)
 	annos := template.Annotations
 	if annos[autoscaling.MinScaleAnnotationKey] != "10" {
 		t.Error("minScale failed")
@@ -260,4 +260,11 @@ func assertNoV1alpha1(t *testing.T, template *servingv1alpha1.RevisionTemplateSp
 	if template.Spec.Containers != nil {
 		t.Error("Assuming only old v1alpha1 fields but found spec.template")
 	}
+}
+
+func updateConcurrencyConfiguration(template *servingv1alpha1.RevisionTemplateSpec, minScale int, maxScale int, target int, limit int) {
+	UpdateMinScale(template, minScale)
+	UpdateMaxScale(template, maxScale)
+	UpdateConcurrencyTarget(template, target)
+	UpdateConcurrencyLimit(template, limit)
 }

--- a/pkg/serving/config_changes_test.go
+++ b/pkg/serving/config_changes_test.go
@@ -15,6 +15,7 @@
 package serving
 
 import (
+	"gotest.tools/assert"
 	"reflect"
 	"testing"
 
@@ -79,13 +80,9 @@ func testUpdateEnvVarsNew(t *testing.T, template *servingv1alpha1.RevisionTempla
 		"b": "bar",
 	}
 	err := UpdateEnvVars(template, env)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 	found, err := EnvToMap(container.Env)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 	if !reflect.DeepEqual(env, found) {
 		t.Fatalf("Env did not match expected %v found %v", env, found)
 	}
@@ -109,9 +106,7 @@ func testUpdateEnvVarsAppendOld(t *testing.T, template *servingv1alpha1.Revision
 		"b": "bar",
 	}
 	err := UpdateEnvVars(template, env)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 
 	expected := map[string]string{
 		"a": "foo",
@@ -119,9 +114,7 @@ func testUpdateEnvVarsAppendOld(t *testing.T, template *servingv1alpha1.Revision
 	}
 
 	found, err := EnvToMap(container.Env)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 	if !reflect.DeepEqual(expected, found) {
 		t.Fatalf("Env did not match expected %v, found %v", env, found)
 	}
@@ -144,18 +137,14 @@ func testUpdateEnvVarsModify(t *testing.T, revision *servingv1alpha1.RevisionTem
 		"a": "fancy",
 	}
 	err := UpdateEnvVars(revision, env)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 
 	expected := map[string]string{
 		"a": "fancy",
 	}
 
 	found, err := EnvToMap(container.Env)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 	if !reflect.DeepEqual(expected, found) {
 		t.Fatalf("Env did not match expected %v, found %v", env, found)
 	}
@@ -164,17 +153,13 @@ func testUpdateEnvVarsModify(t *testing.T, revision *servingv1alpha1.RevisionTem
 func TestUpdateContainerImage(t *testing.T) {
 	template, _ := getV1alpha1RevisionTemplateWithOldFields()
 	err := UpdateImage(template, "gcr.io/foo/bar:baz")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 	// Verify update is successful or not
 	checkContainerImage(t, template, "gcr.io/foo/bar:baz")
 	// Update template with container image info
 	template.Spec.GetContainer().Image = "docker.io/foo/bar:baz"
 	err = UpdateImage(template, "query.io/foo/bar:baz")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 	// Verify that given image overrides the existing container image
 	checkContainerImage(t, template, "query.io/foo/bar:baz")
 }
@@ -188,17 +173,13 @@ func checkContainerImage(t *testing.T, template *servingv1alpha1.RevisionTemplat
 func TestUpdateContainerPort(t *testing.T) {
 	template, _ := getV1alpha1Config()
 	err := UpdateContainerPort(template, 8888)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 	// Verify update is successful or not
 	checkPortUpdate(t, template, 8888)
 	// update template with container port info
 	template.Spec.Containers[0].Ports[0].ContainerPort = 9090
 	err = UpdateContainerPort(template, 80)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 	// Verify that given port overrides the existing container port
 	checkPortUpdate(t, template, 80)
 }
@@ -228,9 +209,7 @@ func testUpdateEnvVarsBoth(t *testing.T, template *servingv1alpha1.RevisionTempl
 		"b": "boo",
 	}
 	err := UpdateEnvVars(template, env)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 
 	expected := map[string]string{
 		"a": "fancy",
@@ -239,9 +218,7 @@ func testUpdateEnvVarsBoth(t *testing.T, template *servingv1alpha1.RevisionTempl
 	}
 
 	found, err := EnvToMap(container.Env)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 	if !reflect.DeepEqual(expected, found) {
 		t.Fatalf("Env did not match expected %v, found %v", env, found)
 	}

--- a/pkg/serving/revision_template.go
+++ b/pkg/serving/revision_template.go
@@ -29,16 +29,11 @@ func ContainerOfRevisionSpec(revisionSpec *servingv1alpha1.RevisionSpec) (*corev
 	if usesOldV1alpha1ContainerField(revisionSpec) {
 		return revisionSpec.DeprecatedContainer, nil
 	}
-	containers := revisionSpec.Containers
-	if len(containers) == 0 {
+	container := revisionSpec.GetContainer()
+	if container == nil {
 		return nil, fmt.Errorf("internal: no container set in spec.template.spec.containers")
 	}
-	if len(containers) > 1 {
-		return nil, fmt.Errorf("internal: can't extract container for updating environment"+
-			" variables as the configuration contains "+
-			"more than one container (i.e. %d containers)", len(containers))
-	}
-	return &containers[0], nil
+	return container, nil
 }
 
 // =======================================================================================

--- a/pkg/serving/v1alpha1/client_test.go
+++ b/pkg/serving/v1alpha1/client_test.go
@@ -423,8 +423,8 @@ func newRoute(name string) *v1alpha1.Route {
 
 func getServiceEvents(name string) []watch.Event {
 	return []watch.Event{
-		{Type: watch.Added, Object: wait.CreateTestServiceWithConditions(name, corev1.ConditionUnknown, corev1.ConditionUnknown, "")},
-		{Type: watch.Modified, Object: wait.CreateTestServiceWithConditions(name, corev1.ConditionUnknown, corev1.ConditionTrue, "")},
-		{Type: watch.Modified, Object: wait.CreateTestServiceWithConditions(name, corev1.ConditionTrue, corev1.ConditionTrue, "")},
+		{watch.Added, wait.CreateTestServiceWithConditions(name, corev1.ConditionUnknown, corev1.ConditionUnknown, "")},
+		{watch.Modified, wait.CreateTestServiceWithConditions(name, corev1.ConditionUnknown, corev1.ConditionTrue, "")},
+		{watch.Modified, wait.CreateTestServiceWithConditions(name, corev1.ConditionTrue, corev1.ConditionTrue, "")},
 	}
 }

--- a/pkg/serving/v1alpha1/client_test.go
+++ b/pkg/serving/v1alpha1/client_test.go
@@ -423,8 +423,8 @@ func newRoute(name string) *v1alpha1.Route {
 
 func getServiceEvents(name string) []watch.Event {
 	return []watch.Event{
-		{watch.Added, wait.CreateTestServiceWithConditions(name, corev1.ConditionUnknown, corev1.ConditionUnknown, "")},
-		{watch.Modified, wait.CreateTestServiceWithConditions(name, corev1.ConditionUnknown, corev1.ConditionTrue, "")},
-		{watch.Modified, wait.CreateTestServiceWithConditions(name, corev1.ConditionTrue, corev1.ConditionTrue, "")},
+		{Type: watch.Added, Object: wait.CreateTestServiceWithConditions(name, corev1.ConditionUnknown, corev1.ConditionUnknown, "")},
+		{Type: watch.Modified, Object: wait.CreateTestServiceWithConditions(name, corev1.ConditionUnknown, corev1.ConditionTrue, "")},
+		{Type: watch.Modified, Object: wait.CreateTestServiceWithConditions(name, corev1.ConditionTrue, corev1.ConditionTrue, "")},
 	}
 }

--- a/test/e2e/service_options_test.go
+++ b/test/e2e/service_options_test.go
@@ -47,12 +47,12 @@ func TestServiceOptions(t *testing.T) {
 	})
 
 	t.Run("update concurrency options with invalid value for hello service and returns no change", func(t *testing.T) {
-		testServiceUpdate(t, k, "hello", []string{"--concurrency-limit", "-1", "--concurrency-target", "0"})
+		test.serviceUpdate(t, "hello", []string{"--concurrency-limit", "-1", "--concurrency-target", "0"})
 	})
 
 	t.Run("returns steady concurrency options for hello service", func(t *testing.T) {
-		testServiceDescribeConcurrencyLimit(t, k, "hello", "300")
-		testServiceDescribeConcurrencyTarget(t, k, "hello", "300")
+		test.serviceDescribeConcurrencyLimit(t, "hello", "300")
+		test.serviceDescribeConcurrencyTarget(t, "hello", "300")
 	})
 
 	t.Run("delete hello service and returns no error", func(t *testing.T) {

--- a/test/e2e/service_options_test.go
+++ b/test/e2e/service_options_test.go
@@ -46,8 +46,8 @@ func TestServiceOptions(t *testing.T) {
 		test.serviceDescribeConcurrencyLimit(t, "hello", "300")
 	})
 
-	t.Run("update concurrency options with invalid value for hello service and returns no change", func(t *testing.T) {
-		test.serviceUpdate(t, "hello", []string{"--concurrency-limit", "-1", "--concurrency-target", "0"})
+	t.Run("update concurrency options with invalid value for hello service and returns error", func(t *testing.T) {
+		test.serviceUpdateWithInvalidValue(t, "hello", []string{"--concurrency-limit", "-1", "--concurrency-target", "0"})
 	})
 
 	t.Run("returns steady concurrency options for hello service", func(t *testing.T) {
@@ -85,4 +85,11 @@ func (test *e2eTest) serviceDescribeConcurrencyTarget(t *testing.T, serviceName,
 
 	expectedOutput := fmt.Sprintf("autoscaling.knative.dev/target: \"%s\"", concurrencyTarget)
 	assert.Check(t, util.ContainsAll(out, expectedOutput))
+}
+
+func (test *e2eTest) serviceUpdateWithInvalidValue(t *testing.T, serviceName string, args []string) {
+	out, err := test.kn.RunWithOpts(append([]string{"service", "update", serviceName}, args...), runOpts{NoNamespace: false})
+	assert.NilError(t, err)
+
+	assert.Check(t, util.ContainsAll(out, "Invalid"))
 }

--- a/test/e2e/service_options_test.go
+++ b/test/e2e/service_options_test.go
@@ -46,6 +46,15 @@ func TestServiceOptions(t *testing.T) {
 		test.serviceDescribeConcurrencyLimit(t, "hello", "300")
 	})
 
+	t.Run("update concurrency options with invalid value for hello service and returns no change", func(t *testing.T) {
+		testServiceUpdate(t, k, "hello", []string{"--concurrency-limit", "-1", "--concurrency-target", "0"})
+	})
+
+	t.Run("returns steady concurrency options for hello service", func(t *testing.T) {
+		testServiceDescribeConcurrencyLimit(t, k, "hello", "300")
+		testServiceDescribeConcurrencyTarget(t, k, "hello", "300")
+	})
+
 	t.Run("delete hello service and returns no error", func(t *testing.T) {
 		test.serviceDelete(t, "hello")
 	})

--- a/test/e2e/service_options_test.go
+++ b/test/e2e/service_options_test.go
@@ -88,8 +88,6 @@ func (test *e2eTest) serviceDescribeConcurrencyTarget(t *testing.T, serviceName,
 }
 
 func (test *e2eTest) serviceUpdateWithInvalidValue(t *testing.T, serviceName string, args []string) {
-	out, err := test.kn.RunWithOpts(append([]string{"service", "update", serviceName}, args...), runOpts{NoNamespace: false})
-	assert.NilError(t, err)
-
-	assert.Check(t, util.ContainsAll(out, "Invalid"))
+	_, err := test.kn.RunWithOpts(append([]string{"service", "update", serviceName}, args...), runOpts{NoNamespace: false, AllowError: true})
+	assert.ErrorContains(t, err, "Invalid")
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -77,9 +77,9 @@ github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1
 github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1/fake
 github.com/knative/serving/pkg/apis/serving
 github.com/knative/serving/pkg/apis/serving/v1alpha1
+github.com/knative/serving/pkg/apis/autoscaling
 github.com/knative/serving/pkg/apis/serving/v1beta1
 github.com/knative/serving/pkg/client/clientset/versioned/scheme
-github.com/knative/serving/pkg/apis/autoscaling
 github.com/knative/serving/pkg/apis/networking
 github.com/knative/serving/pkg/apis/networking/v1alpha1
 github.com/knative/serving/pkg/apis/config


### PR DESCRIPTION
I would like to do more contributions on knative/client but currently some large PRs are under reviewing. Therefore, I decided to read and refactor current code bases without bothering core contributors. If it's too much troubles, just let me know!

## Proposed Changes

* Validate the scale and container concurrency options and returns error when invalid value is found.
* Add unit/e2e tests for handling invalid user inputs
* Use GetContainer method for extracting container spec from revision template
* Use constant values for annotation keys
* Add missing unit test for TestUpdateContainerImage method

**Release Note**

```release-note
None
```
