### PR TITLE
Add service account info into service describe

### DIFF
--- a/pkg/kn/commands/service/describe.go
+++ b/pkg/kn/commands/service/describe.go
@@ -199,6 +199,9 @@ func writeService(dw printers.PrefixWriter, service *v1alpha1.Service) {
 		url := service.Status.Address.GetURL()
 		dw.WriteAttribute("Address", url.String())
 	}
+	if (service.Spec.Template != nil) && (service.Spec.Template.Spec.ServiceAccountName != "") {
+		dw.WriteAttribute("ServiceAccount", service.Spec.Template.Spec.ServiceAccountName)
+	}
 }
 
 // Write out revisions associated with this service. By default only active


### PR DESCRIPTION
Fixes #413 

## Proposed Changes

* Add service account info to `service describe` if present.

Release Note:
- 🧽 Add service account info to `service describe` if present.