### PR TITLE
Fill up test cases for files with low code coverage

### DIFF
--- a/pkg/kn/commands/route/list_flags_test.go
+++ b/pkg/kn/commands/route/list_flags_test.go
@@ -40,8 +40,8 @@ func TestRoutListFlags(t *testing.T) {
 		t.Fatalf("Failed to print the object.")
 	}
 	actualFormats := routeListFlags.AllowedFormats()
-	expectedFormats := []string{"json", "yaml", "name", "go-template", "go-template-file", "template", "templatefile", "jsonpath", "jsonpath-file"}
-	if reflect.DeepEqual(actualFormats, expectedFormats) {
+	expectedFormats := []string{"json", "yaml", "name", "go-template", "go-template-file", "template", "templatefile", "jsonpath", "jsonpath-file", "no-headers"}
+	if !reflect.DeepEqual(actualFormats, expectedFormats) {
 		t.Fatalf("Expecting allowed formats:\n%s\nFound:\n%s\n", expectedFormats, actualFormats)
 	}
 }

--- a/pkg/kn/commands/service/service_delete_test.go
+++ b/pkg/kn/commands/service/service_delete_test.go
@@ -1,0 +1,61 @@
+// Copyright © 2019 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	client_testing "k8s.io/client-go/testing"
+	"knative.dev/client/pkg/kn/commands"
+	"knative.dev/client/pkg/util"
+)
+
+func fakeServiceDelete(args []string) (action client_testing.Action, name string, output string, err error) {
+	knParams := &commands.KnParams{}
+	cmd, fakeServing, buf := commands.CreateTestKnCommand(NewServiceCommand(knParams), knParams)
+	fakeServing.AddReactor("delete", "services",
+		func(a client_testing.Action) (bool, runtime.Object, error) {
+			deleteAction, _ := a.(client_testing.DeleteAction)
+			action = deleteAction
+			name = deleteAction.GetName()
+			return true, nil, nil
+		})
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	if err != nil {
+		return
+	}
+	output = buf.String()
+	return
+}
+
+func TestServiceDelete(t *testing.T) {
+	sevName := "sev-12345"
+	action, name, output, err := fakeServiceDelete([]string{"service", "delete", sevName})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if action == nil {
+		t.Errorf("No action")
+	} else if !action.Matches("delete", "services") {
+		t.Errorf("Bad action %v", action)
+	} else if name != sevName {
+		t.Errorf("Bad service name returned after delete.")
+	}
+	assert.Check(t, util.ContainsAll(output, "Service", sevName, "deleted", "namespace", commands.FakeNamespace))
+}

--- a/pkg/kn/commands/service/service_list_flags_test.go
+++ b/pkg/kn/commands/service/service_list_flags_test.go
@@ -1,0 +1,45 @@
+// Copyright © 2019 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or im
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"gotest.tools/assert"
+)
+
+func TestServiceListFlags(t *testing.T) {
+	var cmd *cobra.Command
+
+	t.Run("adds service list flag", func(t *testing.T) {
+		serviceListFlags := NewServiceListFlags()
+
+		cmd = &cobra.Command{}
+		serviceListFlags.AddFlags(cmd)
+
+		assert.Assert(t, serviceListFlags != nil)
+		assert.Assert(t, cmd.Flags() != nil)
+
+		allowMissingTemplateKeys, err := cmd.Flags().GetBool("allow-missing-template-keys")
+		assert.NilError(t, err)
+		assert.Assert(t, allowMissingTemplateKeys == true)
+
+		actualFormats := serviceListFlags.AllowedFormats()
+		expectedFormats := []string{"json", "yaml", "name", "go-template", "go-template-file", "template", "templatefile", "jsonpath", "jsonpath-file", "no-headers"}
+		assert.Assert(t, reflect.DeepEqual(actualFormats, expectedFormats))
+	})
+}


### PR DESCRIPTION
To get the test pass for https://github.com/knative/client/pull/245,
need to fill up test cases for files with low code coverage

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #
test failure in https://github.com/knative/client/pull/245

## Proposed Changes

* Added test cases

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
