### PR TITLE
fix(e2e): Uses serving v0.8.1 in custom prow job

### DIFF
--- a/test/presubmit-integration-tests-latest-release.sh
+++ b/test/presubmit-integration-tests-latest-release.sh
@@ -18,5 +18,5 @@
 # integration tests against Knative serving of a specific version. We
 # currently take 0.6.0 as the latest release version.
 
-export KNATIVE_VERSION="0.7.1"
+export KNATIVE_VERSION="0.8.1"
 $(dirname $0)/presubmit-tests.sh --integration-tests


### PR DESCRIPTION
## Proposed Changes
* Uses v0.8.1 in custom prow job, it was referring v0.7.1