### PR TITLE
Supports setting comma separated env vars

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -30,6 +30,10 @@
 | List revisions sorted by configuration generation
 | https://github.com/knative/client/pull/332[#332]
 
+| 🎁
+| Support providing multiple comma separated values for --env flag
+|https://github.com/knative/client/pull/347[#347]
+
 |===
 
 ## v0.2.0 (2019-07-10)

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -42,7 +42,7 @@ kn service create NAME --image IMAGE [flags]
       --async                    Create service and don't wait for it to become ready.
       --concurrency-limit int    Hard Limit of concurrent requests to be processed by a single replica.
       --concurrency-target int   Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to --concurrency-limit when given.
-  -e, --env strings              Environment variable to set. NAME=value; you may provide this flag any number of times to set multiple environment variables.
+  -e, --env strings              Environment variable to set. Format: NAME=value; you may repeat this flag any number of times to set multiple environment variables. Supports comma separated values for a flag as well (e.g.: --env K1=V1,K2=v2).
       --force                    Create service forcefully, replaces existing service if any.
   -h, --help                     help for create
       --image string             Image to run.

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -42,7 +42,7 @@ kn service create NAME --image IMAGE [flags]
       --async                    Create service and don't wait for it to become ready.
       --concurrency-limit int    Hard Limit of concurrent requests to be processed by a single replica.
       --concurrency-target int   Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to --concurrency-limit when given.
-  -e, --env stringArray          Environment variable to set. NAME=value; you may provide this flag any number of times to set multiple environment variables.
+  -e, --env strings              Environment variable to set. NAME=value; you may provide this flag any number of times to set multiple environment variables.
       --force                    Create service forcefully, replaces existing service if any.
   -h, --help                     help for create
       --image string             Image to run.

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -30,7 +30,7 @@ kn service update NAME [flags]
       --async                    Update service and don't wait for it to become ready.
       --concurrency-limit int    Hard Limit of concurrent requests to be processed by a single replica.
       --concurrency-target int   Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to --concurrency-limit when given.
-  -e, --env stringArray          Environment variable to set. NAME=value; you may provide this flag any number of times to set multiple environment variables.
+  -e, --env strings              Environment variable to set. NAME=value; you may provide this flag any number of times to set multiple environment variables.
   -h, --help                     help for update
       --image string             Image to run.
       --limits-cpu string        The limits on the requested CPU (e.g., 1000m).

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -30,7 +30,7 @@ kn service update NAME [flags]
       --async                    Update service and don't wait for it to become ready.
       --concurrency-limit int    Hard Limit of concurrent requests to be processed by a single replica.
       --concurrency-target int   Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to --concurrency-limit when given.
-  -e, --env strings              Environment variable to set. NAME=value; you may provide this flag any number of times to set multiple environment variables.
+  -e, --env strings              Environment variable to set. Format: NAME=value; you may repeat this flag any number of times to set multiple environment variables. Supports comma separated values for a flag as well (e.g.: --env K1=V1,K2=v2).
   -h, --help                     help for update
       --image string             Image to run.
       --limits-cpu string        The limits on the requested CPU (e.g., 1000m).

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -44,7 +44,7 @@ type ResourceFlags struct {
 
 func (p *ConfigurationEditFlags) AddUpdateFlags(command *cobra.Command) {
 	command.Flags().StringVar(&p.Image, "image", "", "Image to run.")
-	command.Flags().StringArrayVarP(&p.Env, "env", "e", []string{},
+	command.Flags().StringSliceVarP(&p.Env, "env", "e", []string{},
 		"Environment variable to set. NAME=value; you may provide this flag "+
 			"any number of times to set multiple environment variables.")
 	command.Flags().StringVar(&p.RequestsFlags.CPU, "requests-cpu", "", "The requested CPU (e.g., 250m).")

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -45,8 +45,9 @@ type ResourceFlags struct {
 func (p *ConfigurationEditFlags) AddUpdateFlags(command *cobra.Command) {
 	command.Flags().StringVar(&p.Image, "image", "", "Image to run.")
 	command.Flags().StringSliceVarP(&p.Env, "env", "e", []string{},
-		"Environment variable to set. NAME=value; you may provide this flag "+
-			"any number of times to set multiple environment variables.")
+		"Environment variable to set. Format: NAME=value; you may repeat this flag "+
+			"any number of times to set multiple environment variables. "+
+			"Supports comma separated values for a flag as well (e.g.: --env K1=V1,K2=v2).")
 	command.Flags().StringVar(&p.RequestsFlags.CPU, "requests-cpu", "", "The requested CPU (e.g., 250m).")
 	command.Flags().StringVar(&p.RequestsFlags.Memory, "requests-memory", "", "The requested memory (e.g., 64Mi).")
 	command.Flags().StringVar(&p.LimitsFlags.CPU, "limits-cpu", "", "The limits on the requested CPU (e.g., 1000m).")


### PR DESCRIPTION
/lint

## Proposed Changes
 `--env ENV1=VAL1 --env ENV2=VAL2,ENV3=VAL3`

 should work specifying by separate `--env` or specifying comma separated
 values to `--env` or combination of both.

**Release Note**

```release-note
Supports specifying comma separated environment variables as `--env KEY1=VAL1,KEY2=VAL2`
```
