### PR TITLE
chore (service): Use sets utility for holding updated env vars

### DIFF
--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -189,9 +189,9 @@ k8s.io/apimachinery/pkg/api/resource
 k8s.io/apimachinery/pkg/api/meta
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/runtime/schema
+k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/fields
 k8s.io/apimachinery/pkg/labels
-k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/pkg/util/validation/field
 k8s.io/apimachinery/pkg/conversion


### PR DESCRIPTION
## Proposed Changes

This is a follow up PR of #389.

* Insert updated env vars into [sets.String](https://godoc.org/k8s.io/apimachinery/pkg/util/sets#String) and use it for selecting which items are appended to the original slice of env vars.

/lint
