### PR TITLE
Don't show warnings that are not bad conditions

### DIFF
--- a/pkg/kn/commands/plugin/plugin_list_test.go
+++ b/pkg/kn/commands/plugin/plugin_list_test.go
@@ -73,24 +73,6 @@ func TestPluginList(t *testing.T) {
 		t.Run("when --lookup-plugins-in-path is true", func(t *testing.T) {
 			var pluginPath string
 
-			beforeEach := func(t *testing.T) {
-				err = os.Setenv("PATH", tmpPathDir)
-				assert.Assert(t, err == nil)
-			}
-
-			t.Run("no plugins installed", func(t *testing.T) {
-				setup(t)
-				defer cleanup(t)
-				beforeEach(t)
-
-				t.Run("warns user that no plugins found", func(t *testing.T) {
-					rootCmd.SetArgs([]string{"plugin", "list", "--lookup-plugins-in-path=true", pluginsDirFlag})
-					err = rootCmd.Execute()
-					assert.Assert(t, err != nil)
-					assert.Assert(t, strings.Contains(err.Error(), "warning: unable to find any kn plugins in your plugin path:"))
-				})
-			})
-
 			t.Run("plugins installed", func(t *testing.T) {
 				t.Run("with valid plugin in $PATH", func(t *testing.T) {
 					beforeEach := func(t *testing.T) {
@@ -113,21 +95,19 @@ func TestPluginList(t *testing.T) {
 					})
 				})
 
-				t.Run("with non-executable plugin", func(t *testing.T) {
+				t.Run("with missing plugin path", func(t *testing.T) {
 					beforeEach := func(t *testing.T) {
-						pluginPath = CreateTestPluginInPath(t, KnTestPluginName, KnTestPluginScript, FileModeReadable, tmpPathDir)
-						assert.Assert(t, pluginPath != "")
+						pluginPath = "/tmp/does-not-exist"
 					}
 
-					t.Run("warns user plugin invalid", func(t *testing.T) {
+					t.Run("don't warns user of missing path", func(t *testing.T) {
 						setup(t)
 						defer cleanup(t)
 						beforeEach(t)
 
 						rootCmd.SetArgs([]string{"plugin", "list", "--lookup-plugins-in-path=true", pluginsDirFlag})
 						err = rootCmd.Execute()
-						assert.Assert(t, err != nil)
-						assert.Assert(t, strings.Contains(err.Error(), "warning: unable to find any kn plugins in your plugin path:"))
+						assert.Assert(t, err == nil)
 					})
 				})
 
@@ -228,13 +208,5 @@ func TestPluginList(t *testing.T) {
 			assert.Assert(t, err == nil)
 		})
 
-		t.Run("no plugins installed", func(t *testing.T) {
-			setup(t)
-			defer cleanup(t)
-
-			rootCmd.SetArgs([]string{"plugin", "list", pluginsDirFlag})
-			err = rootCmd.Execute()
-			assert.Assert(t, err != nil)
-		})
 	})
 }


### PR DESCRIPTION
Don't show warnings while running `kn plugin list` when:
- a dir in your plug-in path doesn't exist - e.g. right now it shows it for a missing ~/.kn/plugins - which is a valid state for someone who just downloaded `kn` but doesn't have, or need, a .kn dir
- there are no plugins at all - that's a valid state and doesn't deserve a warning

To me warning are things people need to be aware of (or things they need to
take action to fix).  Neither of those case apply here. Instead they user
will just be annoyed by this:

```
$ kn plugin list
Unable read directory '/root/.kn/plugins' from your plugins path: open /root/.kn/plugins: no such file or directory. Skipping...
warning: unable to find any kn plugins in your plugin path: '[/root/.kn/plugins]'
```

When they should see no output at all. Or, if someone wants to add it we could output `no plugins found` but not call it a "warning" since it's not.

Signed-off-by: Doug Davis <dug@us.ibm.com>

/lint

