### PR TITLE
fix(bug) correct response for unknown command or plugin fixes(#309)

### DIFF
--- a/pkg/kn/core/root.go
+++ b/pkg/kn/core/root.go
@@ -76,7 +76,9 @@ func NewDefaultKnCommandWithArgs(rootCmd *cobra.Command,
 		if _, _, err := rootCmd.Find(cmdPathPieces); err != nil {
 			err := plugin.HandlePluginCommand(pluginHandler, cmdPathPieces)
 			if err != nil {
-				fmt.Fprintf(errOut, "%v\n", err)
+				rootCmd.Help()
+				fmt.Println()
+				fmt.Printf("unknown command or plugin \"%s\" for \"kn\"\n", args[1])
 				os.Exit(1)
 			}
 		}


### PR DESCRIPTION
```bash
➜  client git:(issue309) ✗ ./kn lol
Manage your Knative building blocks:
* Serving: Manage your services and release new software to them.
* Eventing: Manage event subscriptions and channels. Connect up event sources.

Usage:
...
Use "kn [command] --help" for more information about a command.

unknown sub-command or plugin "lol" for "kn"
```

Fixes #309

## Proposed Changes

* add better message if `kn` is called with unknown command or plugin

**Release Note**

```release-note
NONE
```
