### PR TITLE
chore(template): Update release note section in PR template

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -12,12 +12,14 @@ Fixes #
 *
 *
 
-**Release Note**
+<!--
+Release Note:
 
-<!-- Enter your extended release note in the below block. If the PR requires
-additional action from users switching to the new release, include the string
-"action required". If no release note is required, write "NONE". -->
+In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:
 
-```release-note
+- 🎁 Add new feature
+- 🐛 Fix bug
+- 🧽 Update or clean up current behaviour
+- 🗑️ Remove feature or internal logic
 
-```
+-->


### PR DESCRIPTION
## Proposed Changes

We often ask the contributors to update CHANGELOG.adoc manually in PR comment, but shouldn't we write up the instruction in PR template?

* Remove unused release note section in PR template and add instruction for updating CHANGELOG.

Related to #176 