### PR TITLE
check if status detail is nil

### DIFF
--- a/pkg/errors/factory.go
+++ b/pkg/errors/factory.go
@@ -39,6 +39,10 @@ func GetError(err error) error {
 		return err
 	}
 
+	if apiStatus.Status().Details == nil {
+		return err
+	}
+
 	var knerr *KNError
 
 	if isCRDError(apiStatus) {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes nil pointer error in case `apiStatus.Status().Details` is `nil`.

## Proposed Changes

* Adds a nil check of `apiStatus.Status().Details` in errors package
* Returns the original error if it is nil

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
