### PR TITLE
fix(version): Displays supported APIs and version

### DIFF
--- a/hack/build-flags.sh
+++ b/hack/build-flags.sh
@@ -26,7 +26,5 @@ function build_flags() {
     version="v$(date +%Y%m%d)-local-${commit}"
   fi
 
-  local serving_version=$(grep 'knative.dev/serving' ${base}/go.mod | sed -e 's/.*serving \(.*\)/\1/')
-
-  echo "-X '${pkg}.BuildDate=${now}' -X ${pkg}.Version=${version} -X ${pkg}.GitRevision=${rev} -X ${pkg}.ServingVersion=${serving_version}"
+  echo "-X '${pkg}.BuildDate=${now}' -X ${pkg}.Version=${version} -X ${pkg}.GitRevision=${rev}"
 }

--- a/hack/build-flags.sh
+++ b/hack/build-flags.sh
@@ -16,7 +16,7 @@ function build_flags() {
   local base="${1}"
   local now="$(date -u '+%Y-%m-%d %H:%M:%S')"
   local rev="$(git rev-parse --short HEAD)"
-  local pkg="knative.dev/client/pkg/kn/commands"
+  local pkg="knative.dev/client/pkg/kn/commands/version"
   local version="${TAG:-}"
   # Use vYYYYMMDD-local-<hash> for the version string, if not passed.
   if [[ -z "${version}" ]]; then

--- a/pkg/kn/commands/version/version.go
+++ b/pkg/kn/commands/version/version.go
@@ -26,14 +26,12 @@ import (
 var Version string
 var BuildDate string
 var GitRevision string
-var ServingVersion string
 
 type SupportedAPIs []string
 
-// update this var as we increase the serving version in go.mod
-var knServingDep = "v0.8.0"
+// update this var as we add more deps or update
 var supportMatrix = map[string]*SupportedAPIs{
-	knServingDep: {"serving.knative.dev/v1alpha1 (knative-serving v0.8.0)"},
+	"v0.8.0": {"serving.knative.dev/v1alpha1 (knative-serving v0.8.0)"},
 }
 
 func (s SupportedAPIs) print(out io.Writer) {
@@ -47,20 +45,15 @@ func NewVersionCommand(p *commands.KnParams) *cobra.Command {
 	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "Prints the client version",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: func(cmd *cobra.Command, args []string) {
 			out := cmd.OutOrStdout()
 			fmt.Fprintf(out, "Version:      %s\n", Version)
 			fmt.Fprintf(out, "Build Date:   %s\n", BuildDate)
 			fmt.Fprintf(out, "Git Revision: %s\n", GitRevision)
 			fmt.Fprintf(out, "Supported APIs:\n")
-			if apis, ok := supportMatrix[ServingVersion]; ok {
+			for _, apis := range supportMatrix {
 				apis.print(out)
-			} else {
-				// ensure the go build works when we update,
-				// but version command tests fails to prevent shipping
-				fmt.Fprintf(out, "- Serving: %s\n", ServingVersion)
 			}
-			return nil
 		},
 	}
 	return versionCmd

--- a/pkg/kn/commands/version/version.go
+++ b/pkg/kn/commands/version/version.go
@@ -16,7 +16,6 @@ package version
 
 import (
 	"fmt"
-	"io"
 
 	"knative.dev/client/pkg/kn/commands"
 
@@ -27,17 +26,9 @@ var Version string
 var BuildDate string
 var GitRevision string
 
-type SupportedAPIs []string
-
-// update this var as we add more deps or update
-var supportMatrix = map[string]*SupportedAPIs{
-	"v0.8.0": {"serving.knative.dev/v1alpha1 (knative-serving v0.8.0)"},
-}
-
-func (s SupportedAPIs) print(out io.Writer) {
-	for _, api := range s {
-		fmt.Fprintf(out, "- %s\n", api)
-	}
+// update this var as we add more deps
+var apiVersions = []string{
+	"serving.knative.dev/v1alpha1 (knative-serving v0.8.0)",
 }
 
 // NewVersionCommand implements 'kn version' command
@@ -51,8 +42,8 @@ func NewVersionCommand(p *commands.KnParams) *cobra.Command {
 			fmt.Fprintf(out, "Build Date:   %s\n", BuildDate)
 			fmt.Fprintf(out, "Git Revision: %s\n", GitRevision)
 			fmt.Fprintf(out, "Supported APIs:\n")
-			for _, apis := range supportMatrix {
-				apis.print(out)
+			for _, api := range apiVersions {
+				fmt.Fprintf(out, "- %s\n", api)
 			}
 		},
 	}

--- a/pkg/kn/commands/version/version_test.go
+++ b/pkg/kn/commands/version/version_test.go
@@ -12,31 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package commands
+package version
 
 import (
 	"bytes"
 	"testing"
 	"text/template"
 
+	"knative.dev/client/pkg/kn/commands"
+
 	"github.com/spf13/cobra"
 	"gotest.tools/assert"
 )
 
 type versionOutput struct {
-	Version      string
-	BuildDate    string
-	GitRevision  string
-	VersionsAPIs *VersionsAPIs
+	Version       string
+	BuildDate     string
+	GitRevision   string
+	SupportedAPIs *SupportedAPIs
 }
 
 var versionOutputTemplate = `Version:      {{.Version}}
 Build Date:   {{.BuildDate}}
 Git Revision: {{.GitRevision}}
-Support:
-- Serving: {{index .VersionsAPIs.Versions 0}}  {{index .VersionsAPIs.Versions 1}}
-- API(s):  {{index .VersionsAPIs.APIs 0}}
-`
+Supported APIs:{{range $item := .SupportedAPIs }}
+- {{$item}}
+{{end}}`
 
 const (
 	fakeVersion     = "fake-version"
@@ -47,7 +48,7 @@ const (
 func TestVersion(t *testing.T) {
 	var (
 		versionCmd            *cobra.Command
-		knParams              *KnParams
+		knParams              *commands.KnParams
 		expectedVersionOutput string
 		output                *bytes.Buffer
 	)
@@ -65,7 +66,7 @@ func TestVersion(t *testing.T) {
 				fakeGitRevision,
 				supportMatrix[ServingVersion]})
 
-		knParams = &KnParams{}
+		knParams = &commands.KnParams{}
 		versionCmd = NewVersionCommand(knParams)
 		output = new(bytes.Buffer)
 		versionCmd.SetOutput(output)
@@ -88,8 +89,6 @@ func TestVersion(t *testing.T) {
 	})
 
 }
-
-// Private
 
 func genVersionOuput(t *testing.T, templ string, vOutput versionOutput) string {
 	tmpl, err := template.New("versionOutput").Parse(versionOutputTemplate)

--- a/pkg/kn/commands/version/version_test.go
+++ b/pkg/kn/commands/version/version_test.go
@@ -26,18 +26,17 @@ import (
 )
 
 type versionOutput struct {
-	Version       string
-	BuildDate     string
-	GitRevision   string
-	SupportedAPIs *SupportedAPIs
+	Version     string
+	BuildDate   string
+	GitRevision string
 }
 
 var versionOutputTemplate = `Version:      {{.Version}}
 Build Date:   {{.BuildDate}}
 Git Revision: {{.GitRevision}}
-Supported APIs:{{range $item := .SupportedAPIs }}
-- {{$item}}
-{{end}}`
+Supported APIs:
+- serving.knative.dev/v1alpha1 (knative-serving v0.8.0)
+`
 
 const (
 	fakeVersion     = "fake-version"
@@ -57,14 +56,12 @@ func TestVersion(t *testing.T) {
 		Version = fakeVersion
 		BuildDate = fakeBuildDate
 		GitRevision = fakeGitRevision
-		ServingVersion = knServingDep
 
 		expectedVersionOutput = genVersionOuput(t, versionOutputTemplate,
 			versionOutput{
 				fakeVersion,
 				fakeBuildDate,
-				fakeGitRevision,
-				supportMatrix[ServingVersion]})
+				fakeGitRevision})
 
 		knParams = &commands.KnParams{}
 		versionCmd = NewVersionCommand(knParams)
@@ -77,14 +74,13 @@ func TestVersion(t *testing.T) {
 
 		assert.Equal(t, versionCmd.Use, "version")
 		assert.Equal(t, versionCmd.Short, "Prints the client version")
-		assert.Assert(t, versionCmd.RunE != nil)
+		assert.Assert(t, versionCmd.Run != nil)
 	})
 
-	t.Run("prints version, build date, git revision, supported serving version and APIs", func(t *testing.T) {
+	t.Run("prints version, build date, git revision, supported APIs", func(t *testing.T) {
 		setup()
 
-		err := versionCmd.RunE(versionCmd, []string{})
-		assert.NilError(t, err)
+		versionCmd.Run(versionCmd, []string{})
 		assert.Equal(t, output.String(), expectedVersionOutput)
 	})
 

--- a/pkg/kn/core/root.go
+++ b/pkg/kn/core/root.go
@@ -34,6 +34,7 @@ import (
 	"knative.dev/client/pkg/kn/commands/revision"
 	"knative.dev/client/pkg/kn/commands/route"
 	"knative.dev/client/pkg/kn/commands/service"
+	"knative.dev/client/pkg/kn/commands/version"
 	"knative.dev/client/pkg/kn/flags"
 )
 
@@ -139,7 +140,7 @@ func NewKnCommand(params ...commands.KnParams) *cobra.Command {
 	rootCmd.AddCommand(plugin.NewPluginCommand(p))
 	rootCmd.AddCommand(route.NewRouteCommand(p))
 	rootCmd.AddCommand(commands.NewCompletionCommand(p))
-	rootCmd.AddCommand(commands.NewVersionCommand(p))
+	rootCmd.AddCommand(version.NewVersionCommand(p))
 
 	// Deal with empty and unknown sub command groups
 	EmptyAndUnknownSubCommands(rootCmd)

--- a/test/e2e/traffic_split_test.go
+++ b/test/e2e/traffic_split_test.go
@@ -54,7 +54,7 @@ func splitTargets(s, separator string, partsCount int) ([]string, error) {
 	parts := strings.Split(s, separator)
 	if len(parts) != partsCount {
 		return nil, fmt.Errorf("expecting %d targets, got %d targets "+
-			"targets: %s seprator: %s", partsCount, len(parts), s, separator)
+			"targets: %s separator: %s", partsCount, len(parts), s, separator)
 	}
 	return parts, nil
 }


### PR DESCRIPTION
 Fixes #404
/lint

## Proposed Changes
 - Add the API versions and component version vendored
 - Moves the version command under its package version
-  Removes ServingVersion feeding from ldflags

 ```
  ./kn version
Version:      v20191017-local-6328a73-dirty
Build Date:   2019-10-17 09:55:55
Git Revision: 6328a73
Supported APIs:
- serving.knative.dev/v1alpha1 (knative-serving v0.8.0)
 ```