### PR TITLE
Update the description of flag namespace

### DIFF
--- a/docs/cmd/kn_revision_delete.md
+++ b/docs/cmd/kn_revision_delete.md
@@ -22,7 +22,7 @@ kn revision delete NAME [flags]
 
 ```
   -h, --help               help for delete
-  -n, --namespace string   List the requested object(s) in given namespace.
+  -n, --namespace string   Specify the namespace to operate in.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/kn_revision_describe.md
+++ b/docs/cmd/kn_revision_describe.md
@@ -15,7 +15,7 @@ kn revision describe NAME [flags]
 ```
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for describe
-  -n, --namespace string              List the requested object(s) in given namespace.
+  -n, --namespace string              Specify the namespace to operate in.
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file. (default "yaml")
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```

--- a/docs/cmd/kn_revision_list.md
+++ b/docs/cmd/kn_revision_list.md
@@ -33,7 +33,7 @@ kn revision list [name] [flags]
   -A, --all-namespaces                If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
-  -n, --namespace string              List the requested object(s) in given namespace.
+  -n, --namespace string              Specify the namespace to operate in.
       --no-headers                    When using the default output format, don't print headers (default: print headers).
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
   -s, --service string                Service name

--- a/docs/cmd/kn_route_describe.md
+++ b/docs/cmd/kn_route_describe.md
@@ -15,7 +15,7 @@ kn route describe NAME [flags]
 ```
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for describe
-  -n, --namespace string              List the requested object(s) in given namespace.
+  -n, --namespace string              Specify the namespace to operate in.
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file. (default "yaml")
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```

--- a/docs/cmd/kn_route_list.md
+++ b/docs/cmd/kn_route_list.md
@@ -30,7 +30,7 @@ kn route list NAME [flags]
   -A, --all-namespaces                If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
-  -n, --namespace string              List the requested object(s) in given namespace.
+  -n, --namespace string              Specify the namespace to operate in.
       --no-headers                    When using the default output format, don't print headers (default: print headers).
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -52,7 +52,7 @@ kn service create NAME --image IMAGE [flags]
       --lock-to-digest           keep the running image for the service constant when not explicitly specifying the image. (--no-lock-to-digest pulls the image tag afresh with each new revision) (default true)
       --max-scale int            Maximal number of replicas.
       --min-scale int            Minimal number of replicas.
-  -n, --namespace string         List the requested object(s) in given namespace.
+  -n, --namespace string         Specify the namespace to operate in.
       --no-lock-to-digest        do not keep the running image for the service constant when not explicitly specifying the image. (--no-lock-to-digest pulls the image tag afresh with each new revision)
   -p, --port int32               The port where application listens on.
       --requests-cpu string      The requested CPU (e.g., 250m).

--- a/docs/cmd/kn_service_delete.md
+++ b/docs/cmd/kn_service_delete.md
@@ -25,7 +25,7 @@ kn service delete NAME [flags]
 
 ```
   -h, --help               help for delete
-  -n, --namespace string   List the requested object(s) in given namespace.
+  -n, --namespace string   Specify the namespace to operate in.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/kn_service_describe.md
+++ b/docs/cmd/kn_service_describe.md
@@ -15,7 +15,7 @@ kn service describe NAME [flags]
 ```
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for describe
-  -n, --namespace string              List the requested object(s) in given namespace.
+  -n, --namespace string              Specify the namespace to operate in.
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
   -v, --verbose                       More output.

--- a/docs/cmd/kn_service_list.md
+++ b/docs/cmd/kn_service_list.md
@@ -30,7 +30,7 @@ kn service list [name] [flags]
   -A, --all-namespaces                If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
-  -n, --namespace string              List the requested object(s) in given namespace.
+  -n, --namespace string              Specify the namespace to operate in.
       --no-headers                    When using the default output format, don't print headers (default: print headers).
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -50,7 +50,7 @@ kn service update NAME [flags]
       --lock-to-digest           keep the running image for the service constant when not explicitly specifying the image. (--no-lock-to-digest pulls the image tag afresh with each new revision) (default true)
       --max-scale int            Maximal number of replicas.
       --min-scale int            Minimal number of replicas.
-  -n, --namespace string         List the requested object(s) in given namespace.
+  -n, --namespace string         Specify the namespace to operate in.
       --no-lock-to-digest        do not keep the running image for the service constant when not explicitly specifying the image. (--no-lock-to-digest pulls the image tag afresh with each new revision)
   -p, --port int32               The port where application listens on.
       --requests-cpu string      The requested CPU (e.g., 250m).

--- a/pkg/kn/commands/namespaced.go
+++ b/pkg/kn/commands/namespaced.go
@@ -28,7 +28,7 @@ func AddNamespaceFlags(flags *pflag.FlagSet, allowAll bool) {
 		"namespace",
 		"n",
 		"",
-		"List the requested object(s) in given namespace.",
+		"Specify the namespace to operate in.",
 	)
 
 	if allowAll {

--- a/pkg/kn/commands/plugin/handler.go
+++ b/pkg/kn/commands/plugin/handler.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/mitchellh/go-homedir"
+	homedir "github.com/mitchellh/go-homedir"
 )
 
 // PluginHandler is capable of parsing command line arguments

--- a/pkg/kn/commands/plugin/list.go
+++ b/pkg/kn/commands/plugin/list.go
@@ -21,11 +21,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 
 	"knative.dev/client/pkg/kn/commands"
-
-	"github.com/mitchellh/go-homedir"
 )
 
 // ValidPluginFilenamePrefixes controls the prefix for all kn plugins


### PR DESCRIPTION
Fixes #418

## Proposed Changes

* Change the description of flag `namespace` because it will serve for other actions besides `list`, e.g. create, update and etc.
