### PR TITLE
Specify names on service update and generate names client-side.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -38,6 +38,10 @@
 | `kn service list` lists services sorted by alphabetical order
 | https://github.com/knative/client/pull/330[#330]
 
+| 🎁
+| Add --revision-name flag
+| https://github.com/knative/client/pull/282[#282]
+
 |===
 
 ## v0.2.0 (2019-07-10)

--- a/cmd/kn/main.go
+++ b/cmd/kn/main.go
@@ -16,7 +16,9 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
+	"time"
 
 	"github.com/knative/client/pkg/kn/core"
 	"github.com/spf13/viper"
@@ -30,6 +32,7 @@ var err error
 
 func main() {
 	defer cleanup()
+	rand.Seed(time.Now().UnixNano())
 	err = core.NewDefaultKnCommand().Execute()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -51,11 +51,11 @@ kn service create NAME --image IMAGE [flags]
       --limits-memory string     The limits on the requested memory (e.g., 1024Mi).
       --max-scale int            Maximal number of replicas.
       --min-scale int            Minimal number of replicas.
-      --name string              The revision name prefix to set. Implies --generate-revision-name=false
   -n, --namespace string         List the requested object(s) in given namespace.
   -p, --port int32               The port where application listens on.
       --requests-cpu string      The requested CPU (e.g., 250m).
       --requests-memory string   The requested memory (e.g., 64Mi).
+      --revision-name string     The revision name to set. If you don't add the service name as a prefix, it'll be added for you.
       --wait-timeout int         Seconds to wait before giving up on waiting for service to be ready. (default 60)
 ```
 

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -55,7 +55,7 @@ kn service create NAME --image IMAGE [flags]
   -p, --port int32               The port where application listens on.
       --requests-cpu string      The requested CPU (e.g., 250m).
       --requests-memory string   The requested memory (e.g., 64Mi).
-      --revision-name string     The revision name to set. Must start with the service name and a dash as a prefix. Accepts golang templates, allowing {{.Service}} for the service name, {{.Generation}} for the generation, and {{.Random [n]}} for n random consonants. (default "{{.Service}}-{{.Random 5}}-{{.Generation}}")
+      --revision-name string     The revision name to set. Must start with the service name and a dash as a prefix. Empty revision name will result in the server generating a name for the revision. Accepts golang templates, allowing {{.Service}} for the service name, {{.Generation}} for the generation, and {{.Random [n]}} for n random consonants. (default "{{.Service}}-{{.Random 5}}-{{.Generation}}")
       --wait-timeout int         Seconds to wait before giving up on waiting for service to be ready. (default 60)
 ```
 

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -51,6 +51,7 @@ kn service create NAME --image IMAGE [flags]
       --limits-memory string     The limits on the requested memory (e.g., 1024Mi).
       --max-scale int            Maximal number of replicas.
       --min-scale int            Minimal number of replicas.
+      --name string              The revision name prefix to set. Implies --generate-revision-name=false
   -n, --namespace string         List the requested object(s) in given namespace.
   -p, --port int32               The port where application listens on.
       --requests-cpu string      The requested CPU (e.g., 250m).

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -55,7 +55,7 @@ kn service create NAME --image IMAGE [flags]
   -p, --port int32               The port where application listens on.
       --requests-cpu string      The requested CPU (e.g., 250m).
       --requests-memory string   The requested memory (e.g., 64Mi).
-      --revision-name string     The revision name to set. If you don't add the service name as a prefix, it'll be added for you.
+      --revision-name string     The revision name to set. Must start with the service name and a dash as a prefix. Accepts golang templates, allowing {{.Service}} for the service name, {{.Generation}} for the generation, and {{.Random [n]}} for n random consonants. (default "{{.Service}}-{{.Random 5}}-{{.Generation}}")
       --wait-timeout int         Seconds to wait before giving up on waiting for service to be ready. (default 60)
 ```
 

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -39,11 +39,11 @@ kn service update NAME [flags]
       --limits-memory string     The limits on the requested memory (e.g., 1024Mi).
       --max-scale int            Maximal number of replicas.
       --min-scale int            Minimal number of replicas.
-      --name string              The revision name prefix to set. Implies --generate-revision-name=false
   -n, --namespace string         List the requested object(s) in given namespace.
   -p, --port int32               The port where application listens on.
       --requests-cpu string      The requested CPU (e.g., 250m).
       --requests-memory string   The requested memory (e.g., 64Mi).
+      --revision-name string     The revision name to set. If you don't add the service name as a prefix, it'll be added for you.
       --wait-timeout int         Seconds to wait before giving up on waiting for service to be ready. (default 60)
 ```
 

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -42,7 +42,7 @@ kn service update NAME [flags]
   -p, --port int32               The port where application listens on.
       --requests-cpu string      The requested CPU (e.g., 250m).
       --requests-memory string   The requested memory (e.g., 64Mi).
-      --revision-name string     The revision name to set. Must start with the service name and a dash as a prefix. Accepts golang templates, allowing {{.Service}} for the service name, {{.Generation}} for the generation, and {{.Random [n]}} for n random consonants. (default "{{.Service}}-{{.Random 5}}-{{.Generation}}")
+      --revision-name string     The revision name to set. Must start with the service name and a dash as a prefix. Empty revision name will result in the server generating a name for the revision. Accepts golang templates, allowing {{.Service}} for the service name, {{.Generation}} for the generation, and {{.Random [n]}} for n random consonants. (default "{{.Service}}-{{.Random 5}}-{{.Generation}}")
       --wait-timeout int         Seconds to wait before giving up on waiting for service to be ready. (default 60)
 ```
 

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -31,6 +31,7 @@ kn service update NAME [flags]
       --concurrency-limit int    Hard Limit of concurrent requests to be processed by a single replica.
       --concurrency-target int   Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to --concurrency-limit when given.
   -e, --env stringArray          Environment variable to set. NAME=value; you may provide this flag any number of times to set multiple environment variables. To unset, specify the environment variable name followed by a "-" (e.g., NAME-).
+      --generate-revision-name   Automatically generate a revision name client-side. If false, the revision name is cleared. (default true)
   -h, --help                     help for update
       --image string             Image to run.
   -l, --label stringArray        Service label to set. name=value; you may provide this flag any number of times to set multiple labels. To unset, specify the label name followed by a "-" (e.g., name-).
@@ -38,6 +39,7 @@ kn service update NAME [flags]
       --limits-memory string     The limits on the requested memory (e.g., 1024Mi).
       --max-scale int            Maximal number of replicas.
       --min-scale int            Minimal number of replicas.
+      --name string              The revision name prefix to set. Implies --generate-revision-name=false
   -n, --namespace string         List the requested object(s) in given namespace.
   -p, --port int32               The port where application listens on.
       --requests-cpu string      The requested CPU (e.g., 250m).

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -31,7 +31,6 @@ kn service update NAME [flags]
       --concurrency-limit int    Hard Limit of concurrent requests to be processed by a single replica.
       --concurrency-target int   Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to --concurrency-limit when given.
   -e, --env stringArray          Environment variable to set. NAME=value; you may provide this flag any number of times to set multiple environment variables. To unset, specify the environment variable name followed by a "-" (e.g., NAME-).
-      --generate-revision-name   Automatically generate a revision name client-side. If false, the revision name is cleared. (default true)
   -h, --help                     help for update
       --image string             Image to run.
   -l, --label stringArray        Service label to set. name=value; you may provide this flag any number of times to set multiple labels. To unset, specify the label name followed by a "-" (e.g., name-).
@@ -43,7 +42,7 @@ kn service update NAME [flags]
   -p, --port int32               The port where application listens on.
       --requests-cpu string      The requested CPU (e.g., 250m).
       --requests-memory string   The requested memory (e.g., 64Mi).
-      --revision-name string     The revision name to set. If you don't add the service name as a prefix, it'll be added for you.
+      --revision-name string     The revision name to set. Must start with the service name and a dash as a prefix. Accepts golang templates, allowing {{.Service}} for the service name, {{.Generation}} for the generation, and {{.Random [n]}} for n random consonants. (default "{{.Service}}-{{.Random 5}}-{{.Generation}}")
       --wait-timeout int         Seconds to wait before giving up on waiting for service to be ready. (default 60)
 ```
 

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -96,6 +96,7 @@ func (p *ConfigurationEditFlags) addSharedFlags(command *cobra.Command) {
 	p.markFlagMakesRevision("label")
 	command.Flags().StringVar(&p.RevisionName, "revision-name", "{{.Service}}-{{.Random 5}}-{{.Generation}}",
 		"The revision name to set. Must start with the service name and a dash as a prefix. "+
+			"Empty revision name will result in the server generating a name for the revision. "+
 			"Accepts golang templates, allowing {{.Service}} for the service name, "+
 			"{{.Generation}} for the generation, and {{.Random [n]}} for n random consonants.")
 	p.markFlagMakesRevision("revision-name")

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -150,7 +150,9 @@ func (p *ConfigurationEditFlags) Apply(
 	}
 	if anyMutation {
 		err = servinglib.UpdateName(template, name)
-		if err != nil {
+		if err == servinglib.ApiTooOldError && !cmd.Flags().Changed("revision-name") {
+			// pass
+		} else if err != nil {
 			return err
 		}
 	}

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -53,7 +53,7 @@ type ResourceFlags struct {
 	Memory string
 }
 
-func (p *ConfigurationEditFlags) AddSharedFlags(command *cobra.Command) {
+func (p *ConfigurationEditFlags) addSharedFlags(command *cobra.Command) {
 	command.Flags().StringVar(&p.Image, "image", "", "Image to run.")
 	p.flags = append(p.flags, "image")
 	command.Flags().StringArrayVarP(&p.Env, "env", "e", []string{},
@@ -92,21 +92,25 @@ func (p *ConfigurationEditFlags) AddSharedFlags(command *cobra.Command) {
 		"The revision name to set. If you don't add the service name as a prefix, it'll be added for you.")
 	p.flags = append(p.flags, "revision-name")
 }
+
+// AddUpdateFlags adds the flags specific to update.
 func (p *ConfigurationEditFlags) AddUpdateFlags(command *cobra.Command) {
-	p.AddSharedFlags(command)
+	p.addSharedFlags(command)
 
 	command.Flags().BoolVar(&p.GenerateRevisionName, "generate-revision-name", true,
 		"Automatically generate a revision name client-side. If false, the revision name is cleared.")
 	p.flags = append(p.flags, "generate-revision-name")
 }
 
+// AddCreateFlags adds the flags specific to create
 func (p *ConfigurationEditFlags) AddCreateFlags(command *cobra.Command) {
-	p.AddSharedFlags(command)
+	p.addSharedFlags(command)
 	command.Flags().BoolVar(&p.ForceCreate, "force", false,
 		"Create service forcefully, replaces existing service if any.")
 	command.MarkFlagRequired("image")
 }
 
+// Apply mutates the given service according to the flags in the command.
 func (p *ConfigurationEditFlags) Apply(
 	service *servingv1alpha1.Service,
 	cmd *cobra.Command) error {
@@ -249,6 +253,8 @@ func (p *ConfigurationEditFlags) computeResources(resourceFlags ResourceFlags) (
 	return resourceList, nil
 }
 
+// AnyMutation returns tue if there are any revision template mutations in the
+// command.
 func (p *ConfigurationEditFlags) AnyMutation(cmd *cobra.Command) bool {
 	for _, flag := range p.flags {
 		if cmd.Flags().Changed(flag) {

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -256,7 +256,7 @@ func (p *ConfigurationEditFlags) computeResources(resourceFlags ResourceFlags) (
 	return resourceList, nil
 }
 
-// AnyMutation returns tue if there are any revision template mutations in the
+// AnyMutation returns true if there are any revision template mutations in the
 // command.
 func (p *ConfigurationEditFlags) AnyMutation(cmd *cobra.Command) bool {
 	for _, flag := range p.flags {

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -58,6 +58,7 @@ func (p *ConfigurationEditFlags) markFlagMakesRevision(f string) {
 	p.flags = append(p.flags, f)
 }
 
+// addSharedFlags adds the flags common between create & update.
 func (p *ConfigurationEditFlags) addSharedFlags(command *cobra.Command) {
 	command.Flags().StringVar(&p.Image, "image", "", "Image to run.")
 	p.markFlagMakesRevision("image")
@@ -94,8 +95,9 @@ func (p *ConfigurationEditFlags) addSharedFlags(command *cobra.Command) {
 			"To unset, specify the label name followed by a \"-\" (e.g., name-).")
 	p.markFlagMakesRevision("label")
 	command.Flags().StringVar(&p.RevisionName, "revision-name", "{{.Service}}-{{.Random 5}}-{{.Generation}}",
-
-		"The revision name to set. If you don't add the service name as a prefix, it'll be added for you.")
+		"The revision name to set. Must start with the service name and a dash as a prefix. "+
+			"Accepts golang templates, allowing {{.Service}} for the service name, "+
+			"{{.Generation}} for the generation, and {{.Random [n]}} for n random consonants.")
 	p.markFlagMakesRevision("revision-name")
 }
 
@@ -139,7 +141,6 @@ func (p *ConfigurationEditFlags) Apply(
 			return err
 		}
 	}
-	anyMutation := p.AnyMutation(cmd)
 
 	name, err := servinglib.GenerateRevisionName(p.RevisionName, service)
 	if err != nil {

--- a/pkg/kn/commands/service/service_update_test.go
+++ b/pkg/kn/commands/service/service_update_test.go
@@ -168,7 +168,7 @@ func TestServiceUpdateImage(t *testing.T) {
 }
 
 func TestServiceUpdateRevisionNameExplicit(t *testing.T) {
-	orig := newEmptyServiceBeta()
+	orig := newEmptyServiceBetaAPIStyle()
 
 	template, err := servinglib.RevisionTemplateOfService(orig)
 	if err != nil {
@@ -191,7 +191,7 @@ func TestServiceUpdateRevisionNameExplicit(t *testing.T) {
 }
 
 func TestServiceUpdateRevisionNameGenerated(t *testing.T) {
-	orig := newEmptyServiceBeta()
+	orig := newEmptyServiceBetaAPIStyle()
 
 	template, err := servinglib.RevisionTemplateOfService(orig)
 	if err != nil {
@@ -215,7 +215,7 @@ func TestServiceUpdateRevisionNameGenerated(t *testing.T) {
 }
 
 func TestServiceUpdateRevisionNameCleared(t *testing.T) {
-	orig := newEmptyServiceBeta()
+	orig := newEmptyServiceBetaAPIStyle()
 
 	template, err := servinglib.RevisionTemplateOfService(orig)
 	if err != nil {
@@ -237,7 +237,7 @@ func TestServiceUpdateRevisionNameCleared(t *testing.T) {
 }
 
 func TestServiceUpdateRevisionNameNoMutationNoChange(t *testing.T) {
-	orig := newEmptyServiceBeta()
+	orig := newEmptyServiceBetaAPIStyle()
 
 	template, err := servinglib.RevisionTemplateOfService(orig)
 	if err != nil {
@@ -549,7 +549,7 @@ func newEmptyService() *v1alpha1.Service {
 	}
 }
 
-func newEmptyServiceBeta() *v1alpha1.Service {
+func newEmptyServiceBetaAPIStyle() *v1alpha1.Service {
 	ret := &v1alpha1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",

--- a/pkg/kn/commands/service/service_update_test.go
+++ b/pkg/kn/commands/service/service_update_test.go
@@ -167,7 +167,7 @@ func TestServiceUpdateImage(t *testing.T) {
 }
 
 func TestServiceUpdateRevisionNameExplicit(t *testing.T) {
-	orig := newEmptyService()
+	orig := newEmptyServiceBeta()
 
 	template, err := servinglib.RevisionTemplateOfService(orig)
 	if err != nil {
@@ -202,7 +202,7 @@ func TestServiceUpdateRevisionNameExplicit(t *testing.T) {
 }
 
 func TestServiceUpdateRevisionNameGenerated(t *testing.T) {
-	orig := newEmptyService()
+	orig := newEmptyServiceBeta()
 
 	template, err := servinglib.RevisionTemplateOfService(orig)
 	if err != nil {
@@ -226,7 +226,7 @@ func TestServiceUpdateRevisionNameGenerated(t *testing.T) {
 }
 
 func TestServiceUpdateRevisionNameCleared(t *testing.T) {
-	orig := newEmptyService()
+	orig := newEmptyServiceBeta()
 
 	template, err := servinglib.RevisionTemplateOfService(orig)
 	if err != nil {
@@ -248,7 +248,7 @@ func TestServiceUpdateRevisionNameCleared(t *testing.T) {
 }
 
 func TestServiceUpdateRevisionNameNoMutationNoChange(t *testing.T) {
-	orig := newEmptyService()
+	orig := newEmptyServiceBeta()
 
 	template, err := servinglib.RevisionTemplateOfService(orig)
 	if err != nil {
@@ -558,6 +558,23 @@ func newEmptyService() *v1alpha1.Service {
 			},
 		},
 	}
+}
+
+func newEmptyServiceBeta() *v1alpha1.Service {
+	ret := &v1alpha1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "knative.dev/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.ServiceSpec{},
+	}
+	ret.Spec.Template = &v1alpha1.RevisionTemplateSpec{}
+	ret.Spec.Template.Spec.Containers = []corev1.Container{{}}
+	return ret
 }
 
 func createMockServiceWithResources(t *testing.T, requestCPU, requestMemory, limitsCPU, limitsMemory string) *v1alpha1.Service {

--- a/pkg/kn/commands/service/service_update_test.go
+++ b/pkg/kn/commands/service/service_update_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"gotest.tools/assert"
+	"gotest.tools/assert/cmp"
 
 	"github.com/knative/client/pkg/kn/commands"
 	servinglib "github.com/knative/client/pkg/serving"
@@ -176,20 +177,8 @@ func TestServiceUpdateRevisionNameExplicit(t *testing.T) {
 
 	template.Name = "foo-asdf"
 
-	// Test prefix added by command
-	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "--revision-name", "xyzzy", "--namespace", "bar", "--async"}, false)
-	assert.NilError(t, err)
-	if !action.Matches("update", "services") {
-		t.Fatalf("Bad action %v", action)
-	}
-
-	template, err = servinglib.RevisionTemplateOfService(updated)
-	assert.NilError(t, err)
-	assert.Equal(t, "foo-xyzzy", template.Name)
-
 	// Test user provides prefix
-	action, updated, _, err = fakeServiceUpdate(orig, []string{
+	action, updated, _, err := fakeServiceUpdate(orig, []string{
 		"service", "update", "foo", "--revision-name", "foo-dogs", "--namespace", "bar", "--async"}, false)
 	assert.NilError(t, err)
 	if !action.Matches("update", "services") {
@@ -235,7 +224,7 @@ func TestServiceUpdateRevisionNameCleared(t *testing.T) {
 	template.Name = "foo-asdf"
 
 	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "--image", "gcr.io/foo/quux:xyzzy", "--namespace", "bar", "--generate-revision-name=false", "--async"}, false)
+		"service", "update", "foo", "--image", "gcr.io/foo/quux:xyzzy", "--namespace", "bar", "--revision-name=", "--async"}, false)
 
 	assert.NilError(t, err)
 	if !action.Matches("update", "services") {
@@ -244,7 +233,7 @@ func TestServiceUpdateRevisionNameCleared(t *testing.T) {
 
 	template, err = servinglib.RevisionTemplateOfService(updated)
 	assert.NilError(t, err)
-	assert.Assert(t, template.Name == "")
+	assert.Assert(t, cmp.Equal(template.Name, ""))
 }
 
 func TestServiceUpdateRevisionNameNoMutationNoChange(t *testing.T) {

--- a/pkg/serving/config_changes.go
+++ b/pkg/serving/config_changes.go
@@ -92,7 +92,7 @@ func UpdateAnnotation(template *servingv1alpha1.RevisionTemplateSpec, annotation
 	return nil
 }
 
-// Update the name
+// UpdateName updates the revision name.
 func UpdateName(template *servingv1alpha1.RevisionTemplateSpec, name string) error {
 	template.Name = name
 	return nil

--- a/pkg/serving/config_changes.go
+++ b/pkg/serving/config_changes.go
@@ -92,6 +92,12 @@ func UpdateAnnotation(template *servingv1alpha1.RevisionTemplateSpec, annotation
 	return nil
 }
 
+// Update the name
+func UpdateName(template *servingv1alpha1.RevisionTemplateSpec, name string) error {
+	template.Name = name
+	return nil
+}
+
 // EnvToMap is an utility function to translate between the API list form of env vars, and the
 // more convenient map form.
 func EnvToMap(vars []corev1.EnvVar) (map[string]string, error) {

--- a/pkg/serving/config_changes.go
+++ b/pkg/serving/config_changes.go
@@ -93,7 +93,7 @@ func UpdateAnnotation(template *servingv1alpha1.RevisionTemplateSpec, annotation
 	return nil
 }
 
-var ApiTooOldError = errors.New("The service is using too old of an API format for the operation")
+var ApiTooOldError = errors.New("the service is using too old of an API format for the operation")
 
 // UpdateName updates the revision name.
 func UpdateName(template *servingv1alpha1.RevisionTemplateSpec, name string) error {

--- a/pkg/serving/config_changes.go
+++ b/pkg/serving/config_changes.go
@@ -16,6 +16,7 @@ package serving
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -92,8 +93,13 @@ func UpdateAnnotation(template *servingv1alpha1.RevisionTemplateSpec, annotation
 	return nil
 }
 
+var ApiTooOldError = errors.New("The service is using too old of an API format for the operation")
+
 // UpdateName updates the revision name.
 func UpdateName(template *servingv1alpha1.RevisionTemplateSpec, name string) error {
+	if template.Spec.DeprecatedContainer != nil {
+		return ApiTooOldError
+	}
 	template.Name = name
 	return nil
 }

--- a/pkg/serving/config_changes_test.go
+++ b/pkg/serving/config_changes_test.go
@@ -253,6 +253,13 @@ func TestUpdateContainerPort(t *testing.T) {
 	checkPortUpdate(t, template, 80)
 }
 
+func TestUpdateName(t *testing.T) {
+	template, _ := getV1alpha1Config()
+	err := UpdateName(template, "foo-asdf")
+	assert.NilError(t, err)
+	assert.Equal(t, "foo-asdf", template.Name)
+}
+
 func checkPortUpdate(t *testing.T, template *servingv1alpha1.RevisionTemplateSpec, port int32) {
 	if template.Spec.GetContainer().Ports[0].ContainerPort != port {
 		t.Error("Failed to update the container port")

--- a/pkg/serving/service.go
+++ b/pkg/serving/service.go
@@ -73,7 +73,19 @@ func GenerateRevisionName(nameTempl string, service *servingv1alpha1.Service) (s
 	}
 	buf := new(bytes.Buffer)
 	err = templ.Execute(buf, context)
-	return buf.String(), err
+	if err != nil {
+		return "", err
+	}
+	res := buf.String()
+	// Empty is ok.
+	if res == "" {
+		return res, nil
+	}
+	prefix := service.Name + "-"
+	if !strings.HasPrefix(res, prefix) {
+		res = prefix + res
+	}
+	return res, nil
 }
 
 func getConfiguration(service *servingv1alpha1.Service) (*servingv1alpha1.ConfigurationSpec, error) {

--- a/pkg/serving/service.go
+++ b/pkg/serving/service.go
@@ -16,6 +16,9 @@ package serving
 
 import (
 	"errors"
+	"fmt"
+	"math/rand"
+	"strings"
 
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 )
@@ -36,6 +39,21 @@ func RevisionTemplateOfService(service *servingv1alpha1.Service) (*servingv1alph
 		return nil, err
 	}
 	return config.DeprecatedRevisionTemplate, nil
+}
+
+var charChoices = []string{
+	"b", "c", "d", "f", "g", "h", "j", "k", "l", "m", "n", "p", "q", "r", "s", "t", "v", "w", "x",
+	"y", "z",
+}
+
+func GenerateRevisionName(service *servingv1alpha1.Service) string {
+	prefix := service.Name
+	generation := service.Generation + 1
+	chars := []string{}
+	for i := 0; i < 5; i++ {
+		chars = append(chars, charChoices[rand.Int()%len(charChoices)])
+	}
+	return fmt.Sprintf("%s-%s-%d", prefix, strings.Join(chars, ""), generation)
 }
 
 func getConfiguration(service *servingv1alpha1.Service) (*servingv1alpha1.ConfigurationSpec, error) {

--- a/pkg/serving/service.go
+++ b/pkg/serving/service.go
@@ -46,6 +46,8 @@ var charChoices = []string{
 	"y", "z",
 }
 
+// GenerateRevisionName returns an automatically-generated name suitable for the
+// next revision of the given service.
 func GenerateRevisionName(service *servingv1alpha1.Service) string {
 	prefix := service.Name
 	generation := service.Generation + 1

--- a/pkg/serving/service_test.go
+++ b/pkg/serving/service_test.go
@@ -40,6 +40,9 @@ func TestGenerateName(t *testing.T) {
 		{"foo-asdf", "foo-asdf", ""},
 		{"{{.Bad}}", "", "can't evaluate field Bad"},
 		{"{{.Service}}-{{.Random 5}}", "foo-" + someRandomChars[0:5], ""},
+		{"", "", ""},
+		{"andrew", "foo-andrew", ""},
+		{"{{.Random 5}}", "foo-" + someRandomChars[0:5], ""},
 	}
 	for _, c := range cases {
 		rand.Seed(1)

--- a/pkg/serving/service_test.go
+++ b/pkg/serving/service_test.go
@@ -1,0 +1,53 @@
+// Copyright © 2018 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serving
+
+import (
+	"math/rand"
+	"testing"
+
+	"gotest.tools/assert"
+
+	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+)
+
+type generateNameTest struct {
+	templ  string
+	result string
+	err    string
+}
+
+func TestGenerateName(t *testing.T) {
+	rand.Seed(1)
+	someRandomChars := (&revisionTemplContext{}).Random(20)
+	service := &servingv1alpha1.Service{}
+	service.Name = "foo"
+	service.Generation = 3
+	cases := []generateNameTest{
+		{"{{.Service}}-v-{{.Generation}}", "foo-v-4", ""},
+		{"foo-asdf", "foo-asdf", ""},
+		{"{{.Bad}}", "", "can't evaluate field Bad"},
+		{"{{.Service}}-{{.Random 5}}", "foo-" + someRandomChars[0:5], ""},
+	}
+	for _, c := range cases {
+		rand.Seed(1)
+		name, err := GenerateRevisionName(c.templ, service)
+		if c.err != "" {
+			assert.ErrorContains(t, err, c.err)
+		} else {
+			assert.Equal(t, name, c.result)
+		}
+	}
+}

--- a/pkg/serving/service_test.go
+++ b/pkg/serving/service_test.go
@@ -51,3 +51,30 @@ func TestGenerateName(t *testing.T) {
 		}
 	}
 }
+
+func TestRevisionTemplateOfServiceNewStyle(t *testing.T) {
+	service := &servingv1alpha1.Service{}
+	service.Name = "foo"
+	template := &servingv1alpha1.RevisionTemplateSpec{}
+	service.Spec.Template = template
+	got, err := RevisionTemplateOfService(service)
+	assert.NilError(t, err)
+	assert.Equal(t, got, template)
+}
+
+func TestRevisionTemplateOfServiceOldStyle(t *testing.T) {
+	service := &servingv1alpha1.Service{}
+	service.Name = "foo"
+	template := &servingv1alpha1.RevisionTemplateSpec{}
+	service.Spec.DeprecatedRunLatest = &servingv1alpha1.RunLatestType{}
+	service.Spec.DeprecatedRunLatest.Configuration.DeprecatedRevisionTemplate = template
+	got, err := RevisionTemplateOfService(service)
+	assert.NilError(t, err)
+	assert.Equal(t, got, template)
+}
+
+func TestRevisionTemplateOfServiceError(t *testing.T) {
+	service := &servingv1alpha1.Service{}
+	_, err := RevisionTemplateOfService(service)
+	assert.ErrorContains(t, err, "does not specify")
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #277 #276 

## Proposed Changes

* `--revision-name` flag allows setting revision names in service update. If you don't provide the service name as a prefix, it'll get auto-added for you.
* `--generate-revision-name` flag (default TRUE) makes revision names client side by default.

Whether to include the generation is up for discussion. Otherwise this is substantially similar to the server-side generateName(), up to and including our lack of vowels.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
