### PR TITLE
fix(e2e): Improves the error message upon mismatch of traffic targets

### DIFF
--- a/test/e2e/traffic_split_test.go
+++ b/test/e2e/traffic_split_test.go
@@ -17,7 +17,6 @@
 package e2e
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -54,8 +53,8 @@ func splitTargets(s, separator string, partsCount int) ([]string, error) {
 	s = strings.TrimSuffix(s, targetsSeparator)
 	parts := strings.Split(s, separator)
 	if len(parts) != partsCount {
-		return nil, errors.New(fmt.Sprintf("expecting %d targets, got %d targets "+
-			"targets: %s seprator: %s", partsCount, len(parts), s, separator))
+		return nil, fmt.Errorf("expecting %d targets, got %d targets "+
+			"targets: %s seprator: %s", partsCount, len(parts), s, separator)
 	}
 	return parts, nil
 }

--- a/test/e2e/traffic_split_test.go
+++ b/test/e2e/traffic_split_test.go
@@ -51,10 +51,11 @@ func newTargetFields(tag, revision string, percent int, latest bool) TargetField
 }
 
 func splitTargets(s, separator string, partsCount int) ([]string, error) {
-	parts := strings.SplitN(s, separator, partsCount)
+	s = strings.TrimSuffix(s, targetsSeparator)
+	parts := strings.Split(s, separator)
 	if len(parts) != partsCount {
-		return nil, errors.New(fmt.Sprintf("expecting to receive parts of length %d, got %d "+
-			"string: %s seprator: %s", partsCount, len(parts), s, separator))
+		return nil, errors.New(fmt.Sprintf("expecting %d targets, got %d targets "+
+			"targets: %s seprator: %s", partsCount, len(parts), s, separator))
 	}
 	return parts, nil
 }
@@ -362,7 +363,6 @@ func TestTrafficSplit(t *testing.T) {
 func (test *e2eTest) verifyTargets(t *testing.T, serviceName string, expectedTargets []TargetFields) {
 	out := test.serviceDescribeWithJsonPath(t, serviceName, targetsJsonPath)
 	assert.Check(t, out != "")
-	out = strings.TrimSuffix(out, targetsSeparator)
 	actualTargets, err := splitTargets(out, targetsSeparator, len(expectedTargets))
 	assert.NilError(t, err)
 	formattedActualTargets := formatActualTargets(t, actualTargets)


### PR DESCRIPTION
 Fixes #434
/lint

## Proposed Changes
 - The error message now prints the expected/actual length of traffic targets
 - Also prints the actual traffic targets