### PR TITLE
Add support for -A variant of --all-namespaces

### DIFF
--- a/docs/cmd/kn_revision_list.md
+++ b/docs/cmd/kn_revision_list.md
@@ -30,7 +30,7 @@ kn revision list [name] [flags]
 ### Options
 
 ```
-      --all-namespaces                If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.
+  -A, --all-namespaces                If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
   -n, --namespace string              List the requested object(s) in given namespace.

--- a/docs/cmd/kn_route_list.md
+++ b/docs/cmd/kn_route_list.md
@@ -27,7 +27,7 @@ kn route list NAME [flags]
 ### Options
 
 ```
-      --all-namespaces                If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.
+  -A, --all-namespaces                If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
   -n, --namespace string              List the requested object(s) in given namespace.

--- a/docs/cmd/kn_service_list.md
+++ b/docs/cmd/kn_service_list.md
@@ -27,7 +27,7 @@ kn service list [name] [flags]
 ### Options
 
 ```
-      --all-namespaces                If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.
+  -A, --all-namespaces                If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
   -n, --namespace string              List the requested object(s) in given namespace.

--- a/pkg/kn/commands/namespaced.go
+++ b/pkg/kn/commands/namespaced.go
@@ -32,8 +32,9 @@ func AddNamespaceFlags(flags *pflag.FlagSet, allowAll bool) {
 	)
 
 	if allowAll {
-		flags.Bool(
+		flags.BoolP(
 			"all-namespaces",
+			"A",
 			false,
 			"If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.",
 		)
@@ -43,7 +44,7 @@ func AddNamespaceFlags(flags *pflag.FlagSet, allowAll bool) {
 // GetNamespace returns namespace from command specified by flag
 func (params *KnParams) GetNamespace(cmd *cobra.Command) (string, error) {
 	namespace := cmd.Flag("namespace").Value.String()
-	// check value of all-namepace only if its defined
+	// check value of all-namepaces only if its defined
 	if cmd.Flags().Lookup("all-namespaces") != nil {
 		all, err := cmd.Flags().GetBool("all-namespaces")
 		if err != nil {

--- a/pkg/kn/commands/namespaced_test.go
+++ b/pkg/kn/commands/namespaced_test.go
@@ -78,6 +78,18 @@ func TestGetNamespaceAllNamespacesSet(t *testing.T) {
 	if actualNamespace != expectedNamespace {
 		t.Fatalf("Incorrect namespace retrieved: %v, expected: %v", actualNamespace, expectedNamespace)
 	}
+
+	// Now do it again using -A instead
+	testCmd.SetArgs([]string{"--namespace", sampleNamespace, "-A"})
+	testCmd.Execute()
+	kp = &KnParams{fixedCurrentNamespace: FakeNamespace}
+	actualNamespace, err = kp.GetNamespace(testCmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actualNamespace != expectedNamespace {
+		t.Fatalf("Incorrect namespace retrieved: %v, expected: %v", actualNamespace, expectedNamespace)
+	}
 }
 
 // test with all-namespace flag set without any namespace flag set
@@ -89,6 +101,18 @@ func TestGetNamespaceDefaultAllNamespacesUnset(t *testing.T) {
 	testCmd.Execute()
 	kp := &KnParams{fixedCurrentNamespace: FakeNamespace}
 	actualNamespace, err := kp.GetNamespace(testCmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actualNamespace != expectedNamespace {
+		t.Fatalf("Incorrect namespace retrieved: %v, expected: %v", actualNamespace, expectedNamespace)
+	}
+
+	// Now do it again using -A instead
+	testCmd.SetArgs([]string{"-A"})
+	testCmd.Execute()
+	kp = &KnParams{fixedCurrentNamespace: FakeNamespace}
+	actualNamespace, err = kp.GetNamespace(testCmd)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kn/commands/namespaced_test.go
+++ b/pkg/kn/commands/namespaced_test.go
@@ -68,28 +68,21 @@ func TestGetNamespaceAllNamespacesSet(t *testing.T) {
 	testCmd := testCommandGenerator(true)
 	expectedNamespace := ""
 	sampleNamespace := "test1"
-	testCmd.SetArgs([]string{"--namespace", sampleNamespace, "--all-namespaces"})
-	testCmd.Execute()
-	kp := &KnParams{fixedCurrentNamespace: FakeNamespace}
-	actualNamespace, err := kp.GetNamespace(testCmd)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if actualNamespace != expectedNamespace {
-		t.Fatalf("Incorrect namespace retrieved: %v, expected: %v", actualNamespace, expectedNamespace)
+
+	// Test both variants of the "all namespaces" flag
+	for _, arg := range []string{"--all-namespaces", "-A"} {
+		testCmd.SetArgs([]string{"--namespace", sampleNamespace, arg})
+		testCmd.Execute()
+		kp := &KnParams{fixedCurrentNamespace: FakeNamespace}
+		actualNamespace, err := kp.GetNamespace(testCmd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if actualNamespace != expectedNamespace {
+			t.Fatalf("Incorrect namespace retrieved: %v, expected: %v", actualNamespace, expectedNamespace)
+		}
 	}
 
-	// Now do it again using -A instead
-	testCmd.SetArgs([]string{"--namespace", sampleNamespace, "-A"})
-	testCmd.Execute()
-	kp = &KnParams{fixedCurrentNamespace: FakeNamespace}
-	actualNamespace, err = kp.GetNamespace(testCmd)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if actualNamespace != expectedNamespace {
-		t.Fatalf("Incorrect namespace retrieved: %v, expected: %v", actualNamespace, expectedNamespace)
-	}
 }
 
 // test with all-namespace flag set without any namespace flag set
@@ -97,28 +90,21 @@ func TestGetNamespaceAllNamespacesSet(t *testing.T) {
 func TestGetNamespaceDefaultAllNamespacesUnset(t *testing.T) {
 	testCmd := testCommandGenerator(true)
 	expectedNamespace := ""
-	testCmd.SetArgs([]string{"--all-namespaces"})
-	testCmd.Execute()
-	kp := &KnParams{fixedCurrentNamespace: FakeNamespace}
-	actualNamespace, err := kp.GetNamespace(testCmd)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if actualNamespace != expectedNamespace {
-		t.Fatalf("Incorrect namespace retrieved: %v, expected: %v", actualNamespace, expectedNamespace)
+
+	// Test both variants of the "all namespaces" flag
+	for _, arg := range []string{"--all-namespaces", "-A"} {
+		testCmd.SetArgs([]string{arg})
+		testCmd.Execute()
+		kp := &KnParams{fixedCurrentNamespace: FakeNamespace}
+		actualNamespace, err := kp.GetNamespace(testCmd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if actualNamespace != expectedNamespace {
+			t.Fatalf("Incorrect namespace retrieved: %v, expected: %v", actualNamespace, expectedNamespace)
+		}
 	}
 
-	// Now do it again using -A instead
-	testCmd.SetArgs([]string{"-A"})
-	testCmd.Execute()
-	kp = &KnParams{fixedCurrentNamespace: FakeNamespace}
-	actualNamespace, err = kp.GetNamespace(testCmd)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if actualNamespace != expectedNamespace {
-		t.Fatalf("Incorrect namespace retrieved: %v, expected: %v", actualNamespace, expectedNamespace)
-	}
 }
 
 // test with all-namespaces flag not defined for command


### PR DESCRIPTION
-A is my newest favorite kubectl flag, it's so much easier/faster to type
than --all-namespaces. kn users should benefit from it too!

Signed-off-by: Doug Davis <dug@us.ibm.com>
/lint

**Release Note**

```release-note
The kubectl `-A` variant of the `--all-namespaces` flag is now supported.
```
