### PR TITLE
Fix a small error in verify-codegen.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ tags
 # VSCode specific
 .vscode
 
+# Operating system temporary files
+.DS_Store

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -31,6 +31,6 @@ else
   git status --porcelain
   echo "ERROR: Diff"
   git diff
-  echo "ERROR: ${REPO_ROOT_DIR} is out of date. Please run ./hack/build.sh -u and commit."
+  echo "ERROR: ${REPO_ROOT_DIR} is out of date. Please run ./hack/build.sh -c and commit."
   exit 1
 fi


### PR DESCRIPTION
## Proposed Changes

* `build.sh` accepts `-c` option for code generation, not `-u`.
* Add `.DS_Store` to `.gitignore`