### PR TITLE
fix English typo: 'an equally' instead of 'a equally'

### DIFF
--- a/pkg/kn/commands/plugin/verifier.go
+++ b/pkg/kn/commands/plugin/verifier.go
@@ -92,7 +92,7 @@ func (v *pluginVerifier) verify(eaw errorsAndWarnings, path string) errorsAndWar
 func (v *pluginVerifier) addWarningIfAlreadySeen(eaw errorsAndWarnings, path string) errorsAndWarnings {
 	fileName := filepath.Base(path)
 	if existingPath, ok := v.seenPlugins[fileName]; ok {
-		return eaw.addWarning("%s is ignored because it is shadowed by a equally named plugin: %s.", path, existingPath)
+		return eaw.addWarning("%s is ignored because it is shadowed by an equally named plugin: %s.", path, existingPath)
 	}
 	return eaw
 }

--- a/pkg/kn/commands/plugin/verifier_windows.go
+++ b/pkg/kn/commands/plugin/verifier_windows.go
@@ -88,7 +88,7 @@ func (v *pluginVerifier) verify(eaw errorsAndWarnings, path string) errorsAndWar
 func (v *pluginVerifier) addWarningIfAlreadySeen(eaw errorsAndWarnings, path string) errorsAndWarnings {
 	fileName := filepath.Base(path)
 	if existingPath, ok := v.seenPlugins[fileName]; ok {
-		return eaw.addWarning("%s is ignored because it is shadowed by a equally named plugin: %s.", path, existingPath)
+		return eaw.addWarning("%s is ignored because it is shadowed by an equally named plugin: %s.", path, existingPath)
 	}
 	return eaw
 }


### PR DESCRIPTION
Fixes an English typo

## Proposed Changes

* changes plugins code WARNING message "... a equally" to "... an equally"