### PR TITLE
feat(annotations): Adds annotation flag for service create and update

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -62,6 +62,14 @@
 | Add --service-account flag
 | https://github.com/knative/client/pull/401[#401]
 
+| 🧽
+| Docs restructure
+| https://github.com/knative/client/pull/421[#421]
+
+| 🎁
+| Add --annotation flag
+| https://github.com/knative/client/pull/422[#422]
+
 |===
 
 ## v0.2.0 (2019-07-10)

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -34,6 +34,9 @@ kn service create NAME --image IMAGE [flags]
   # (earlier configured resource requests and limits will be replaced with default)
   # (earlier configured environment variables will be cleared too if any)
   kn service create --force s1 --image dev.local/ns/image:v1
+
+  # Create a service with annotation
+  kn service create s1 --image dev.local/ns/image:v3 --annotation sidecar.istio.io/inject=false
 ```
 
 ### Options

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -42,7 +42,7 @@ kn service create NAME --image IMAGE [flags]
 ### Options
 
 ```
-  -a, --annotation stringArray   Service annotation to set. name=value; you may provide this flag any number of times to set multiple annotations. To unset, specify the annotation name followed by a "-" (e.g., name-).
+      --annotation stringArray   Service annotation to set. name=value; you may provide this flag any number of times to set multiple annotations. To unset, specify the annotation name followed by a "-" (e.g., name-).
       --async                    Create service and don't wait for it to become ready.
       --concurrency-limit int    Hard Limit of concurrent requests to be processed by a single replica.
       --concurrency-target int   Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to --concurrency-limit when given.

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -39,6 +39,7 @@ kn service create NAME --image IMAGE [flags]
 ### Options
 
 ```
+  -a, --annotation stringArray   Service annotation to set. name=value; you may provide this flag any number of times to set multiple annotations. To unset, specify the annotation name followed by a "-" (e.g., name-).
       --async                    Create service and don't wait for it to become ready.
       --concurrency-limit int    Hard Limit of concurrent requests to be processed by a single replica.
       --concurrency-target int   Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to --concurrency-limit when given.

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -38,6 +38,7 @@ kn service update NAME [flags]
 ### Options
 
 ```
+  -a, --annotation stringArray   Service annotation to set. name=value; you may provide this flag any number of times to set multiple annotations. To unset, specify the annotation name followed by a "-" (e.g., name-).
       --async                    Update service and don't wait for it to become ready.
       --concurrency-limit int    Hard Limit of concurrent requests to be processed by a single replica.
       --concurrency-target int   Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to --concurrency-limit when given.

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -38,7 +38,7 @@ kn service update NAME [flags]
 ### Options
 
 ```
-  -a, --annotation stringArray   Service annotation to set. name=value; you may provide this flag any number of times to set multiple annotations. To unset, specify the annotation name followed by a "-" (e.g., name-).
+      --annotation stringArray   Service annotation to set. name=value; you may provide this flag any number of times to set multiple annotations. To unset, specify the annotation name followed by a "-" (e.g., name-).
       --async                    Update service and don't wait for it to become ready.
       --concurrency-limit int    Hard Limit of concurrent requests to be processed by a single replica.
       --concurrency-target int   Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to --concurrency-limit when given.

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -267,7 +267,6 @@ func (p *ConfigurationEditFlags) Apply(
 		if err != nil {
 			return errors.Wrap(err, "Invalid --annotation")
 		}
-
 		annotationsToRemove := []string{}
 		for key := range annotationsMap {
 			if strings.HasSuffix(key, "-") {
@@ -275,12 +274,10 @@ func (p *ConfigurationEditFlags) Apply(
 				delete(annotationsMap, key)
 			}
 		}
-
 		err = servinglib.UpdateAnnotations(service, template, annotationsMap, annotationsToRemove)
 		if err != nil {
 			return err
 		}
-
 	}
 
 	if cmd.Flags().Changed("service-account") {

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -111,7 +111,7 @@ func (p *ConfigurationEditFlags) addSharedFlags(command *cobra.Command) {
 	// Don't mark as changing the revision.
 	command.Flags().StringVar(&p.ServiceAccountName, "service-account", "", "Service account name to set. Empty service account name will result to clear the service account.")
 	p.markFlagMakesRevision("service-account")
-	command.Flags().StringArrayVarP(&p.Annotations, "annotation", "a", []string{},
+	command.Flags().StringArrayVar(&p.Annotations, "annotation", []string{},
 		"Service annotation to set. name=value; you may provide this flag "+
 			"any number of times to set multiple annotations. "+
 			"To unset, specify the annotation name followed by a \"-\" (e.g., name-).")

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -41,6 +41,7 @@ type ConfigurationEditFlags struct {
 	NamePrefix                 string
 	RevisionName               string
 	ServiceAccountName         string
+	Annotations                []string
 
 	// Preferences about how to do the action.
 	LockToDigest         bool
@@ -110,6 +111,11 @@ func (p *ConfigurationEditFlags) addSharedFlags(command *cobra.Command) {
 	// Don't mark as changing the revision.
 	command.Flags().StringVar(&p.ServiceAccountName, "service-account", "", "Service account name to set. Empty service account name will result to clear the service account.")
 	p.markFlagMakesRevision("service-account")
+	command.Flags().StringArrayVarP(&p.Annotations, "annotation", "a", []string{},
+		"Service annotation to set. name=value; you may provide this flag "+
+			"any number of times to set multiple annotations. "+
+			"To unset, specify the annotation name followed by a \"-\" (e.g., name-).")
+	p.markFlagMakesRevision("annotation")
 }
 
 // AddUpdateFlags adds the flags specific to update.
@@ -254,6 +260,27 @@ func (p *ConfigurationEditFlags) Apply(
 		if err != nil {
 			return err
 		}
+	}
+
+	if cmd.Flags().Changed("annotation") {
+		annotationsMap, err := util.MapFromArrayAllowingSingles(p.Annotations, "=")
+		if err != nil {
+			return errors.Wrap(err, "Invalid --annotation")
+		}
+
+		annotationsToRemove := []string{}
+		for key := range annotationsMap {
+			if strings.HasSuffix(key, "-") {
+				annotationsToRemove = append(annotationsToRemove, key[:len(key)-1])
+				delete(annotationsMap, key)
+			}
+		}
+
+		err = servinglib.UpdateAnnotations(service, template, annotationsMap, annotationsToRemove)
+		if err != nil {
+			return err
+		}
+
 	}
 
 	if cmd.Flags().Changed("service-account") {

--- a/pkg/kn/commands/service/create.go
+++ b/pkg/kn/commands/service/create.go
@@ -33,14 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func NewServiceCreateCommand(p *commands.KnParams) *cobra.Command {
-	var editFlags ConfigurationEditFlags
-	var waitFlags commands.WaitFlags
-
-	serviceCreateCommand := &cobra.Command{
-		Use:   "create NAME --image IMAGE",
-		Short: "Create a service.",
-		Example: `
+var create_example = `
   # Create a service 'mysvc' using image at dev.local/ns/image:latest
   kn service create mysvc --image dev.local/ns/image:latest
 
@@ -60,8 +53,19 @@ func NewServiceCreateCommand(p *commands.KnParams) *cobra.Command {
   # Create or replace default resources of a service 's1' using --force flag
   # (earlier configured resource requests and limits will be replaced with default)
   # (earlier configured environment variables will be cleared too if any)
-  kn service create --force s1 --image dev.local/ns/image:v1`,
+  kn service create --force s1 --image dev.local/ns/image:v1
 
