### PR TITLE
docs: References golang 1.12.7 or later in docs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -24,7 +24,7 @@ Start by creating [a GitHub account](https://github.com/join), then set up
 You must install these tools:
 
 1. [`go`](https://golang.org/doc/install): The language `Knative Client` is
-   built in (1.11.4 or later)
+   built in (1.12 or later)
 1. [`goimports`](https://godoc.org/golang.org/x/tools/cmd/goimports)
 1. `gcc` compiler: Used during testing. Not needed if golang is installed
    via the installer


### PR DESCRIPTION
Fixes #353

As we require minimum 1.12.7 for building  kn