### PR TITLE
Portable plugin executable check for Windows platform

### DIFF
--- a/pkg/kn/commands/plugin/plugin_verifier.go
+++ b/pkg/kn/commands/plugin/plugin_verifier.go
@@ -14,6 +14,10 @@
 
 // +build !windows
 
+// This file doesn't compile for Windows platform, it defines respective build tag (build tag),
+// the respective functionality is present in plugin_verifier_windows.go file in same dir,
+// which only compiles for Windows platform.
+
 package plugin
 
 import (

--- a/pkg/kn/commands/plugin/plugin_verifier_windows.go
+++ b/pkg/kn/commands/plugin/plugin_verifier_windows.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build windows
+// This file is replacement of plugin_verifier.go file in same dir, and
+// compiles only for Windows platform (its suffix defines that).
 
 package plugin
 


### PR DESCRIPTION
 Fixes #365

## Proposed Changes
 The code used for checking whether plugin is executable or not in plugin verifier
 does not build for Windows. Builds Windows and non-Windows platform plugin verifier separately
