### PR TITLE
chore(plugins, services, routes): Aligned "Not found" messages

### DIFF
--- a/pkg/kn/commands/plugin/plugin_list.go
+++ b/pkg/kn/commands/plugin/plugin_list.go
@@ -80,7 +80,9 @@ func listPlugins(cmd *cobra.Command, flags pluginListFlags) error {
 
 	if len(pluginsFound) == 0 {
 		if flags.verbose {
-			fmt.Fprintf(out, "No plugins found in path %s\n", pluginPath)
+			fmt.Fprintf(out, "No plugins found in path %s.\n", pluginPath)
+		} else {
+			fmt.Fprintln(out, "No plugins found.")
 		}
 		return nil
 	}

--- a/pkg/kn/commands/plugin/plugin_list_test.go
+++ b/pkg/kn/commands/plugin/plugin_list_test.go
@@ -124,7 +124,7 @@ func TestPluginList(t *testing.T) {
 					defer ctx.cleanup()
 					err := ctx.execute("plugin", "list", "--lookup-plugins-in-path=true")
 					assert.NilError(t, err)
-					assert.Equal(t, ctx.output(), "")
+					assert.Equal(t, ctx.output(), "No plugins found.\n")
 				})
 			})
 
@@ -224,7 +224,7 @@ func TestPluginList(t *testing.T) {
 
 			err := ctx.execute("plugin", "list")
 			assert.NilError(t, err)
-			assert.Equal(t, ctx.output(), "")
+			assert.Equal(t, ctx.output(), "No plugins found.\n")
 		})
 	})
 }

--- a/pkg/kn/commands/route/list.go
+++ b/pkg/kn/commands/route/list.go
@@ -15,6 +15,7 @@
 package route
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/knative/client/pkg/kn/commands"
@@ -57,13 +58,13 @@ func NewRouteListCommand(p *commands.KnParams) *cobra.Command {
 			case 1:
 				routeList, err = client.ListRoutes(v1alpha12.WithName(args[0]))
 			default:
-				return fmt.Errorf("'kn route list' accepts maximum 1 argument.")
+				return errors.New("'kn route list' accepts only one additional argument")
 			}
 			if err != nil {
 				return err
 			}
 			if len(routeList.Items) == 0 {
-				fmt.Fprintf(cmd.OutOrStdout(), "No resources found.\n")
+				fmt.Fprintf(cmd.OutOrStdout(), "No routes found.\n")
 				return nil
 			}
 			printer, err := routeListFlags.ToPrinter()

--- a/pkg/kn/commands/route/list_test.go
+++ b/pkg/kn/commands/route/list_test.go
@@ -54,7 +54,7 @@ func TestListEmpty(t *testing.T) {
 		t.Errorf("No action")
 	} else if !action.Matches("list", "routes") {
 		t.Errorf("Bad action %v", action)
-	} else if output[0] != "No resources found." {
+	} else if output[0] != "No routes found." {
 		t.Errorf("Bad output %s", output[0])
 	}
 }

--- a/pkg/kn/commands/service/service_list.go
+++ b/pkg/kn/commands/service/service_list.go
@@ -54,7 +54,7 @@ func NewServiceListCommand(p *commands.KnParams) *cobra.Command {
 				return err
 			}
 			if len(serviceList.Items) == 0 {
-				fmt.Fprintf(cmd.OutOrStdout(), "No resources found.\n")
+				fmt.Fprintf(cmd.OutOrStdout(), "No services found.\n")
 				return nil
 			}
 			printer, err := serviceListFlags.ToPrinter()

--- a/pkg/kn/commands/service/service_list_test.go
+++ b/pkg/kn/commands/service/service_list_test.go
@@ -57,7 +57,7 @@ func TestListEmpty(t *testing.T) {
 		t.Errorf("No action")
 	} else if !action.Matches("list", "services") {
 		t.Errorf("Bad action %v", action)
-	} else if output[0] != "No resources found." {
+	} else if output[0] != "No services found." {
 		t.Errorf("Bad output %s", output[0])
 	}
 }

--- a/test/e2e/basic_workflow_test.go
+++ b/test/e2e/basic_workflow_test.go
@@ -75,7 +75,7 @@ func (test *e2eTest) serviceListEmpty(t *testing.T) {
 	out, err := test.kn.RunWithOpts([]string{"service", "list"}, runOpts{NoNamespace: false})
 	assert.NilError(t, err)
 
-	assert.Check(t, util.ContainsAll(out, "No resources found."))
+	assert.Check(t, util.ContainsAll(out, "No services found."))
 }
 
 func (test *e2eTest) serviceCreate(t *testing.T, serviceName string) {


### PR DESCRIPTION
For the sake of consistency with out own service commands and for kubectl,

`kn plugin list` should print:

```
No plugins found.
```

`kn service list` should print:

```
No services found.
```

and not `No resources found.` like it does now.

Same for `kn routes list`.