+  # Create a service with annotation
+  kn service create s1 --image dev.local/ns/image:v3 --annotation sidecar.istio.io/inject=false`
+
+func NewServiceCreateCommand(p *commands.KnParams) *cobra.Command {
+	var editFlags ConfigurationEditFlags
+	var waitFlags commands.WaitFlags
+
+	serviceCreateCommand := &cobra.Command{
+		Use:     "create NAME --image IMAGE",
+		Short:   "Create a service.",
+		Example: create_example,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {
 				return errors.New("'service create' requires the service name given as single argument")

--- a/pkg/kn/commands/service/service_update_mock_test.go
+++ b/pkg/kn/commands/service/service_update_mock_test.go
@@ -111,9 +111,9 @@ func TestServiceUpdateAnnotationsMock(t *testing.T) {
 
 	output, err := executeServiceCommand(client,
 		"create", svcName, "--image", "gcr.io/foo/bar:baz",
-		"-a", "an1=staysConstant",
-		"-a", "an2=getsUpdated",
-		"-a", "an3=getsRemoved",
+		"--annotation", "an1=staysConstant",
+		"--annotation", "an2=getsUpdated",
+		"--annotation", "an3=getsRemoved",
 		"--async", "--revision-name=",
 	)
 	assert.NilError(t, err)
@@ -121,8 +121,8 @@ func TestServiceUpdateAnnotationsMock(t *testing.T) {
 
 	output, err = executeServiceCommand(client,
 		"update", svcName,
-		"-a", "an2=isUpdated",
-		"-a", "an3-",
+		"--annotation", "an2=isUpdated",
+		"--annotation", "an3-",
 		"--async", "--revision-name=",
 	)
 	assert.NilError(t, err)

--- a/pkg/kn/commands/service/update.go
+++ b/pkg/kn/commands/service/update.go
@@ -28,14 +28,7 @@ import (
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 )
 
-func NewServiceUpdateCommand(p *commands.KnParams) *cobra.Command {
-	var editFlags ConfigurationEditFlags
-	var waitFlags commands.WaitFlags
-	var trafficFlags flags.Traffic
-	serviceUpdateCommand := &cobra.Command{
-		Use:   "update NAME [flags]",
-		Short: "Update a service.",
-		Example: `
+var update_example = `
   # Updates a service 'svc' with new environment variables
   kn service update svc --env KEY1=VALUE1 --env KEY2=VALUE2
 
@@ -54,7 +47,16 @@ func NewServiceUpdateCommand(p *commands.KnParams) *cobra.Command {
   kn service update svc --untag testing --tag @latest=staging
 
   # Add tag 'test' to echo-v3 revision with 10% traffic and rest to latest ready revision of service
-  kn service update svc --tag echo-v3=test --traffic test=10,@latest=90`,
+  kn service update svc --tag echo-v3=test --traffic test=10,@latest=90`
+
+func NewServiceUpdateCommand(p *commands.KnParams) *cobra.Command {
+	var editFlags ConfigurationEditFlags
+	var waitFlags commands.WaitFlags
+	var trafficFlags flags.Traffic
+	serviceUpdateCommand := &cobra.Command{
+		Use:     "update NAME [flags]",
+		Short:   "Update a service.",
+		Example: update_example,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {
 				return errors.New("requires the service name.")


### PR DESCRIPTION
Fixes #327 

## Proposed Changes
  - Adds specified annotations to service object meta and revision template meta
  - Adds `--annotation` / `-a` flag to service create and update options
  - User can specify '-' at the end of the annotation key to remove an annotation
  - Adds unit and e2e tests
  - Updates docs accordingly


/lint

<!--
Release Note:

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behaviour
- 🗑️ Remove feature or internal logic

-->
