### PR TITLE
fix(service): Set default timeout for update to the same value as for create

### DIFF
--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -61,7 +61,7 @@ kn service update NAME [flags]
       --tag strings              Set tag (format: --tag revisionRef=tagName) where revisionRef can be a revision or '@latest' string representing latest ready revision. This flag can be specified multiple times.
       --traffic strings          Set traffic distribution (format: --traffic revisionRef=percent) where revisionRef can be a revision or a tag or '@latest' string representing latest ready revision. This flag can be given multiple times with percent summing up to 100%.
       --untag strings            Untag revision (format: --untag tagName). This flag can be spcified multiple times.
-      --wait-timeout int         Seconds to wait before giving up on waiting for service to be ready. (default 60)
+      --wait-timeout int         Seconds to wait before giving up on waiting for service to be ready. (default 600)
 ```
 
 ### Options inherited from parent commands

--- a/pkg/kn/commands/service/create.go
+++ b/pkg/kn/commands/service/create.go
@@ -114,7 +114,7 @@ func NewServiceCreateCommand(p *commands.KnParams) *cobra.Command {
 	}
 	commands.AddNamespaceFlags(serviceCreateCommand.Flags(), false)
 	editFlags.AddCreateFlags(serviceCreateCommand)
-	waitFlags.AddConditionWaitFlags(serviceCreateCommand, 600, "Create", "service")
+	waitFlags.AddConditionWaitFlags(serviceCreateCommand, commands.WaitDefaultTimeout, "Create", "service")
 	return serviceCreateCommand
 }
 
@@ -188,10 +188,12 @@ func prepareAndUpdateService(client serving_kn_v1alpha1.KnServingClient, service
 }
 
 func waitForServiceToGetReady(client serving_kn_v1alpha1.KnServingClient, name string, timeout int, verbDone string, out io.Writer) error {
+	fmt.Fprintln(out, "")
 	err := waitForService(client, name, out, timeout)
 	if err != nil {
 		return err
 	}
+	fmt.Fprintln(out, "")
 	return showUrl(client, name, "", verbDone, out)
 }
 

--- a/pkg/kn/commands/service/service.go
+++ b/pkg/kn/commands/service/service.go
@@ -68,6 +68,6 @@ func showUrl(client serving_kn_v1alpha1.KnServingClient, serviceName string, ori
 	if originalRevision != "" && originalRevision == newRevision {
 		revisionUpdateStatus = " (unchanged)"
 	}
-	fmt.Fprintf(out, "\nService '%s' %s with latest revision '%s'%s and URL:\n%s\n", serviceName, what, newRevision, revisionUpdateStatus, url)
+	fmt.Fprintf(out, "Service '%s' %s with latest revision '%s'%s and URL:\n%s\n", serviceName, what, newRevision, revisionUpdateStatus, url)
 	return nil
 }

--- a/pkg/kn/commands/service/update.go
+++ b/pkg/kn/commands/service/update.go
@@ -115,10 +115,12 @@ func NewServiceUpdateCommand(p *commands.KnParams) *cobra.Command {
 				out := cmd.OutOrStdout()
 				if !waitFlags.Async {
 					fmt.Fprintf(out, "Updating Service '%s' in namespace '%s':\n", args[0], namespace)
+					fmt.Fprintln(out, "")
 					err := waitForService(client, name, out, waitFlags.TimeoutInSeconds)
 					if err != nil {
 						return err
 					}
+					fmt.Fprintln(out, "")
 					return showUrl(client, name, latestRevisionBeforeUpdate, "updated", out)
 				} else {
 					fmt.Fprintf(out, "Service '%s' updated in namespace '%s'.\n", args[0], namespace)
@@ -134,7 +136,7 @@ func NewServiceUpdateCommand(p *commands.KnParams) *cobra.Command {
 
 	commands.AddNamespaceFlags(serviceUpdateCommand.Flags(), false)
 	editFlags.AddUpdateFlags(serviceUpdateCommand)
-	waitFlags.AddConditionWaitFlags(serviceUpdateCommand, 60, "Update", "service")
+	waitFlags.AddConditionWaitFlags(serviceUpdateCommand, commands.WaitDefaultTimeout, "Update", "service")
 	trafficFlags.Add(serviceUpdateCommand)
 	return serviceUpdateCommand
 }

--- a/pkg/kn/commands/wait_flags.go
+++ b/pkg/kn/commands/wait_flags.go
@@ -20,6 +20,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Default time out to use when waiting for reconciliation. It is deliberately very long as it is expected that
+// the service doesn't stay in `Unknown` status very long and eventually ends up as `False` or `True` in a timely
+// manner
+const WaitDefaultTimeout = 600
+
 // Flags for tuning wait behaviour
 type WaitFlags struct {
 	// Timeout in seconds for how long to wait for a command to return


### PR DESCRIPTION
Also, added accidentally removed seperator lines during create/update