### PR TITLE
Retain the request body when logging HTTP.

### DIFF
--- a/pkg/util/logging_http_transport_test.go
+++ b/pkg/util/logging_http_transport_test.go
@@ -17,17 +17,26 @@ package util
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/http/httputil"
 	"strings"
 	"testing"
 
 	"gotest.tools/assert"
 )
 
-type dummyTransport struct{}
+type dummyTransport struct {
+	requestDump string
+}
 
 func (d *dummyTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	dump, err := httputil.DumpRequest(r, true)
+	if err != nil {
+		return nil, fmt.Errorf("dumping request: %v", err)
+	}
+	d.requestDump = string(dump)
 	return &http.Response{
 		Status:     "200 OK",
 		StatusCode: 200,
@@ -44,13 +53,17 @@ func (d *errorTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 
 func TestWritesRequestResponse(t *testing.T) {
 	out := &bytes.Buffer{}
-	transport := NewLoggingTransportWithStream(&dummyTransport{}, out)
-	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	dt := &dummyTransport{}
+	transport := NewLoggingTransportWithStream(dt, out)
+	body := "{this: is, the: body, of: [the, request]}"
+	req, _ := http.NewRequest("POST", "http://example.com", strings.NewReader(body))
 	_, e := transport.RoundTrip(req)
 	assert.NilError(t, e)
 	s := out.String()
 	assert.Assert(t, strings.Contains(s, "REQUEST"))
 	assert.Assert(t, strings.Contains(s, "RESPONSE"))
+	assert.Assert(t, strings.Contains(s, body))
+	assert.Assert(t, strings.Contains(dt.requestDump, body))
 }
 
 func TestElideAuthorizationHeader(t *testing.T) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -191,6 +191,7 @@ k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/runtime/schema
 k8s.io/apimachinery/pkg/fields
 k8s.io/apimachinery/pkg/labels
+k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/pkg/util/validation/field
 k8s.io/apimachinery/pkg/conversion
@@ -206,7 +207,6 @@ k8s.io/apimachinery/pkg/api/validation
 k8s.io/apimachinery/pkg/runtime/serializer
 k8s.io/apimachinery/pkg/conversion/queryparams
 k8s.io/apimachinery/pkg/util/naming
-k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/util/net
 k8s.io/apimachinery/pkg/util/yaml
 k8s.io/apimachinery/third_party/forked/golang/reflect


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #377

## Proposed Changes

* Retain the request body when logging HTTP.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
--log-http now works for requests with a body.
```
