### PR TITLE
feature(testing): Introduce a mock implementation for KnClient

### DIFF
--- a/pkg/kn/commands/service/service_create_mock_test.go
+++ b/pkg/kn/commands/service/service_create_mock_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/knative/client/pkg/kn/commands"
 	knclient "github.com/knative/client/pkg/serving/v1alpha1"
-	mock "github.com/knative/client/pkg/serving/v1alpha1_test"
 
 	"github.com/knative/client/pkg/util"
 )

--- a/pkg/kn/commands/service/service_create_mock_test.go
+++ b/pkg/kn/commands/service/service_create_mock_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/knative/client/pkg/kn/commands"
 	knclient "github.com/knative/client/pkg/serving/v1alpha1"
+	mock "github.com/knative/client/pkg/serving/v1alpha1_test"
 
 	"github.com/knative/client/pkg/util"
 )

--- a/pkg/kn/commands/service/service_create_mock_test.go
+++ b/pkg/kn/commands/service/service_create_mock_test.go
@@ -1,0 +1,79 @@
+// Copyright © 2019 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/knative/pkg/apis"
+	"gotest.tools/assert"
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+
+	"github.com/knative/client/pkg/kn/commands"
+	knclient "github.com/knative/client/pkg/serving/v1alpha1"
+
+	"github.com/knative/client/pkg/util"
+)
+
+func TestServiceCreateImageMock(t *testing.T) {
+
+	// New mock client
+	client := knclient.NewMockKnClient(t)
+
+	// Recording:
+	r := client.Recorder()
+	// Check for existing service --> no
+	r.GetService("foo", nil, errors.NewNotFound(v1alpha1.Resource("service"), "foo"))
+	// Create service (don't validate given service --> "Any()" arg is allowed)
+	r.CreateService(knclient.Any(), nil)
+	// Wait for service to become ready
+	r.WaitForService("foo", knclient.Any(), nil)
+	// Get for showing the URL
+	r.GetService("foo", getServiceWithUrl("foo", "http://foo.example.com"), nil)
+
+	// Testing:
+	output, err := executeCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz")
+	assert.NilError(t, err)
+	assert.Assert(t, util.ContainsAll(output, "created", "foo", "http://foo.example.com", "Waiting"))
+
+	// Validate that all recorded API methods have been called
+	r.Validate()
+}
+
+func getServiceWithUrl(name string, urlName string) *v1alpha1.Service {
+	service := v1alpha1.Service{}
+	url, _ := apis.ParseURL(urlName)
+	service.Status.URL = url
+	service.Name = name
+	return &service
+}
+
+func executeCommand(client knclient.KnClient, args ...string) (string, error) {
+	knParams := &commands.KnParams{}
+
+	output := new(bytes.Buffer)
+	knParams.Output = output
+	knParams.NewClient = func(namespace string) (knclient.KnClient, error) {
+		return client, nil
+	}
+	cmd := NewServiceCommand(knParams)
+	cmd.SetArgs(args)
+	cmd.SetOutput(output)
+	err := cmd.Execute()
+	return output.String(), err
+}

--- a/pkg/kn/commands/testing_helper.go
+++ b/pkg/kn/commands/testing_helper.go
@@ -50,7 +50,7 @@ func CreateTestKnCommand(cmd *cobra.Command, knParams *KnParams) (*cobra.Command
 		return v1alpha1.NewKnServingClient(fakeServing, namespace), nil
 	}
 	knParams.fixedCurrentNamespace = FakeNamespace
-	knCommand := newKnCommand(cmd, knParams)
+	knCommand := NewKnTestCommand(cmd, knParams)
 	return knCommand, fakeServing, buf
 }
 
