### PR TITLE
Fix index out of range error

### DIFF
--- a/pkg/kn/core/root.go
+++ b/pkg/kn/core/root.go
@@ -45,7 +45,8 @@ func NewDefaultKnCommand() *cobra.Command {
 	// and will not be parsed
 	pluginsDir, lookupPluginsInPath, err := extractKnPluginFlags(os.Args)
 	if err != nil {
-		panic("Invalid plugin flag value")
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
 	}
 
 	pluginHandler := plugin.NewDefaultPluginHandler(plugin.ValidPluginFilenamePrefixes,
@@ -204,27 +205,33 @@ func initConfig() {
 func extractKnPluginFlags(args []string) (string, bool, error) {
 	pluginsDir := "~/.kn/plugins"
 	lookupPluginsInPath := false
+
+	dirFlag := "--plugins-dir"
+	pathFlag := "--lookup-plugins-in-path"
+	var err error
+
 	for _, arg := range args {
-		if strings.Contains(arg, "--plugins-dir") {
-			values := strings.Split(arg, "=")
-			if len(values) < 1 {
-				return "", false, errors.New("Invalid --plugins-dir flag value")
+		if arg == dirFlag {
+			// They forgot the =...
+			return "", false, fmt.Errorf("Missing %s flag value", dirFlag)
+		} else if strings.HasPrefix(arg, dirFlag+"=") {
+			// Starts with --plugins-dir=   so we parse the value
+			pluginsDir = arg[len(dirFlag)+1:]
+			if pluginsDir == "" {
+				// They have a "=" but nothing afer it
+				return "", false, fmt.Errorf("Missing %s flag value", dirFlag)
 			}
-			pluginsDir = values[1]
 		}
 
-		if strings.Contains(arg, "--lookup-plugins-in-path") {
-			values := strings.Split(arg, "=")
-			if len(values) < 1 {
-				return "", false, errors.New("Invalid --lookup-plugins-in-path flag value")
+		if arg == pathFlag {
+			// just --lookup-plugins-in-path   no "="
+			lookupPluginsInPath = true
+		} else if strings.HasPrefix(arg, pathFlag+"=") {
+			// Starts with --lookup-plugins-in-path=  so we parse value
+			arg = arg[len(pathFlag)+1:]
+			if lookupPluginsInPath, err = strconv.ParseBool(arg); err != nil {
+				return "", false, fmt.Errorf("Invalid boolean value(%q) for %s flag", arg, dirFlag)
 			}
-
-			boolValue, err := strconv.ParseBool(values[1])
-			if err != nil {
-				return "", false, err
-			}
-
-			lookupPluginsInPath = boolValue
 		}
 	}
 	return pluginsDir, lookupPluginsInPath, nil
@@ -232,9 +239,15 @@ func extractKnPluginFlags(args []string) (string, bool, error) {
 
 func removeKnPluginFlags(args []string) []string {
 	var remainingArgs []string
+
+	// Remove these two flags from the list of args. Even though some of
+	// of these cases should have resulted in an error, if for some reason
+	// we got here just remove them anyway.
 	for _, arg := range args {
-		if strings.Contains(arg, "--plugins-dir") ||
-			strings.Contains(arg, "--lookup-plugins-in-path") {
+		if arg == "--plugins-dir" ||
+			strings.HasPrefix(arg, "--plugins-dir=") ||
+			arg == "--lookup-plugins-in-path" ||
+			strings.HasPrefix(arg, "--plookup-plugins-in-path=") {
 			continue
 		} else {
 			remainingArgs = append(remainingArgs, arg)


### PR DESCRIPTION
Fixed:
```
$ ./kn plugin list --lookup-plugins-in-path
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/knative/client/pkg/kn/core.extractKnPluginFlags(0xc00003c0c0, 0x4, 0x4, 0xc0002be280, 0xc000000180, 0xc0002ba180, 0xc0000de670, 0xc000117f68)
        /root/go/src/knative.dev/client/pkg/kn/core/root.go:222 +0x666
github.com/knative/client/pkg/kn/core.NewDefaultKnCommand(0xc000000000)
        /root/go/src/knative.dev/client/pkg/kn/core/root.go:46 +0x79
main.main()
        /root/go/src/knative.dev/client/cmd/kn/main.go:33 +0x46
```

While in there I fixed it so that we only look for --flag at the start
of the arg, and handle the --flag, --flag=, and --flag=xxx cases.
If there's --flagX we skip it because it's some other flag and not one
of interest to us.

Also, fixed some error processing that seemed a bit off.

Signed-off-by: Doug Davis <dug@us.ibm.com>

/lint
