### PR TITLE
Report an error if no flag(s) set in service update

### DIFF
--- a/pkg/kn/commands/service/service_update.go
+++ b/pkg/kn/commands/service/service_update.go
@@ -29,7 +29,7 @@ func NewServiceUpdateCommand(p *commands.KnParams) *cobra.Command {
 	var waitFlags commands.WaitFlags
 
 	serviceUpdateCommand := &cobra.Command{
-		Use:   "update NAME",
+		Use:   "update NAME [flags]",
 		Short: "Update a service.",
 		Example: `
   # Updates a service 'mysvc' with new environment variables
@@ -91,10 +91,21 @@ func NewServiceUpdateCommand(p *commands.KnParams) *cobra.Command {
 				return nil
 			}
 		},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return preCheck(cmd, args)
+		},
 	}
 
 	commands.AddNamespaceFlags(serviceUpdateCommand.Flags(), false)
 	editFlags.AddUpdateFlags(serviceUpdateCommand)
 	waitFlags.AddConditionWaitFlags(serviceUpdateCommand, 60, "Update", "service")
 	return serviceUpdateCommand
+}
+
+func preCheck(cmd *cobra.Command, args []string) error {
+	if cmd.Flags().NFlag() == 0 {
+		return errors.New(fmt.Sprintf("flag(s) not set\nUsage: %s", cmd.Use))
+	}
+
+	return nil
 }

--- a/pkg/kn/commands/service/service_update_test.go
+++ b/pkg/kn/commands/service/service_update_test.go
@@ -88,6 +88,26 @@ func fakeServiceUpdate(original *v1alpha1.Service, args []string, sync bool) (
 	return
 }
 
+func TestServcieUpdateNoFlags(t *testing.T) {
+	orig := newEmptyService()
+
+	action, _, _, err := fakeServiceUpdate(orig, []string{
+		"service", "update", "foo"}, false)
+
+	if action != nil {
+		t.Errorf("Unexpected action if no flag(s) set")
+	}
+
+	if err == nil {
+		t.Fatal(err)
+	}
+
+	expectedErrMsg := "flag(s) not set"
+	if !strings.Contains(err.Error(), expectedErrMsg) {
+		t.Fatalf("Missing %s in %s", expectedErrMsg, err.Error())
+	}
+}
+
 func TestServiceUpdateImageSync(t *testing.T) {
 	orig := newEmptyService()
 


### PR DESCRIPTION
For now if no flag(s) set, service update will still try to do an update as below, it should return an error instead.

```
$ ./kn service update hello
Waiting for service 'hello' to become ready ... OK
Service 'hello' updated in namespace 'default'.
```
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes [issue 286](https://github.com/knative/client/issues/286)

## Proposed Changes

* Return an error if no flag(s) set in service update

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
