### PR TITLE
Add E2E tests for Service, Revision, Route

### DIFF
--- a/test/e2e/revision_workflow_test.go
+++ b/test/e2e/revision_workflow_test.go
@@ -77,7 +77,7 @@ func (test *e2eTest) revisionDescribeWithPrintFlags(t *testing.T, serviceName st
 	assert.NilError(t, err)
 
 	expectedName := fmt.Sprintf("revision.serving.knative.dev/%s", revName)
-	assert.Check(t, strings.Contains(out, expectedName))
+	assert.Equal(t, strings.TrimSpace(out), expectedName)
 }
 
 func (test *e2eTest) findRevision(t *testing.T, serviceName string) string {


### PR DESCRIPTION
* service, revision, route describe and describe with print flags
* route list with print flags
* service create for a duplicate service

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* increase test coverage via new E2E tests

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
