### PR TITLE
refactor(knclient): Moved KnClient -> KnServingClient

### DIFF
--- a/pkg/kn/commands/plugin/handler.go
+++ b/pkg/kn/commands/plugin/handler.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/mitchellh/go-homedir"
+	homedir "github.com/mitchellh/go-homedir"
 )
 
 // PluginHandler is capable of parsing command line arguments

--- a/pkg/kn/commands/plugin/list.go
+++ b/pkg/kn/commands/plugin/list.go
@@ -21,11 +21,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 
 	"knative.dev/client/pkg/kn/commands"
-
-	"github.com/mitchellh/go-homedir"
 )
 
 // ValidPluginFilenamePrefixes controls the prefix for all kn plugins

--- a/pkg/kn/commands/revision/list.go
+++ b/pkg/kn/commands/revision/list.go
@@ -122,7 +122,7 @@ func NewRevisionListCommand(p *commands.KnParams) *cobra.Command {
 	return revisionListCommand
 }
 
-func getRevisionInfo(args []string, client v1alpha12.KnClient) (*v1alpha1.RevisionList, error) {
+func getRevisionInfo(args []string, client v1alpha12.KnServingClient) (*v1alpha1.RevisionList, error) {
 	var (
 		revisionList *v1alpha1.RevisionList
 		err          error

--- a/pkg/kn/commands/service/create.go
+++ b/pkg/kn/commands/service/create.go
@@ -134,7 +134,7 @@ func flush(out io.Writer) {
 	}
 }
 
-func createService(client v1alpha1.KnClient, service *serving_v1alpha1_api.Service, namespace string, out io.Writer) error {
+func createService(client v1alpha1.KnServingClient, service *serving_v1alpha1_api.Service, namespace string, out io.Writer) error {
 	err := client.CreateService(service)
 	if err != nil {
 		return err
@@ -143,7 +143,7 @@ func createService(client v1alpha1.KnClient, service *serving_v1alpha1_api.Servi
 	return nil
 }
 
-func replaceService(client v1alpha1.KnClient, service *serving_v1alpha1_api.Service, namespace string, out io.Writer) error {
+func replaceService(client v1alpha1.KnServingClient, service *serving_v1alpha1_api.Service, namespace string, out io.Writer) error {
 	var retries = 0
 	for {
 		existingService, err := client.GetService(service.Name)
@@ -186,7 +186,7 @@ func replaceService(client v1alpha1.KnClient, service *serving_v1alpha1_api.Serv
 	}
 }
 
-func serviceExists(client v1alpha1.KnClient, name string) (bool, error) {
+func serviceExists(client v1alpha1.KnServingClient, name string) (bool, error) {
 	_, err := client.GetService(name)
 	if api_errors.IsNotFound(err) {
 		return false, nil
@@ -225,7 +225,7 @@ func constructService(cmd *cobra.Command, editFlags ConfigurationEditFlags, name
 	return &service, nil
 }
 
-func showUrl(client v1alpha1.KnClient, serviceName string, namespace string, out io.Writer) error {
+func showUrl(client v1alpha1.KnServingClient, serviceName string, namespace string, out io.Writer) error {
 	service, err := client.GetService(serviceName)
 	if err != nil {
 		return fmt.Errorf("cannot fetch service '%s' in namespace '%s' for extracting the URL: %v", serviceName, namespace, err)

--- a/pkg/kn/commands/service/describe.go
+++ b/pkg/kn/commands/service/describe.go
@@ -452,7 +452,7 @@ func age(t time.Time) string {
 
 // Call the backend to query revisions for the given service and build up
 // the view objects used for output
-func getRevisionDescriptions(client serving_kn_v1alpha1.KnClient, service *v1alpha1.Service, withDetails bool) ([]*revisionDesc, error) {
+func getRevisionDescriptions(client serving_kn_v1alpha1.KnServingClient, service *v1alpha1.Service, withDetails bool) ([]*revisionDesc, error) {
 	revisionDescs := make(map[string]*revisionDesc)
 
 	trafficTargets := service.Status.Traffic
@@ -489,7 +489,7 @@ func orderByConfigurationGeneration(descs map[string]*revisionDesc) []*revisionD
 	return descsList
 }
 
-func completeWithUntargetedRevisions(client serving_kn_v1alpha1.KnClient, service *v1alpha1.Service, descs map[string]*revisionDesc) error {
+func completeWithUntargetedRevisions(client serving_kn_v1alpha1.KnServingClient, service *v1alpha1.Service, descs map[string]*revisionDesc) error {
 	revisions, err := client.ListRevisions(serving_kn_v1alpha1.WithService(service.Name))
 	if err != nil {
 		return err
@@ -635,7 +635,7 @@ func extractContainer(revision *v1alpha1.Revision) *v1.Container {
 	return revision.Spec.DeprecatedContainer
 }
 
-func extractRevisionFromTarget(client serving_kn_v1alpha1.KnClient, target v1alpha1.TrafficTarget) (*v1alpha1.Revision, error) {
+func extractRevisionFromTarget(client serving_kn_v1alpha1.KnServingClient, target v1alpha1.TrafficTarget) (*v1alpha1.Revision, error) {
 	var revisionName = target.RevisionName
 	if revisionName == "" {
 		configurationName := target.ConfigurationName

--- a/pkg/kn/commands/service/list.go
+++ b/pkg/kn/commands/service/list.go
@@ -85,7 +85,7 @@ func NewServiceListCommand(p *commands.KnParams) *cobra.Command {
 	return serviceListCommand
 }
 
-func getServiceInfo(args []string, client v1alpha12.KnClient) (*v1alpha1.ServiceList, error) {
+func getServiceInfo(args []string, client v1alpha12.KnServingClient) (*v1alpha1.ServiceList, error) {
 	var (
 		serviceList *v1alpha1.ServiceList
 		err         error

--- a/pkg/kn/commands/service/service.go
+++ b/pkg/kn/commands/service/service.go
@@ -44,7 +44,7 @@ func NewServiceCommand(p *commands.KnParams) *cobra.Command {
 	return serviceCmd
 }
 
-func waitForService(client serving_kn_v1alpha1.KnClient, serviceName string, out io.Writer, timeout int) error {
+func waitForService(client serving_kn_v1alpha1.KnServingClient, serviceName string, out io.Writer, timeout int) error {
 	fmt.Fprintf(out, "Waiting for service '%s' to become ready ... ", serviceName)
 	flush(out)
 

--- a/pkg/kn/commands/service/service_test.go
+++ b/pkg/kn/commands/service/service_test.go
@@ -47,13 +47,13 @@ current-context: x
 	}
 }
 
-func executeServiceCommand(client knclient.KnClient, args ...string) (string, error) {
+func executeServiceCommand(client knclient.KnServingClient, args ...string) (string, error) {
 	knParams := &commands.KnParams{}
 	knParams.ClientConfig = blankConfig
 
 	output := new(bytes.Buffer)
 	knParams.Output = output
-	knParams.NewClient = func(namespace string) (knclient.KnClient, error) {
+	knParams.NewClient = func(namespace string) (knclient.KnServingClient, error) {
 		return client, nil
 	}
 	cmd := NewServiceCommand(knParams)

--- a/pkg/kn/commands/testing_helper.go
+++ b/pkg/kn/commands/testing_helper.go
@@ -46,7 +46,7 @@ func CreateTestKnCommand(cmd *cobra.Command, knParams *KnParams) (*cobra.Command
 	buf := new(bytes.Buffer)
 	fakeServing := &fake.FakeServingV1alpha1{&client_testing.Fake{}}
 	knParams.Output = buf
-	knParams.NewClient = func(namespace string) (v1alpha1.KnClient, error) {
+	knParams.NewClient = func(namespace string) (v1alpha1.KnServingClient, error) {
 		return v1alpha1.NewKnServingClient(fakeServing, namespace), nil
 	}
 	knParams.fixedCurrentNamespace = FakeNamespace

--- a/pkg/kn/commands/types.go
+++ b/pkg/kn/commands/types.go
@@ -43,7 +43,7 @@ type KnParams struct {
 	Output       io.Writer
 	KubeCfgPath  string
 	ClientConfig clientcmd.ClientConfig
-	NewClient    func(namespace string) (serving_kn_v1alpha1.KnClient, error)
+	NewClient    func(namespace string) (serving_kn_v1alpha1.KnServingClient, error)
 
 	// General global options
 	LogHTTP bool
@@ -58,7 +58,7 @@ func (params *KnParams) Initialize() {
 	}
 }
 
-func (params *KnParams) newClient(namespace string) (serving_kn_v1alpha1.KnClient, error) {
+func (params *KnParams) newClient(namespace string) (serving_kn_v1alpha1.KnServingClient, error) {
 	client, err := params.GetConfig()
 	if err != nil {
 		return nil, err

--- a/pkg/serving/v1alpha1/client.go
+++ b/pkg/serving/v1alpha1/client.go
@@ -20,22 +20,25 @@ import (
 
 	"k8s.io/apimachinery/pkg/fields"
 	"knative.dev/pkg/apis"
+	"knative.dev/serving/pkg/client/clientset/versioned/scheme"
 
 	"knative.dev/client/pkg/serving"
+	"knative.dev/client/pkg/util"
 	"knative.dev/client/pkg/wait"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	kn_errors "knative.dev/client/pkg/errors"
 	api_serving "knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	client_v1alpha1 "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
+
+	kn_errors "knative.dev/client/pkg/errors"
 )
 
 // Kn interface to serving. All methods are relative to the
 // namespace specified during construction
-type KnClient interface {
+type KnServingClient interface {
 
 	// Get a service by its unique name
 	GetService(name string) (*v1alpha1.Service, error)
@@ -121,26 +124,26 @@ func WithService(service string) ListConfig {
 	}
 }
 
-type knClient struct {
+type knServingClient struct {
 	client    client_v1alpha1.ServingV1alpha1Interface
 	namespace string
 }
 
 // Create a new client facade for the provided namespace
-func NewKnServingClient(client client_v1alpha1.ServingV1alpha1Interface, namespace string) KnClient {
-	return &knClient{
+func NewKnServingClient(client client_v1alpha1.ServingV1alpha1Interface, namespace string) KnServingClient {
+	return &knServingClient{
 		client:    client,
 		namespace: namespace,
 	}
 }
 
 // Get a service by its unique name
-func (cl *knClient) GetService(name string) (*v1alpha1.Service, error) {
+func (cl *knServingClient) GetService(name string) (*v1alpha1.Service, error) {
 	service, err := cl.client.Services(cl.namespace).Get(name, v1.GetOptions{})
 	if err != nil {
 		return nil, kn_errors.GetError(err)
 	}
-	err = serving.UpdateGroupVersionKind(service, v1alpha1.SchemeGroupVersion)
+	err = updateServingGvk(service)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +151,7 @@ func (cl *knClient) GetService(name string) (*v1alpha1.Service, error) {
 }
 
 // List services
-func (cl *knClient) ListServices(config ...ListConfig) (*v1alpha1.ServiceList, error) {
+func (cl *knServingClient) ListServices(config ...ListConfig) (*v1alpha1.ServiceList, error) {
 	serviceList, err := cl.client.Services(cl.namespace).List(ListConfigs(config).toListOptions())
 	if err != nil {
 		return nil, kn_errors.GetError(err)
@@ -172,7 +175,7 @@ func (cl *knClient) ListServices(config ...ListConfig) (*v1alpha1.ServiceList, e
 }
 
 // Create a new service
-func (cl *knClient) CreateService(service *v1alpha1.Service) error {
+func (cl *knServingClient) CreateService(service *v1alpha1.Service) error {
 	_, err := cl.client.Services(cl.namespace).Create(service)
 	if err != nil {
 		return kn_errors.GetError(err)
@@ -181,7 +184,7 @@ func (cl *knClient) CreateService(service *v1alpha1.Service) error {
 }
 
 // Update the given service
-func (cl *knClient) UpdateService(service *v1alpha1.Service) error {
+func (cl *knServingClient) UpdateService(service *v1alpha1.Service) error {
 	_, err := cl.client.Services(cl.namespace).Update(service)
 	if err != nil {
 		return err
@@ -190,7 +193,7 @@ func (cl *knClient) UpdateService(service *v1alpha1.Service) error {
 }
 
 // Delete a service by name
-func (cl *knClient) DeleteService(serviceName string) error {
+func (cl *knServingClient) DeleteService(serviceName string) error {
 	err := cl.client.Services(cl.namespace).Delete(
 		serviceName,
 		&v1.DeleteOptions{},
@@ -203,13 +206,13 @@ func (cl *knClient) DeleteService(serviceName string) error {
 }
 
 // Wait for a service to become ready, but not longer than provided timeout
-func (cl *knClient) WaitForService(name string, timeout time.Duration) error {
+func (cl *knServingClient) WaitForService(name string, timeout time.Duration) error {
 	waitForReady := newServiceWaitForReady(cl.client.Services(cl.namespace).Watch)
 	return waitForReady.Wait(name, timeout)
 }
 
 // Get the configuration for a service
-func (cl *knClient) GetConfiguration(name string) (*v1alpha1.Configuration, error) {
+func (cl *knServingClient) GetConfiguration(name string) (*v1alpha1.Configuration, error) {
 	configuration, err := cl.client.Configurations(cl.namespace).Get(name, v1.GetOptions{})
 	if err != nil {
 		return nil, err
@@ -222,7 +225,7 @@ func (cl *knClient) GetConfiguration(name string) (*v1alpha1.Configuration, erro
 }
 
 // Get a revision by name
-func (cl *knClient) GetRevision(name string) (*v1alpha1.Revision, error) {
+func (cl *knServingClient) GetRevision(name string) (*v1alpha1.Revision, error) {
 	revision, err := cl.client.Revisions(cl.namespace).Get(name, v1.GetOptions{})
 	if err != nil {
 		return nil, kn_errors.GetError(err)
@@ -248,11 +251,11 @@ var noBaseRevisionError = &NoBaseRevisionError{"base revision not found"}
 // a Service. It may not be findable with our heuristics, in which case this
 // method returns Errors()["no-base-revision"]. If it simply doesn't exist (like
 // it wasn't yet created or was deleted), return the usual not found error.
-func (cl *knClient) GetBaseRevision(service *v1alpha1.Service) (*v1alpha1.Revision, error) {
+func (cl *knServingClient) GetBaseRevision(service *v1alpha1.Service) (*v1alpha1.Revision, error) {
 	return getBaseRevision(cl, service)
 }
 
-func getBaseRevision(cl KnClient, service *v1alpha1.Service) (*v1alpha1.Revision, error) {
+func getBaseRevision(cl KnServingClient, service *v1alpha1.Service) (*v1alpha1.Revision, error) {
 	template, err := serving.RevisionTemplateOfService(service)
 	if err != nil {
 		return nil, err
@@ -291,7 +294,7 @@ func getBaseRevision(cl KnClient, service *v1alpha1.Service) (*v1alpha1.Revision
 }
 
 // Delete a revision by name
-func (cl *knClient) DeleteRevision(name string) error {
+func (cl *knServingClient) DeleteRevision(name string) error {
 	err := cl.client.Revisions(cl.namespace).Delete(name, &v1.DeleteOptions{})
 	if err != nil {
 		return kn_errors.GetError(err)
@@ -301,7 +304,7 @@ func (cl *knClient) DeleteRevision(name string) error {
 }
 
 // List revisions
-func (cl *knClient) ListRevisions(config ...ListConfig) (*v1alpha1.RevisionList, error) {
+func (cl *knServingClient) ListRevisions(config ...ListConfig) (*v1alpha1.RevisionList, error) {
 	revisionList, err := cl.client.Revisions(cl.namespace).List(ListConfigs(config).toListOptions())
 	if err != nil {
 		return nil, kn_errors.GetError(err)
@@ -310,12 +313,12 @@ func (cl *knClient) ListRevisions(config ...ListConfig) (*v1alpha1.RevisionList,
 }
 
 // Get a route by its unique name
-func (cl *knClient) GetRoute(name string) (*v1alpha1.Route, error) {
+func (cl *knServingClient) GetRoute(name string) (*v1alpha1.Route, error) {
 	route, err := cl.client.Routes(cl.namespace).Get(name, v1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
-	err = serving.UpdateGroupVersionKind(route, v1alpha1.SchemeGroupVersion)
+	err = updateServingGvk(route)
 	if err != nil {
 		return nil, err
 	}
@@ -323,7 +326,7 @@ func (cl *knClient) GetRoute(name string) (*v1alpha1.Route, error) {
 }
 
 // List routes
-func (cl *knClient) ListRoutes(config ...ListConfig) (*v1alpha1.RouteList, error) {
+func (cl *knServingClient) ListRoutes(config ...ListConfig) (*v1alpha1.RouteList, error) {
 	routeList, err := cl.client.Routes(cl.namespace).List(ListConfigs(config).toListOptions())
 	if err != nil {
 		return nil, err
@@ -375,7 +378,7 @@ func updateServingGvkForRouteList(routeList *v1alpha1.RouteList) (*v1alpha1.Rout
 
 // update with the v1alpha1 group + version
 func updateServingGvk(obj runtime.Object) error {
-	return serving.UpdateGroupVersionKind(obj, v1alpha1.SchemeGroupVersion)
+	return util.UpdateGroupVersionKindWithScheme(obj, v1alpha1.SchemeGroupVersion, scheme.Scheme)
 }
 
 // Create wait arguments for a Knative service which can be used to wait for

--- a/pkg/serving/v1alpha1/client_test.go
+++ b/pkg/serving/v1alpha1/client_test.go
@@ -23,6 +23,7 @@ import (
 	"gotest.tools/assert/cmp"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/watch"
+	"knative.dev/serving/pkg/client/clientset/versioned/scheme"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -35,13 +36,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	client_testing "k8s.io/client-go/testing"
 
-	"knative.dev/client/pkg/serving"
+	"knative.dev/client/pkg/util"
 	"knative.dev/client/pkg/wait"
 )
 
 var testNamespace = "test-ns"
 
-func setup() (serving fake.FakeServingV1alpha1, client KnClient) {
+func setup() (serving fake.FakeServingV1alpha1, client KnServingClient) {
 	serving = fake.FakeServingV1alpha1{Fake: &client_testing.Fake{}}
 	client = NewKnServingClient(&serving, testNamespace)
 	return
@@ -480,7 +481,7 @@ func TestGetConfiguration(t *testing.T) {
 }
 
 func validateGroupVersionKind(t *testing.T, obj runtime.Object) {
-	gvkExpected, err := serving.GetGroupVersionKind(obj, v1alpha1.SchemeGroupVersion)
+	gvkExpected, err := util.GetGroupVersionKind(obj, v1alpha1.SchemeGroupVersion, scheme.Scheme)
 	assert.NilError(t, err)
 	gvkGiven := obj.GetObjectKind().GroupVersionKind()
 	assert.Equal(t, *gvkExpected, gvkGiven, "GVK should be the same")

--- a/pkg/util/schema_handling.go
+++ b/pkg/util/schema_handling.go
@@ -12,20 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package serving
+package util
 
 import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"knative.dev/serving/pkg/client/clientset/versioned/scheme"
 )
 
-// Update the GVK on the given object, based on the GVK registered in into the serving scheme
-// for the given GroupVersion
-func UpdateGroupVersionKind(obj runtime.Object, gv schema.GroupVersion) error {
-	gvk, err := GetGroupVersionKind(obj, gv)
+func UpdateGroupVersionKindWithScheme(obj runtime.Object, gv schema.GroupVersion, scheme *runtime.Scheme) error {
+	gvk, err := GetGroupVersionKind(obj, gv, scheme)
 	if err != nil {
 		return err
 	}
@@ -33,8 +30,8 @@ func UpdateGroupVersionKind(obj runtime.Object, gv schema.GroupVersion) error {
 	return nil
 }
 
-func GetGroupVersionKind(obj runtime.Object, gv schema.GroupVersion) (*schema.GroupVersionKind, error) {
-	gvks, _, err := scheme.Scheme.ObjectKinds(obj)
+func GetGroupVersionKind(obj runtime.Object, gv schema.GroupVersion, scheme *runtime.Scheme) (*schema.GroupVersionKind, error) {
+	gvks, _, err := scheme.ObjectKinds(obj)
 	if err != nil {
 		return nil, err
 	}
@@ -43,5 +40,5 @@ func GetGroupVersionKind(obj runtime.Object, gv schema.GroupVersion) (*schema.Gr
 			return &gvk, nil
 		}
 	}
-	return nil, fmt.Errorf("no group version %s registered in %s", gv, scheme.Scheme.Name())
+	return nil, fmt.Errorf("no group version %s registered in %s", gv, scheme.Name())
 }

--- a/pkg/util/schema_handling_test.go
+++ b/pkg/util/schema_handling_test.go
@@ -12,18 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package serving
+package util
 
 import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	"knative.dev/serving/pkg/client/clientset/versioned/scheme"
 )
 
 func TestGVKUpdate(t *testing.T) {
 	service := v1alpha1.Service{}
-	err := UpdateGroupVersionKind(&service, v1alpha1.SchemeGroupVersion)
+	err := UpdateGroupVersionKindWithScheme(&service, v1alpha1.SchemeGroupVersion, scheme.Scheme)
 	if err != nil {
 		t.Fatalf("cannot update GVK to a service %v", err)
 	}
@@ -37,7 +38,7 @@ func TestGVKUpdate(t *testing.T) {
 
 func TestGVKUpdateNegative(t *testing.T) {
 	service := v1alpha1.Service{}
-	err := UpdateGroupVersionKind(&service, schema.GroupVersion{Group: "bla", Version: "blub"})
+	err := UpdateGroupVersionKindWithScheme(&service, schema.GroupVersion{Group: "bla", Version: "blub"}, scheme.Scheme)
 	if err == nil {
 		t.Fatal("expect an error for an unregistered group version")
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -188,10 +188,10 @@ k8s.io/apimachinery/pkg/runtime
 k8s.io/apimachinery/pkg/api/resource
 k8s.io/apimachinery/pkg/api/meta
 k8s.io/apimachinery/pkg/util/runtime
-k8s.io/apimachinery/pkg/runtime/schema
 k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/fields
 k8s.io/apimachinery/pkg/labels
+k8s.io/apimachinery/pkg/runtime/schema
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/pkg/util/validation/field
 k8s.io/apimachinery/pkg/conversion


### PR DESCRIPTION
This is in preparation of introducting eventing and makes sense anyway.
Also, the GVK update handling has been moved to "util" so that it then
can be also reused by eventing.