@@ -88,8 +88,8 @@ func ReadStdout(t *testing.T) string {
 
 // Private
 
-// newKnCommand needed since calling the one in core would cause a import cycle
-func newKnCommand(subCommand *cobra.Command, params *KnParams) *cobra.Command {
+// NewKnTestCommand needed since calling the one in core would cause a import cycle
+func NewKnTestCommand(subCommand *cobra.Command, params *KnParams) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "kn",
 		Short: "Knative client",
@@ -111,7 +111,7 @@ Eventing: Manage event subscriptions and channels. Connect up event sources.`,
 	if params.Output != nil {
 		rootCmd.SetOutput(params.Output)
 	}
-	rootCmd.PersistentFlags().StringVar(&CfgFile, "config", "", "config file (default is $HOME/.kn.yaml)")
+	rootCmd.PersistentFlags().StringVar(&CfgFile, "config", "", "config file (default is $HOME/.kn/config.yaml)")
 	rootCmd.PersistentFlags().StringVar(&params.KubeCfgPath, "kubeconfig", "", "kubectl config file (default is $HOME/.kube/config)")
 
 	rootCmd.Flags().StringVar(&Cfg.PluginsDir, "plugins-dir", "~/.kn/plugins", "kn plugins directory")

--- a/pkg/serving/v1alpha1/client_mock.go
+++ b/pkg/serving/v1alpha1/client_mock.go
@@ -126,7 +126,7 @@ func (c *MockKnClient) GetService(name string) (*v1alpha1.Service, error) {
 }
 
 // List services
-func (r *Recorder) ListServices(opts []interface{}, serviceList *v1alpha1.Service, err error) *Recorder {
+func (r *Recorder) ListServices(opts interface{}, serviceList *v1alpha1.ServiceList, err error) *Recorder {
 	r.add("ListServices", apiMethodCall{[]interface{}{opts}, []interface{}{serviceList, err}})
 	return r
 }
@@ -147,7 +147,6 @@ func (c *MockKnClient) CreateService(service *v1alpha1.Service) error {
 	call := c.getCall("CreateService")
 	c.verifyArgs(call, service)
 	return errorOrNil(call.result[0])
-
 }
 
 // Update the given service
@@ -189,8 +188,8 @@ func (c *MockKnClient) WaitForService(name string, timeout time.Duration) error 
 }
 
 // Get a revision by name
-func (r *Recorder) GetRevision(name interface{}, err error) *Recorder {
-	r.add("GetRevision", apiMethodCall{[]interface{}{name}, []interface{}{err}})
+func (r *Recorder) GetRevision(name interface{}, revision *v1alpha1.Revision, err error) *Recorder {
+	r.add("GetRevision", apiMethodCall{[]interface{}{name}, []interface{}{revision, err}})
 	return r
 }
 
@@ -202,8 +201,8 @@ func (c *MockKnClient) GetRevision(name string) (*v1alpha1.Revision, error) {
 }
 
 // List revisions
-func (r *Recorder) ListRevisions(opts []interface{}, err error) *Recorder {
-	r.add("ListRevisions", apiMethodCall{[]interface{}{opts}, []interface{}{err}})
+func (r *Recorder) ListRevisions(opts interface{}, revisionList *v1alpha1.RevisionList, err error) *Recorder {
+	r.add("ListRevisions", apiMethodCall{[]interface{}{opts}, []interface{}{revisionList, err}})
 	return r
 }
 
@@ -228,8 +227,8 @@ func (c *MockKnClient) DeleteRevision(name string) error {
 }
 
 // Get a route by its unique name
-func (r *Recorder) GetRoute(name interface{}, err error) *Recorder {
-	r.add("GetRoute", apiMethodCall{[]interface{}{name}, []interface{}{err}})
+func (r *Recorder) GetRoute(name interface{}, route *v1alpha1.Route, err error) *Recorder {
+	r.add("GetRoute", apiMethodCall{[]interface{}{name}, []interface{}{route, err}})
 	return r
 }
 
@@ -241,8 +240,8 @@ func (c *MockKnClient) GetRoute(name string) (*v1alpha1.Route, error) {
 }
 
 // List routes
-func (r *Recorder) ListRoutes(opts []interface{}, err error) *Recorder {
-	r.add("ListRoutes", apiMethodCall{[]interface{}{opts}, []interface{}{err}})
+func (r *Recorder) ListRoutes(opts interface{}, routeList *v1alpha1.RouteList, err error) *Recorder {
+	r.add("ListRoutes", apiMethodCall{[]interface{}{opts}, []interface{}{routeList, err}})
 	return r
 }
 

--- a/pkg/serving/v1alpha1/client_mock.go
+++ b/pkg/serving/v1alpha1/client_mock.go
@@ -58,6 +58,143 @@ func (c *MockKnClient) Recorder() *Recorder {
 	return &c.recorder
 }
 
+// any() can be used in recording to not check for the argument
+func Any() func(t *testing.T, a, b interface{}) {
+	return func(t *testing.T, a, b interface{}) {}
+}
+
+// Get Service
+func (r *Recorder) GetService(name interface{}, service *v1alpha1.Service, err error) {
+	r.add("GetService", apiMethodCall{[]interface{}{name}, []interface{}{service, err}})
+}
+
+func (c *MockKnClient) GetService(name string) (*v1alpha1.Service, error) {
+	call := c.getCall("GetService")
+	c.verifyArgs(call, name)
+	return call.result[0].(*v1alpha1.Service), errorOrNil(call.result[1])
+}
+
+// List services
+func (r *Recorder) ListServices(opts interface{}, serviceList *v1alpha1.ServiceList, err error) {
+	r.add("ListServices", apiMethodCall{[]interface{}{opts}, []interface{}{serviceList, err}})
+}
+
+func (c *MockKnClient) ListServices(opts ...ListConfig) (*v1alpha1.ServiceList, error) {
+	call := c.getCall("ListServices")
+	c.verifyArgs(call, opts)
+	return call.result[0].(*v1alpha1.ServiceList), errorOrNil(call.result[1])
+}
+
+// Create a new service
+func (r *Recorder) CreateService(service interface{}, err error) {
+	r.add("CreateService", apiMethodCall{[]interface{}{service}, []interface{}{err}})
+}
+
+func (c *MockKnClient) CreateService(service *v1alpha1.Service) error {
+	call := c.getCall("CreateService")
+	c.verifyArgs(call, service)
+	return errorOrNil(call.result[0])
+}
+
+// Update the given service
+func (r *Recorder) UpdateService(service interface{}, err error) {
+	r.add("UpdateService", apiMethodCall{[]interface{}{service}, []interface{}{err}})
+}
+
+func (c *MockKnClient) UpdateService(service *v1alpha1.Service) error {
+	call := c.getCall("UpdateService")
+	c.verifyArgs(call, service)
+	return errorOrNil(call.result[0])
+}
+
+// Delete a service by name
+func (r *Recorder) DeleteService(name interface{}, err error) {
+	r.add("DeleteService", apiMethodCall{[]interface{}{name}, []interface{}{err}})
+}
+
+func (c *MockKnClient) DeleteService(name string) error {
+	call := c.getCall("DeleteService")
+	c.verifyArgs(call, name)
+	return errorOrNil(call.result[0])
+}
+
+// Wait for a service to become ready, but not longer than provided timeout
+func (r *Recorder) WaitForService(name interface{}, timeout interface{}, err error) {
+	r.add("WaitForService", apiMethodCall{[]interface{}{name}, []interface{}{err}})
+}
+
+func (c *MockKnClient) WaitForService(name string, timeout time.Duration) error {
+	call := c.getCall("WaitForService")
+	c.verifyArgs(call, name)
+	return errorOrNil(call.result[0])
+}
+
+// Get a revision by name
+func (r *Recorder) GetRevision(name interface{}, revision *v1alpha1.Revision, err error) {
+	r.add("GetRevision", apiMethodCall{[]interface{}{name}, []interface{}{revision, err}})
+}
+
+func (c *MockKnClient) GetRevision(name string) (*v1alpha1.Revision, error) {
+	call := c.getCall("GetRevision")
+	c.verifyArgs(call, name)
+	return call.result[0].(*v1alpha1.Revision), errorOrNil(call.result[1])
+}
+
+// List revisions
+func (r *Recorder) ListRevisions(opts interface{}, revisionList *v1alpha1.RevisionList, err error) {
+	r.add("ListRevisions", apiMethodCall{[]interface{}{opts}, []interface{}{revisionList, err}})
+}
+
+func (c *MockKnClient) ListRevisions(opts ...ListConfig) (*v1alpha1.RevisionList, error) {
+	call := c.getCall("ListRevisions")
+	c.verifyArgs(call, opts)
+	return call.result[0].(*v1alpha1.RevisionList), errorOrNil(call.result[1])
+}
+
+// Delete a revision
+func (r *Recorder) DeleteRevision(name interface{}, err error) {
+	r.add("DeleteRevision", apiMethodCall{[]interface{}{name}, []interface{}{err}})
+}
+
+func (c *MockKnClient) DeleteRevision(name string) error {
+	call := c.getCall("DeleteRevision")
+	c.verifyArgs(call, name)
+	return errorOrNil(call.result[0])
+
+}
+
+// Get a route by its unique name
+func (r *Recorder) GetRoute(name interface{}, route *v1alpha1.Route, err error) {
+	r.add("GetRoute", apiMethodCall{[]interface{}{name}, []interface{}{route, err}})
+}
+
+func (c *MockKnClient) GetRoute(name string) (*v1alpha1.Route, error) {
+	call := c.getCall("GetRoute")
+	c.verifyArgs(call, name)
+	return call.result[0].(*v1alpha1.Route), errorOrNil(call.result[1])
+
+}
+
+// List routes
+func (r *Recorder) ListRoutes(opts interface{}, routeList *v1alpha1.RouteList, err error) {
+	r.add("ListRoutes", apiMethodCall{[]interface{}{opts}, []interface{}{routeList, err}})
+}
+
+func (c *MockKnClient) ListRoutes(opts ...ListConfig) (*v1alpha1.RouteList, error) {
+	call := c.getCall("ListRoutes")
+	c.verifyArgs(call, opts)
+	return call.result[0].(*v1alpha1.RouteList), errorOrNil(call.result[1])
+}
+
+// Check that every recorded method has been called
+func (r *Recorder) Validate() {
+	for k, v := range r.recordedCalls {
+		if len(v) > 0 {
+			r.t.Errorf("Recorded method \"%s\" not been called", k)
+		}
+	}
+}
+
 // Add a recorded api call the list of calls
 func (r *Recorder) add(name string, call apiMethodCall) {
 	calls, ok := r.recordedCalls[name]
@@ -106,156 +243,4 @@ func errorOrNil(err interface{}) error {
 		return nil
 	}
 	return err.(error)
-}
-
-// any() can be used in recording to not check for the argument
-func Any() func(t *testing.T, a, b interface{}) {
-	return func(t *testing.T, a, b interface{}) {}
-}
-
-// Get Service
-func (r *Recorder) GetService(name interface{}, service *v1alpha1.Service, err error) *Recorder {
-	r.add("GetService", apiMethodCall{[]interface{}{name}, []interface{}{service, err}})
-	return r
-}
-
-func (c *MockKnClient) GetService(name string) (*v1alpha1.Service, error) {
-	call := c.getCall("GetService")
-	c.verifyArgs(call, name)
-	return call.result[0].(*v1alpha1.Service), errorOrNil(call.result[1])
-}
-
-// List services
-func (r *Recorder) ListServices(opts interface{}, serviceList *v1alpha1.ServiceList, err error) *Recorder {
-	r.add("ListServices", apiMethodCall{[]interface{}{opts}, []interface{}{serviceList, err}})
-	return r
-}
-
-func (c *MockKnClient) ListServices(opts ...ListConfig) (*v1alpha1.ServiceList, error) {
-	call := c.getCall("ListServices")
-	c.verifyArgs(call, opts)
-	return call.result[0].(*v1alpha1.ServiceList), errorOrNil(call.result[1])
-}
-
-// Create a new service
-func (r *Recorder) CreateService(service interface{}, err error) *Recorder {
-	r.add("CreateService", apiMethodCall{[]interface{}{service}, []interface{}{err}})
-	return r
-}
-
-func (c *MockKnClient) CreateService(service *v1alpha1.Service) error {
-	call := c.getCall("CreateService")
-	c.verifyArgs(call, service)
-	return errorOrNil(call.result[0])
-}
-
-// Update the given service
-func (r *Recorder) UpdateService(service interface{}, err error) *Recorder {
-	r.add("UpdateService", apiMethodCall{[]interface{}{service}, []interface{}{err}})
-	return r
-}
-
-func (c *MockKnClient) UpdateService(service *v1alpha1.Service) error {
-	call := c.getCall("UpdateService")
-	c.verifyArgs(call, service)
-	return errorOrNil(call.result[0])
-
-}
-
-// Delete a service by name
-func (r *Recorder) DeleteService(name interface{}, err error) *Recorder {
-	r.add("DeleteService", apiMethodCall{[]interface{}{name}, []interface{}{err}})
-	return r
-}
-
-func (c *MockKnClient) DeleteService(name string) error {
-	call := c.getCall("DeleteService")
-	c.verifyArgs(call, name)
-	return errorOrNil(call.result[0])
-}
-
-// Wait for a service to become ready, but not longer than provided timeout
-func (r *Recorder) WaitForService(name interface{}, timeout interface{}, err error) *Recorder {
-	r.add("WaitForService", apiMethodCall{[]interface{}{name}, []interface{}{err}})
-	return r
-}
-
-func (c *MockKnClient) WaitForService(name string, timeout time.Duration) error {
-	call := c.getCall("WaitForService")
-	c.verifyArgs(call, name)
-	return errorOrNil(call.result[0])
-
-}
-
-// Get a revision by name
-func (r *Recorder) GetRevision(name interface{}, revision *v1alpha1.Revision, err error) *Recorder {
-	r.add("GetRevision", apiMethodCall{[]interface{}{name}, []interface{}{revision, err}})
-	return r
-}
-
-func (c *MockKnClient) GetRevision(name string) (*v1alpha1.Revision, error) {
-	call := c.getCall("GetRevision")
-	c.verifyArgs(call, name)
-	return call.result[0].(*v1alpha1.Revision), errorOrNil(call.result[1])
-
-}
-
-// List revisions
-func (r *Recorder) ListRevisions(opts interface{}, revisionList *v1alpha1.RevisionList, err error) *Recorder {
-	r.add("ListRevisions", apiMethodCall{[]interface{}{opts}, []interface{}{revisionList, err}})
-	return r
-}
-
-func (c *MockKnClient) ListRevisions(opts ...ListConfig) (*v1alpha1.RevisionList, error) {
-	call := c.getCall("ListRevisions")
-	c.verifyArgs(call, opts)
-	return call.result[0].(*v1alpha1.RevisionList), errorOrNil(call.result[1])
-
-}
-
-// Delete a revision
-func (r *Recorder) DeleteRevision(name interface{}, err error) *Recorder {
-	r.add("DeleteRevision", apiMethodCall{[]interface{}{name}, []interface{}{err}})
-	return r
-}
-
-func (c *MockKnClient) DeleteRevision(name string) error {
-	call := c.getCall("DeleteRevision")
-	c.verifyArgs(call, name)
-	return errorOrNil(call.result[0])
-
-}
-
-// Get a route by its unique name
-func (r *Recorder) GetRoute(name interface{}, route *v1alpha1.Route, err error) *Recorder {
-	r.add("GetRoute", apiMethodCall{[]interface{}{name}, []interface{}{route, err}})
-	return r
-}
-
-func (c *MockKnClient) GetRoute(name string) (*v1alpha1.Route, error) {
-	call := c.getCall("GetRoute")
-	c.verifyArgs(call, name)
-	return call.result[0].(*v1alpha1.Route), errorOrNil(call.result[1])
-
-}
-
-// List routes
-func (r *Recorder) ListRoutes(opts interface{}, routeList *v1alpha1.RouteList, err error) *Recorder {
-	r.add("ListRoutes", apiMethodCall{[]interface{}{opts}, []interface{}{routeList, err}})
-	return r
-}
-
-func (c *MockKnClient) ListRoutes(opts ...ListConfig) (*v1alpha1.RouteList, error) {
-	call := c.getCall("ListRoutes")
-	c.verifyArgs(call, opts)
-	return call.result[0].(*v1alpha1.RouteList), errorOrNil(call.result[1])
-}
-
-// Check that every recorded method has been called
-func (r *Recorder) Validate() {
-	for k, v := range r.recordedCalls {
-		if len(v) > 0 {
-			r.t.Errorf("Recorded method \"%s\" not been called", k)
-		}
-	}
 }

--- a/pkg/serving/v1alpha1/client_mock_test.go
+++ b/pkg/serving/v1alpha1/client_mock_test.go
@@ -1,0 +1,45 @@
+package v1alpha1
+
+import (
+	"testing"
+	"time"
+
+	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
+)
+
+func TestMockKnClient(t *testing.T) {
+
+	client := NewMockKnClient(t)
+
+	recorder := client.Recorder()
+
+	// Record all services
+	recorder.GetService("hello", nil, nil)
+	recorder.ListServices(Any(), nil, nil)
+	recorder.CreateService(&v1alpha1.Service{},nil)
+	recorder.UpdateService(&v1alpha1.Service{}, nil)
+	recorder.DeleteService("hello", nil)
+	recorder.WaitForService("hello", time.Duration(10) * time.Second, nil)
+	recorder.GetRevision("hello", nil, nil)
+	recorder.ListRevisions(Any(), nil, nil)
+	recorder.DeleteRevision("hello", nil)
+	recorder.GetRoute("hello", nil, nil)
+	recorder.ListRoutes(Any(), nil, nil)
+
+	// Call all services
+	client.GetService("hello")
+	client.ListServices(WithName("blub"))
+	client.CreateService(&v1alpha1.Service{})
+	client.UpdateService(&v1alpha1.Service{})
+	client.DeleteService("hello")
+	client.WaitForService("hello", time.Duration(10) * time.Second)
+	client.GetRevision("hello")
+	client.ListRevisions(WithName("blub"))
+	client.DeleteRevision("hello")
+	client.GetRoute("hello")
+	client.ListRoutes(WithName("blub"))
+
+
+	// Validate
+	recorder.Validate()
+}

--- a/pkg/serving/v1alpha1/client_mock_test.go
+++ b/pkg/serving/v1alpha1/client_mock_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2019 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package v1alpha1
 
 import (
@@ -16,10 +30,10 @@ func TestMockKnClient(t *testing.T) {
 	// Record all services
 	recorder.GetService("hello", nil, nil)
 	recorder.ListServices(Any(), nil, nil)
-	recorder.CreateService(&v1alpha1.Service{},nil)
+	recorder.CreateService(&v1alpha1.Service{}, nil)
 	recorder.UpdateService(&v1alpha1.Service{}, nil)
 	recorder.DeleteService("hello", nil)
-	recorder.WaitForService("hello", time.Duration(10) * time.Second, nil)
+	recorder.WaitForService("hello", time.Duration(10)*time.Second, nil)
 	recorder.GetRevision("hello", nil, nil)
 	recorder.ListRevisions(Any(), nil, nil)
 	recorder.DeleteRevision("hello", nil)
@@ -32,13 +46,12 @@ func TestMockKnClient(t *testing.T) {
 	client.CreateService(&v1alpha1.Service{})
 	client.UpdateService(&v1alpha1.Service{})
 	client.DeleteService("hello")
-	client.WaitForService("hello", time.Duration(10) * time.Second)
+	client.WaitForService("hello", time.Duration(10)*time.Second)
 	client.GetRevision("hello")
 	client.ListRevisions(WithName("blub"))
 	client.DeleteRevision("hello")
 	client.GetRoute("hello")
 	client.ListRoutes(WithName("blub"))
-
 
 	// Validate
 	recorder.Validate()

--- a/pkg/wait/test_wait_helper.go
+++ b/pkg/wait/test_wait_helper.go
@@ -28,7 +28,7 @@ type FakeWatch struct {
 	eventChan chan watch.Event
 	events    []watch.Event
 
-	// Record how often stop was called
+	// Recorder how often stop was called
 	StopCalled int
 }
 

--- a/pkg/wait/test_wait_helper.go
+++ b/pkg/wait/test_wait_helper.go
@@ -28,7 +28,7 @@ type FakeWatch struct {
 	eventChan chan watch.Event
 	events    []watch.Event
 
-	// Recorder how often stop was called
+	// Record how often stop was called
 	StopCalled int
 }
 


### PR DESCRIPTION
Commands must only use the `KnClient` API and their unit tests should also
only use a mock implementation for this interface.

This commit introduces such a Mock implementation and works like in
the example below for creating a simple service in a synchronous
way

```golang
// New mock client
client := knclient.NewMockKnClient(t)

// Recording:
r := client.Recorder()
// Check for existing service --> no
r.GetService("foo", nil, errors.NewNotFound(v1alpha1.Resource("service"), "foo"))
// Create service (don't validate given service --> "Any()" arg is allowed)
r.CreateService(knclient.Any(), nil)
// Wait for service to become ready
r.WaitForService("foo", knclient.Any(), nil)
// Get for showing the URL
r.GetService("foo", getServiceWithUrl("foo", "http://foo.example.com"), nil)

// Testing:
output, err := executeCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz")
assert.NilError(t, err)
assert.Assert(t, util.ContainsAll(output, "created", "foo", "http://foo.example.com", "Waiting"))

// Validate that all recorded API methods have been called
r.Validate()
```

Such tests have three phases:

* A recording phase where the mock client is prepared. In this phase a
  recorder is called with the expected arguments and the return values
  it can return. The arguments can be also functions with
  signature `func (t *testing.T, actual interface{}, expected interface{})`
  and will be called to verify a given argument. Such a function should
  `t.Fail()` on its own if the validation fails.
  A convenient `Any()` method is added to allow no validation on an argument
  (see example below).
  Method can be called multiple times, but the order needs to reflect
  the actual calling order
* A playback phase where the test executed which in turn calls out to the
  Mocks
* A validation phase to check the expected output. The recorder can be
  also validated to verify that all recorded mock calls has been
  used during the test.

  See `service_create_mock_test.go` for a full example.