### PR TITLE
Fix json path to latest revision in e2e tests to something reliable

### DIFF
--- a/test/e2e/traffic_split_test.go
+++ b/test/e2e/traffic_split_test.go
@@ -35,7 +35,7 @@ var targetFieldsLength = 4
 var targetsJsonPath = "jsonpath={range .status.traffic[*]}{.tag}{','}{.revisionName}{','}{.percent}{','}{.latestRevision}{'|'}{end}"
 
 // returns deployed service latest revision name
-var latestRevisionJsonPath = "jsonpath={.status.traffic[?(@.latestRevision==true)].revisionName}"
+var latestRevisionJsonPath = "jsonpath={.status.latestCreatedRevisionName}"
 
 // TargetFileds are used in e2e to store expected fields per traffic target
 // and actual traffic targets fields of deployed service are converted into struct before comparing


### PR DESCRIPTION
This is just a small change that should make a helper function in the tests reliably return the latest revision name even when traffic doesn't have anything set to latest. No change to the actual running of the tests.
