### PR TITLE
chore(service): Improvements for waiting on service readiness

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -73,6 +73,11 @@
 | 🎁
 | Update build.sh -w to add a message when compilation succeeded
 | https://github.com/knative/client/pull/432[#432]
+
+| 🧽
+| Add more progress information during service create/update
+| https://github.com/knative/client/pull/431[#431]
+
 |===
 
 ## v0.2.0 (2019-07-10)

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -63,7 +63,7 @@ kn service create NAME --image IMAGE [flags]
       --requests-memory string   The requested memory (e.g., 64Mi).
       --revision-name string     The revision name to set. Must start with the service name and a dash as a prefix. Empty revision name will result in the server generating a name for the revision. Accepts golang templates, allowing {{.Service}} for the service name, {{.Generation}} for the generation, and {{.Random [n]}} for n random consonants. (default "{{.Service}}-{{.Random 5}}-{{.Generation}}")
       --service-account string   Service account name to set. Empty service account name will result to clear the service account.
-      --wait-timeout int         Seconds to wait before giving up on waiting for service to be ready. (default 60)
+      --wait-timeout int         Seconds to wait before giving up on waiting for service to be ready. (default 600)
 ```
 
 ### Options inherited from parent commands

--- a/pkg/kn/commands/service/create_mock_test.go
+++ b/pkg/kn/commands/service/create_mock_test.go
@@ -16,6 +16,7 @@ package service
 
 import (
 	"testing"
+	"time"
 
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +28,7 @@ import (
 
 	servinglib "knative.dev/client/pkg/serving"
 	knclient "knative.dev/client/pkg/serving/v1alpha1"
+	"knative.dev/client/pkg/wait"
 
 	"knative.dev/client/pkg/util"
 )
@@ -43,14 +45,14 @@ func TestServiceCreateImageMock(t *testing.T) {
 	// Create service (don't validate given service --> "Any()" arg is allowed)
 	r.CreateService(knclient.Any(), nil)
 	// Wait for service to become ready
-	r.WaitForService("foo", knclient.Any(), nil)
+	r.WaitForService("foo", knclient.Any(), wait.NoopMessageCallback(), nil, time.Second)
 	// Get for showing the URL
 	r.GetService("foo", getServiceWithUrl("foo", "http://foo.example.com"), nil)
 
 	// Testing:
 	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz")
 	assert.NilError(t, err)
-	assert.Assert(t, util.ContainsAll(output, "created", "foo", "http://foo.example.com", "Waiting"))
+	assert.Assert(t, util.ContainsAll(output, "Creating", "foo", "http://foo.example.com", "Ready"))
 
 	// Validate that all recorded API methods have been called
 	r.Validate()

--- a/pkg/kn/commands/service/create_test.go
+++ b/pkg/kn/commands/service/create_test.go
@@ -107,9 +107,9 @@ func fakeServiceCreate(args []string, withExistingService bool, sync bool) (
 
 func getServiceEvents(name string) []watch.Event {
 	return []watch.Event{
-		{watch.Added, wait.CreateTestServiceWithConditions(name, corev1.ConditionUnknown, corev1.ConditionUnknown, "")},
-		{watch.Modified, wait.CreateTestServiceWithConditions(name, corev1.ConditionUnknown, corev1.ConditionTrue, "")},
-		{watch.Modified, wait.CreateTestServiceWithConditions(name, corev1.ConditionTrue, corev1.ConditionTrue, "")},
+		{watch.Added, wait.CreateTestServiceWithConditions(name, corev1.ConditionUnknown, corev1.ConditionUnknown, "", "msg1")},
+		{watch.Modified, wait.CreateTestServiceWithConditions(name, corev1.ConditionUnknown, corev1.ConditionTrue, "", "msg2")},
+		{watch.Modified, wait.CreateTestServiceWithConditions(name, corev1.ConditionTrue, corev1.ConditionTrue, "", "")},
 	}
 }
 
@@ -147,11 +147,11 @@ func TestServiceCreateImageSync(t *testing.T) {
 	if template.Spec.Containers[0].Image != "gcr.io/foo/bar:baz" {
 		t.Fatalf("wrong image set: %v", template.Spec.Containers[0].Image)
 	}
-	if !strings.Contains(output, "foo") || !strings.Contains(output, "created") ||
+	if !strings.Contains(output, "foo") || !strings.Contains(output, "Creating") ||
 		!strings.Contains(output, commands.FakeNamespace) {
 		t.Fatalf("wrong stdout message: %v", output)
 	}
-	if !strings.Contains(output, "OK") || !strings.Contains(output, "Waiting") {
+	if !strings.Contains(output, "Ready") {
 		t.Fatalf("not running in sync mode")
 	}
 }

--- a/pkg/kn/commands/service/update_test.go
+++ b/pkg/kn/commands/service/update_test.go
@@ -158,7 +158,7 @@ func TestServiceUpdateImageSync(t *testing.T) {
 	assert.NilError(t, err)
 
 	assert.Equal(t, template.Spec.Containers[0].Image, "gcr.io/foo/quux:xyzzy")
-	assert.Assert(t, util.ContainsAll(strings.ToLower(output), "update", "foo", "service", "namespace", "bar", "ok", "waiting"))
+	assert.Assert(t, util.ContainsAll(strings.ToLower(output), "updating", "foo", "service", "namespace", "bar", "ready"))
 }
 
 func TestServiceUpdateImage(t *testing.T) {

--- a/pkg/kn/commands/testing_helper.go
+++ b/pkg/kn/commands/testing_helper.go
@@ -47,7 +47,7 @@ func CreateTestKnCommand(cmd *cobra.Command, knParams *KnParams) (*cobra.Command
 	fakeServing := &fake.FakeServingV1alpha1{&client_testing.Fake{}}
 	knParams.Output = buf
 	knParams.NewClient = func(namespace string) (v1alpha1.KnServingClient, error) {
-		return v1alpha1.NewKnServingClient(fakeServing, namespace), nil
+		return v1alpha1.NewKnServingClient(fakeServing, FakeNamespace), nil
 	}
 	knParams.fixedCurrentNamespace = FakeNamespace
 	knCommand := NewKnTestCommand(cmd, knParams)

--- a/pkg/serving/v1alpha1/client_mock_test.go
+++ b/pkg/serving/v1alpha1/client_mock_test.go
@@ -20,6 +20,8 @@ import (
 
 	api_serving "knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+
+	"knative.dev/client/pkg/wait"
 )
 
 func TestMockKnClient(t *testing.T) {
@@ -34,7 +36,7 @@ func TestMockKnClient(t *testing.T) {
 	recorder.CreateService(&v1alpha1.Service{}, nil)
 	recorder.UpdateService(&v1alpha1.Service{}, nil)
 	recorder.DeleteService("hello", nil)
-	recorder.WaitForService("hello", time.Duration(10)*time.Second, nil)
+	recorder.WaitForService("hello", time.Duration(10)*time.Second, wait.NoopMessageCallback(), nil, 10*time.Second)
 	recorder.GetRevision("hello", nil, nil)
 	recorder.ListRevisions(Any(), nil, nil)
 	recorder.DeleteRevision("hello", nil)
@@ -48,7 +50,7 @@ func TestMockKnClient(t *testing.T) {
 	client.CreateService(&v1alpha1.Service{})
 	client.UpdateService(&v1alpha1.Service{})
 	client.DeleteService("hello")
-	client.WaitForService("hello", time.Duration(10)*time.Second)
+	client.WaitForService("hello", time.Duration(10)*time.Second, wait.NoopMessageCallback())
 	client.GetRevision("hello")
 	client.ListRevisions(WithName("blub"))
 	client.DeleteRevision("hello")

--- a/pkg/serving/v1alpha1/client_test.go
+++ b/pkg/serving/v1alpha1/client_test.go
@@ -390,8 +390,9 @@ func TestWaitForService(t *testing.T) {
 		})
 
 	t.Run("wait on a service to become ready with success", func(t *testing.T) {
-		err := client.WaitForService(serviceName, 60*time.Second)
+		err, duration := client.WaitForService(serviceName, 60*time.Second, wait.NoopMessageCallback())
 		assert.NilError(t, err)
+		assert.Assert(t, duration > 0)
 	})
 }
 
@@ -509,8 +510,8 @@ func newRoute(name string) *v1alpha1.Route {
 
 func getServiceEvents(name string) []watch.Event {
 	return []watch.Event{
-		{watch.Added, wait.CreateTestServiceWithConditions(name, corev1.ConditionUnknown, corev1.ConditionUnknown, "")},
-		{watch.Modified, wait.CreateTestServiceWithConditions(name, corev1.ConditionUnknown, corev1.ConditionTrue, "")},
-		{watch.Modified, wait.CreateTestServiceWithConditions(name, corev1.ConditionTrue, corev1.ConditionTrue, "")},
+		{watch.Added, wait.CreateTestServiceWithConditions(name, corev1.ConditionUnknown, corev1.ConditionUnknown, "", "msg1")},
+		{watch.Modified, wait.CreateTestServiceWithConditions(name, corev1.ConditionUnknown, corev1.ConditionTrue, "", "msg2")},
+		{watch.Modified, wait.CreateTestServiceWithConditions(name, corev1.ConditionTrue, corev1.ConditionTrue, "", "")},
 	}
 }

--- a/pkg/wait/test_wait_helper.go
+++ b/pkg/wait/test_wait_helper.go
@@ -64,7 +64,7 @@ func (f *FakeWatch) fireEvents() {
 }
 
 // Create a service skeleton with a given ConditionReady status and all other statuses set to otherReadyStatus. Optionally a single generation can be added.
-func CreateTestServiceWithConditions(name string, readyStatus corev1.ConditionStatus, otherReadyStatus corev1.ConditionStatus, reason string, generations ...int64) runtime.Object {
+func CreateTestServiceWithConditions(name string, readyStatus corev1.ConditionStatus, otherReadyStatus corev1.ConditionStatus, reason string, message string, generations ...int64) runtime.Object {
 	service := v1alpha1.Service{ObjectMeta: metav1.ObjectMeta{Name: name}}
 	if len(generations) == 2 {
 		service.Generation = generations[0]
@@ -75,7 +75,7 @@ func CreateTestServiceWithConditions(name string, readyStatus corev1.ConditionSt
 	}
 	service.Status.Conditions = duck.Conditions([]apis.Condition{
 		{Type: "RoutesReady", Status: otherReadyStatus},
-		{Type: apis.ConditionReady, Status: readyStatus, Reason: reason},
+		{Type: apis.ConditionReady, Status: readyStatus, Reason: reason, Message: message},
 		{Type: "ConfigurationsReady", Status: otherReadyStatus},
 	})
 	return &service

--- a/test/e2e/basic_workflow_test.go
+++ b/test/e2e/basic_workflow_test.go
@@ -83,7 +83,7 @@ func (test *e2eTest) serviceCreate(t *testing.T, serviceName string) {
 		"--image", KnDefaultTestImage}, runOpts{NoNamespace: false})
 	assert.NilError(t, err)
 
-	assert.Check(t, util.ContainsAll(out, "Service", serviceName, "successfully created in namespace", test.kn.namespace, "OK"))
+	assert.Check(t, util.ContainsAllIgnoreCase(out, "service", serviceName, "creating", "namespace", test.kn.namespace, "ready"))
 }
 
 func (test *e2eTest) serviceList(t *testing.T, serviceName string) {
@@ -106,8 +106,7 @@ func (test *e2eTest) serviceUpdate(t *testing.T, serviceName string, args []stri
 	out, err := test.kn.RunWithOpts(append([]string{"service", "update", serviceName}, args...), runOpts{NoNamespace: false})
 	assert.NilError(t, err)
 
-	expectedOutput := fmt.Sprintf("Service '%s' updated", serviceName)
-	assert.Check(t, util.ContainsAll(out, expectedOutput))
+	assert.Check(t, util.ContainsAllIgnoreCase(out, "updating", "service", serviceName, "ready"))
 }
 
 func (test *e2eTest) serviceDelete(t *testing.T, serviceName string) {

--- a/test/e2e/service_options_test.go
+++ b/test/e2e/service_options_test.go
@@ -85,7 +85,7 @@ func (test *e2eTest) serviceCreateWithOptions(t *testing.T, serviceName string, 
 	command = append(command, options...)
 	out, err := test.kn.RunWithOpts(command, runOpts{NoNamespace: false})
 	assert.NilError(t, err)
-	assert.Check(t, util.ContainsAll(out, "Service", serviceName, "successfully created in namespace", test.kn.namespace, "OK"))
+	assert.Check(t, util.ContainsAll(out, "service", serviceName, "Creating", "namespace", test.kn.namespace, "Ready"))
 }
 
 func (test *e2eTest) validateServiceConcurrencyLimit(t *testing.T, serviceName, concurrencyLimit string) {

--- a/test/e2e/traffic_split_test.go
+++ b/test/e2e/traffic_split_test.go
@@ -37,7 +37,7 @@ var targetsJsonPath = "jsonpath={range .status.traffic[*]}{.tag}{','}{.revisionN
 // returns deployed service latest revision name
 var latestRevisionJsonPath = "jsonpath={.status.latestCreatedRevisionName}"
 
-// TargetFileds are used in e2e to store expected fields per traffic target
+// TargetFields are used in e2e to store expected fields per traffic target
 // and actual traffic targets fields of deployed service are converted into struct before comparing
 type TargetFields struct {
 	Tag      string
@@ -385,5 +385,5 @@ func (test *e2eTest) serviceUpdateWithOptions(t *testing.T, serviceName string, 
 	command = append(command, options...)
 	out, err := test.kn.RunWithOpts(command, runOpts{NoNamespace: false})
 	assert.NilError(t, err)
-	assert.Check(t, util.ContainsAll(out, "Service", serviceName, "update", "namespace", test.kn.namespace))
+	assert.Check(t, util.ContainsAllIgnoreCase(out, "Service", serviceName, "updating", "namespace", test.kn.namespace))
 }


### PR DESCRIPTION
* Increased default timeout to 600s. This timeout will be triggered
  only when the Ready condition stays in UNKNOWN for that long. If its
  True or False then the command will return anyway sooner.
  So it makes sense to go for a much longer timeout than 60s
* Enhanced output to indicate the progress

This change needs some updates to the API and introduces a 'MessageCallback'
type which is calle for each intermediate event with the "Ready" condition message.

Example of the UX:

[![asciicast](https://asciinema.org/a/5MwD9j3HJpLdBgosJFbFsDBdB.svg)](https://asciinema.org/a/5MwD9j3HJpLdBgosJFbFsDBdB)