### PR TITLE
Restructure E2E test suite

### DIFF
--- a/test/e2e/basic_workflow_test.go
+++ b/test/e2e/basic_workflow_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestBasicWorkflow(t *testing.T) {
+	t.Parallel()
 	test := NewE2eTest(t)
 	test.Setup(t)
 	defer test.Teardown(t)

--- a/test/e2e/revision_test.go
+++ b/test/e2e/revision_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestRevision(t *testing.T) {
+	t.Parallel()
 	test := NewE2eTest(t)
 	test.Setup(t)
 	defer test.Teardown(t)

--- a/test/e2e/revision_test.go
+++ b/test/e2e/revision_test.go
@@ -25,25 +25,24 @@ import (
 	"gotest.tools/assert"
 )
 
-func TestRevisionWorkflow(t *testing.T) {
+func TestRevision(t *testing.T) {
 	test := NewE2eTest(t)
 	test.Setup(t)
 	defer test.Teardown(t)
 
-	t.Run("create hello service and returns no error", func(t *testing.T) {
+	t.Run("create hello service and return no error", func(t *testing.T) {
 		test.serviceCreate(t, "hello")
 	})
 
-	t.Run("describe revision from hello service", func(t *testing.T) {
-		test.revisionDescribe(t, "hello")
+	t.Run("describe revision from hello service with print flags", func(t *testing.T) {
 		test.revisionDescribeWithPrintFlags(t, "hello")
 	})
 
-	t.Run("delete latest revision from hello service and returns no error", func(t *testing.T) {
+	t.Run("delete latest revision from hello service and return no error", func(t *testing.T) {
 		test.revisionDelete(t, "hello")
 	})
 
-	t.Run("delete hello service and returns no error", func(t *testing.T) {
+	t.Run("delete hello service and return no error", func(t *testing.T) {
 		test.serviceDelete(t, "hello")
 	})
 }
@@ -55,19 +54,6 @@ func (test *e2eTest) revisionDelete(t *testing.T, serviceName string) {
 	assert.NilError(t, err)
 
 	assert.Check(t, util.ContainsAll(out, "Revision", revName, "deleted", "namespace", test.kn.namespace))
-}
-
-func (test *e2eTest) revisionDescribe(t *testing.T, serviceName string) {
-	revName := test.findRevision(t, serviceName)
-
-	out, err := test.kn.RunWithOpts([]string{"revision", "describe", revName}, runOpts{})
-	assert.NilError(t, err)
-
-	expectedGVK := `apiVersion: serving.knative.dev/v1alpha1
-kind: Revision`
-	expectedNamespace := fmt.Sprintf("namespace: %s", test.kn.namespace)
-	expectedServiceLabel := fmt.Sprintf("serving.knative.dev/service: %s", serviceName)
-	assert.Check(t, util.ContainsAll(out, expectedGVK, expectedNamespace, expectedServiceLabel))
 }
 
 func (test *e2eTest) revisionDescribeWithPrintFlags(t *testing.T, serviceName string) {

--- a/test/e2e/route_test.go
+++ b/test/e2e/route_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestRoute(t *testing.T) {
+	t.Parallel()
 	test := NewE2eTest(t)
 	test.Setup(t)
 	defer test.Teardown(t)

--- a/test/e2e/route_test.go
+++ b/test/e2e/route_test.go
@@ -1,0 +1,102 @@
+// Copyright 2019 The Knative Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/knative/client/pkg/util"
+	"gotest.tools/assert"
+)
+
+func TestRoute(t *testing.T) {
+	test := NewE2eTest(t)
+	test.Setup(t)
+	defer test.Teardown(t)
+
+	t.Run("create hello service and return no error", func(t *testing.T) {
+		test.serviceCreate(t, "hello")
+	})
+
+	t.Run("return a list of routes", func(t *testing.T) {
+		test.routeList(t)
+	})
+
+	t.Run("return a list of routes associated with hello service", func(t *testing.T) {
+		test.routeListWithArgument(t, "hello")
+	})
+
+	t.Run("return a list of routes associated with hello service with print flags", func(t *testing.T) {
+		test.routeListWithPrintFlags(t, "hello")
+	})
+
+	t.Run("describe route from hello service", func(t *testing.T) {
+		test.routeDescribe(t, "hello")
+	})
+
+	t.Run("describe route from hello service with print flags", func(t *testing.T) {
+		test.routeDescribeWithPrintFlags(t, "hello")
+	})
+
+	t.Run("delete hello service and return no error", func(t *testing.T) {
+		test.serviceDelete(t, "hello")
+	})
+}
+
+func (test *e2eTest) routeList(t *testing.T) {
+	out, err := test.kn.RunWithOpts([]string{"route", "list"}, runOpts{})
+	assert.NilError(t, err)
+
+	expectedHeaders := []string{"NAME", "URL", "AGE", "CONDITIONS", "TRAFFIC"}
+	assert.Check(t, util.ContainsAll(out, expectedHeaders...))
+}
+
+func (test *e2eTest) routeListWithArgument(t *testing.T, routeName string) {
+	out, err := test.kn.RunWithOpts([]string{"route", "list", routeName}, runOpts{})
+	assert.NilError(t, err)
+
+	expectedOutput := fmt.Sprintf("100%% -> %s", routeName)
+	assert.Check(t, util.ContainsAll(out, routeName, expectedOutput))
+}
+
+func (test *e2eTest) routeDescribe(t *testing.T, routeName string) {
+	out, err := test.kn.RunWithOpts([]string{"route", "describe", routeName}, runOpts{})
+	assert.NilError(t, err)
+
+	expectedGVK := `apiVersion: serving.knative.dev/v1alpha1
+kind: Route`
+	expectedNamespace := fmt.Sprintf("namespace: %s", test.kn.namespace)
+	expectedServiceLabel := fmt.Sprintf("serving.knative.dev/service: %s", routeName)
+	assert.Check(t, util.ContainsAll(out, expectedGVK, expectedNamespace, expectedServiceLabel))
+}
+
+func (test *e2eTest) routeDescribeWithPrintFlags(t *testing.T, routeName string) {
+	out, err := test.kn.RunWithOpts([]string{"route", "describe", routeName, "-o=name"}, runOpts{})
+	assert.NilError(t, err)
+
+	expectedName := fmt.Sprintf("route.serving.knative.dev/%s", routeName)
+	assert.Equal(t, strings.TrimSpace(out), expectedName)
+}
+
+func (test *e2eTest) routeListWithPrintFlags(t *testing.T, names ...string) {
+	out, err := test.kn.RunWithOpts([]string{"route", "list", "-o=jsonpath={.items[*].metadata.name}"}, runOpts{})
+	assert.NilError(t, err)
+
+	assert.Check(t, util.ContainsAll(out, names...))
+}

--- a/test/e2e/service_options_test.go
+++ b/test/e2e/service_options_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestServiceOptions(t *testing.T) {
+	t.Parallel()
 	test := NewE2eTest(t)
 	test.Setup(t)
 	defer test.Teardown(t)

--- a/test/e2e/service_test.go
+++ b/test/e2e/service_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestService(t *testing.T) {
+	t.Parallel()
 	test := NewE2eTest(t)
 	test.Setup(t)
 	defer test.Teardown(t)

--- a/test/e2e/service_test.go
+++ b/test/e2e/service_test.go
@@ -1,0 +1,73 @@
+// Copyright 2019 The Knative Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestService(t *testing.T) {
+	test := NewE2eTest(t)
+	test.Setup(t)
+	defer test.Teardown(t)
+
+	t.Run("create hello service duplicate and get service already exists error", func(t *testing.T) {
+		test.serviceCreate(t, "hello")
+		test.serviceCreateDuplicate(t, "hello")
+	})
+
+	t.Run("return valid info about hello service with print flags", func(t *testing.T) {
+		test.serviceDescribeWithPrintFlags(t, "hello")
+	})
+
+	t.Run("delete hello service repeatedly and get an error", func(t *testing.T) {
+		test.serviceDelete(t, "hello")
+		test.serviceDeleteNonexistent(t, "hello")
+	})
+}
+
+func (test *e2eTest) serviceCreateDuplicate(t *testing.T, serviceName string) {
+	out, err := test.kn.RunWithOpts([]string{"service", "list", serviceName}, runOpts{NoNamespace: false})
+	assert.Check(t, strings.Contains(out, serviceName), "The service does not exist yet")
+
+	_, err = test.kn.RunWithOpts([]string{"service", "create", serviceName,
+		"--image", KnDefaultTestImage}, runOpts{NoNamespace: false, AllowError: true})
+
+	assert.ErrorContains(t, err, "the service already exists")
+}
+
+func (test *e2eTest) serviceDescribeWithPrintFlags(t *testing.T, serviceName string) {
+	out, err := test.kn.RunWithOpts([]string{"service", "describe", serviceName, "-o=name"}, runOpts{})
+	assert.NilError(t, err)
+
+	expectedName := fmt.Sprintf("service.serving.knative.dev/%s", serviceName)
+	assert.Equal(t, strings.TrimSpace(out), expectedName)
+}
+
+func (test *e2eTest) serviceDeleteNonexistent(t *testing.T, serviceName string) {
+	out, err := test.kn.RunWithOpts([]string{"service", "list", serviceName}, runOpts{NoNamespace: false})
+	assert.Check(t, !strings.Contains(out, serviceName), "The service exists")
+
+	_, err = test.kn.RunWithOpts([]string{"service", "delete", serviceName}, runOpts{NoNamespace: false, AllowError: true})
+
+	expectedErr := fmt.Sprintf(`services.serving.knative.dev "%s" not found`, serviceName)
+	assert.ErrorContains(t, err, expectedErr)
+}

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestVersion(t *testing.T) {
+	t.Parallel()
 	env := buildEnv(t)
 	kn := kn{t, env.Namespace, Logger{}}
 


### PR DESCRIPTION
* move out more tests from the basic workflow and put them in separate
files, including tests for routes
* rename revision_workflow_test.go to revision_test.go

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #https://github.com/knative/client/issues/301

## Proposed Changes

I've also excluded things related to routes from the basic workflow. IMO, it is not required to touch routes in the basic workflow. We get information about the route from "service describe". OTOH, I included `revision describe` in the basic workflow because I think that will be a common operation to get information about the given revision.

Moving test files into sub-folders such as revision, service, etc. is currently not possible with the current way we run tests. There are two problems:
1) When running `go test command` for all tests we'd have to list multiple/many directories
2) We can't really define methods for the e2eTest type outside the e2e package, this is not allowed in Go. So we can't define our methods in e.g. service package for the e2eType


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
