### PR TITLE
Always create in new format rather than old

### DIFF
--- a/pkg/kn/commands/service/service_create.go
+++ b/pkg/kn/commands/service/service_create.go
@@ -206,16 +206,10 @@ func constructService(cmd *cobra.Command, editFlags ConfigurationEditFlags, name
 		},
 	}
 
-	// TODO: Should it always be `runLatest` ?
-	service.Spec.DeprecatedRunLatest = &serving_v1alpha1_api.RunLatestType{
-		Configuration: serving_v1alpha1_api.ConfigurationSpec{
-			DeprecatedRevisionTemplate: &serving_v1alpha1_api.RevisionTemplateSpec{
-				Spec: serving_v1alpha1_api.RevisionSpec{
-					DeprecatedContainer: &corev1.Container{},
-				},
-			},
-		},
+	service.Spec.Template = &serving_v1alpha1_api.RevisionTemplateSpec{
+		Spec: serving_v1alpha1_api.RevisionSpec{},
 	}
+	service.Spec.Template.Spec.Containers = []corev1.Container{{}}
 
 	err := editFlags.Apply(&service, cmd)
 	if err != nil {

--- a/pkg/kn/commands/service/service_create_mock_test.go
+++ b/pkg/kn/commands/service/service_create_mock_test.go
@@ -75,7 +75,7 @@ func TestServiceCreateLabel(t *testing.T) {
 	template.Spec.Containers[0].Image = "gcr.io/foo/bar:baz"
 	r.CreateService(service, nil)
 
-	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz", "-l", "a=mouse", "--label", "b=cookie", "--label=empty", "--async")
+	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz", "-l", "a=mouse", "--label", "b=cookie", "--label=empty", "--async", "--revision-name=")
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", "foo", "default"))
 

--- a/pkg/kn/commands/service/service_create_mock_test.go
+++ b/pkg/kn/commands/service/service_create_mock_test.go
@@ -72,7 +72,7 @@ func TestServiceCreateLabel(t *testing.T) {
 	template, err := servinglib.RevisionTemplateOfService(service)
 	assert.NilError(t, err)
 	template.ObjectMeta.Labels = expected
-	template.Spec.DeprecatedContainer.Image = "gcr.io/foo/bar:baz"
+	template.Spec.Containers[0].Image = "gcr.io/foo/bar:baz"
 	r.CreateService(service, nil)
 
 	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz", "-l", "a=mouse", "--label", "b=cookie", "--label=empty", "--async")
@@ -88,23 +88,19 @@ func getService(name string) *v1alpha1.Service {
 			Name:      name,
 			Namespace: "default",
 		},
-		Spec: v1alpha1.ServiceSpec{
-			DeprecatedRunLatest: &v1alpha1.RunLatestType{
-				Configuration: v1alpha1.ConfigurationSpec{
-					DeprecatedRevisionTemplate: &v1alpha1.RevisionTemplateSpec{
-						Spec: v1alpha1.RevisionSpec{
-							DeprecatedContainer: &corev1.Container{
-								Resources: corev1.ResourceRequirements{
-									Limits:   corev1.ResourceList{},
-									Requests: corev1.ResourceList{},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
+		Spec: v1alpha1.ServiceSpec{},
 	}
+
+	service.Spec.Template = &v1alpha1.RevisionTemplateSpec{
+		Spec: v1alpha1.RevisionSpec{},
+	}
+
+	service.Spec.Template.Spec.Containers = []corev1.Container{{
+		Resources: corev1.ResourceRequirements{
+			Limits:   corev1.ResourceList{},
+			Requests: corev1.ResourceList{},
+		},
+	}}
 	return service
 }
 

--- a/pkg/kn/commands/service/service_create_test.go
+++ b/pkg/kn/commands/service/service_create_test.go
@@ -124,8 +124,8 @@ func TestServiceCreateImage(t *testing.T) {
 	template, err := servinglib.RevisionTemplateOfService(created)
 	if err != nil {
 		t.Fatal(err)
-	} else if template.Spec.DeprecatedContainer.Image != "gcr.io/foo/bar:baz" {
-		t.Fatalf("wrong image set: %v", template.Spec.DeprecatedContainer.Image)
+	} else if template.Spec.Containers[0].Image != "gcr.io/foo/bar:baz" {
+		t.Fatalf("wrong image set: %v", template.Spec.Containers[0].Image)
 	} else if !strings.Contains(output, "foo") || !strings.Contains(output, "created") ||
 		!strings.Contains(output, commands.FakeNamespace) {
 		t.Fatalf("wrong stdout message: %v", output)
@@ -144,8 +144,8 @@ func TestServiceCreateImageSync(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if template.Spec.DeprecatedContainer.Image != "gcr.io/foo/bar:baz" {
-		t.Fatalf("wrong image set: %v", template.Spec.DeprecatedContainer.Image)
+	if template.Spec.Containers[0].Image != "gcr.io/foo/bar:baz" {
+		t.Fatalf("wrong image set: %v", template.Spec.Containers[0].Image)
 	}
 	if !strings.Contains(output, "foo") || !strings.Contains(output, "created") ||
 		!strings.Contains(output, commands.FakeNamespace) {
@@ -173,19 +173,19 @@ func TestServiceCreateEnv(t *testing.T) {
 	}
 
 	template, err := servinglib.RevisionTemplateOfService(created)
-	actualEnvVars, err := servinglib.EnvToMap(template.Spec.DeprecatedContainer.Env)
+	actualEnvVars, err := servinglib.EnvToMap(template.Spec.Containers[0].Env)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if err != nil {
 		t.Fatal(err)
-	} else if template.Spec.DeprecatedContainer.Image != "gcr.io/foo/bar:baz" {
-		t.Fatalf("wrong image set: %v", template.Spec.DeprecatedContainer.Image)
+	} else if template.Spec.Containers[0].Image != "gcr.io/foo/bar:baz" {
+		t.Fatalf("wrong image set: %v", template.Spec.Containers[0].Image)
 	} else if !reflect.DeepEqual(
 		actualEnvVars,
 		expectedEnvVars) {
-		t.Fatalf("wrong env vars %v", template.Spec.DeprecatedContainer.Env)
+		t.Fatalf("wrong env vars %v", template.Spec.Containers[0].Env)
 	}
 }
 
@@ -209,9 +209,9 @@ func TestServiceCreateWithRequests(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(
-		template.Spec.DeprecatedContainer.Resources.Requests,
+		template.Spec.Containers[0].Resources.Requests,
 		expectedRequestsVars) {
-		t.Fatalf("wrong requests vars %v", template.Spec.DeprecatedContainer.Resources.Requests)
+		t.Fatalf("wrong requests vars %v", template.Spec.Containers[0].Resources.Requests)
 	}
 }
 
@@ -235,9 +235,9 @@ func TestServiceCreateWithLimits(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(
-		template.Spec.DeprecatedContainer.Resources.Limits,
+		template.Spec.Containers[0].Resources.Limits,
 		expectedLimitsVars) {
-		t.Fatalf("wrong limits vars %v", template.Spec.DeprecatedContainer.Resources.Limits)
+		t.Fatalf("wrong limits vars %v", template.Spec.Containers[0].Resources.Limits)
 	}
 }
 
@@ -265,15 +265,15 @@ func TestServiceCreateRequestsLimitsCPU(t *testing.T) {
 		t.Fatal(err)
 	} else {
 		if !reflect.DeepEqual(
-			template.Spec.DeprecatedContainer.Resources.Requests,
+			template.Spec.Containers[0].Resources.Requests,
 			expectedRequestsVars) {
-			t.Fatalf("wrong requests vars %v", template.Spec.DeprecatedContainer.Resources.Requests)
+			t.Fatalf("wrong requests vars %v", template.Spec.Containers[0].Resources.Requests)
 		}
 
 		if !reflect.DeepEqual(
-			template.Spec.DeprecatedContainer.Resources.Limits,
+			template.Spec.Containers[0].Resources.Limits,
 			expectedLimitsVars) {
-			t.Fatalf("wrong limits vars %v", template.Spec.DeprecatedContainer.Resources.Limits)
+			t.Fatalf("wrong limits vars %v", template.Spec.Containers[0].Resources.Limits)
 		}
 	}
 }
@@ -302,15 +302,15 @@ func TestServiceCreateRequestsLimitsMemory(t *testing.T) {
 		t.Fatal(err)
 	} else {
 		if !reflect.DeepEqual(
-			template.Spec.DeprecatedContainer.Resources.Requests,
+			template.Spec.Containers[0].Resources.Requests,
 			expectedRequestsVars) {
-			t.Fatalf("wrong requests vars %v", template.Spec.DeprecatedContainer.Resources.Requests)
+			t.Fatalf("wrong requests vars %v", template.Spec.Containers[0].Resources.Requests)
 		}
 
 		if !reflect.DeepEqual(
-			template.Spec.DeprecatedContainer.Resources.Limits,
+			template.Spec.Containers[0].Resources.Limits,
 			expectedLimitsVars) {
-			t.Fatalf("wrong limits vars %v", template.Spec.DeprecatedContainer.Resources.Limits)
+			t.Fatalf("wrong limits vars %v", template.Spec.Containers[0].Resources.Limits)
 		}
 	}
 }
@@ -379,15 +379,15 @@ func TestServiceCreateRequestsLimitsCPUMemory(t *testing.T) {
 		t.Fatal(err)
 	} else {
 		if !reflect.DeepEqual(
-			template.Spec.DeprecatedContainer.Resources.Requests,
+			template.Spec.Containers[0].Resources.Requests,
 			expectedRequestsVars) {
-			t.Fatalf("wrong requests vars %v", template.Spec.DeprecatedContainer.Resources.Requests)
+			t.Fatalf("wrong requests vars %v", template.Spec.Containers[0].Resources.Requests)
 		}
 
 		if !reflect.DeepEqual(
-			template.Spec.DeprecatedContainer.Resources.Limits,
+			template.Spec.Containers[0].Resources.Limits,
 			expectedLimitsVars) {
-			t.Fatalf("wrong limits vars %v", template.Spec.DeprecatedContainer.Resources.Limits)
+			t.Fatalf("wrong limits vars %v", template.Spec.Containers[0].Resources.Limits)
 		}
 	}
 }
@@ -426,8 +426,8 @@ func TestServiceCreateImageForce(t *testing.T) {
 	template, err := servinglib.RevisionTemplateOfService(created)
 	if err != nil {
 		t.Fatal(err)
-	} else if template.Spec.DeprecatedContainer.Image != "gcr.io/foo/bar:v2" {
-		t.Fatalf("wrong image set: %v", template.Spec.DeprecatedContainer.Image)
+	} else if template.Spec.Containers[0].Image != "gcr.io/foo/bar:v2" {
+		t.Fatalf("wrong image set: %v", template.Spec.Containers[0].Image)
 	} else if !strings.Contains(output, "foo") || !strings.Contains(output, commands.FakeNamespace) {
 		t.Fatalf("wrong output: %s", output)
 	}
@@ -453,18 +453,18 @@ func TestServiceCreateEnvForce(t *testing.T) {
 		"B": "LIONS"}
 
 	template, err := servinglib.RevisionTemplateOfService(created)
-	actualEnvVars, err := servinglib.EnvToMap(template.Spec.DeprecatedContainer.Env)
+	actualEnvVars, err := servinglib.EnvToMap(template.Spec.Containers[0].Env)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if err != nil {
 		t.Fatal(err)
-	} else if template.Spec.DeprecatedContainer.Image != "gcr.io/foo/bar:v2" {
-		t.Fatalf("wrong image set: %v", template.Spec.DeprecatedContainer.Image)
+	} else if template.Spec.Containers[0].Image != "gcr.io/foo/bar:v2" {
+		t.Fatalf("wrong image set: %v", template.Spec.Containers[0].Image)
 	} else if !reflect.DeepEqual(
 		actualEnvVars,
 		expectedEnvVars) {
-		t.Fatalf("wrong env vars:%v", template.Spec.DeprecatedContainer.Env)
+		t.Fatalf("wrong env vars:%v", template.Spec.Containers[0].Env)
 	} else if !strings.Contains(output, "foo") || !strings.Contains(output, commands.FakeNamespace) {
 		t.Fatalf("wrong output: %s", output)
 	}

--- a/pkg/kn/commands/service/service_test.go
+++ b/pkg/kn/commands/service/service_test.go
@@ -19,12 +19,37 @@ import (
 
 	"github.com/knative/client/pkg/kn/commands"
 	knclient "github.com/knative/client/pkg/serving/v1alpha1"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // Helper methods
+var blankConfig clientcmd.ClientConfig
+
+func init() {
+	var err error
+	blankConfig, err = clientcmd.NewClientConfigFromBytes([]byte(`kind: Config
+version: v1
+users:
+- name: u
+clusters:
+- name: c
+  cluster:
+    server: example.com
+contexts:
+- name: x
+  context:
+    user: u
+    cluster: c
+current-context: x
+`))
+	if err != nil {
+		panic(err)
+	}
+}
 
 func executeServiceCommand(client knclient.KnClient, args ...string) (string, error) {
 	knParams := &commands.KnParams{}
+	knParams.ClientConfig = blankConfig
 
 	output := new(bytes.Buffer)
 	knParams.Output = output


### PR DESCRIPTION
This is the version of the pull request where we don't make a flag to determine whether we want to use the "old format" or the "new lemonadey v1beta1 format", we just create new services in the new format.

This will DROP SUPPORT for 0.5

We could also have a flag, but this PR is quicker and easier to make, so I'm making it and we can discuss.