### PR TITLE
removes remaining references to 'lookup-plugins-in-path'

### DIFF
--- a/pkg/kn/commands/plugin/handler_test.go
+++ b/pkg/kn/commands/plugin/handler_test.go
@@ -90,7 +90,7 @@ func TestPluginHandler(t *testing.T) {
 		})
 
 		t.Run("when plugin is in $PATH", func(t *testing.T) {
-			t.Run("--lookup-plugins-in-path=true", func(t *testing.T) {
+			t.Run("--lookup-plugins=true", func(t *testing.T) {
 				setup(t)
 				defer cleanup(t)
 
@@ -106,7 +106,7 @@ func TestPluginHandler(t *testing.T) {
 				assert.Assert(t, exists == true, fmt.Sprintf("could not Lookup(%s)", pluginName))
 			})
 
-			t.Run("--lookup-plugins-in-path=false", func(t *testing.T) {
+			t.Run("--lookup-plugins=false", func(t *testing.T) {
 				setup(t)
 				defer cleanup(t)
 

--- a/pkg/kn/commands/plugin/plugin.go
+++ b/pkg/kn/commands/plugin/plugin.go
@@ -38,7 +38,7 @@ Please refer to the documentation and examples for more information about how wr
 	return pluginCmd
 }
 
-// AddPluginFlags plugins-dir and lookup-plugins-in-path to cmd
+// AddPluginFlags plugins-dir and lookup-plugins to cmd
 func AddPluginFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&commands.Cfg.PluginsDir, "plugins-dir", "~/.kn/plugins", "kn plugins directory")
 	cmd.Flags().BoolVar(&commands.Cfg.LookupPlugins, "lookup-plugins", false, "look for kn plugins in $PATH")

--- a/pkg/kn/core/root.go
+++ b/pkg/kn/core/root.go
@@ -43,7 +43,7 @@ import (
 func NewDefaultKnCommand() *cobra.Command {
 	rootCmd := NewKnCommand()
 
-	// Needed since otherwise --plugins-dir and --lookup-plugins-in-path
+	// Needed since otherwise --plugins-dir and --lookup-plugins
 	// will not be accounted for since the plugin is not a Cobra command
 	// and will not be parsed
 	pluginsDir, lookupPluginsInPath, err := extractKnPluginFlags(os.Args)
@@ -218,7 +218,7 @@ func extractKnPluginFlags(args []string) (string, bool, error) {
 	lookupPluginsInPath := false
 
 	dirFlag := "--plugins-dir"
-	pathFlag := "--lookup-plugins-in-path"
+	pathFlag := "--lookup-plugins"
 	var err error
 
 	for _, arg := range args {
@@ -235,10 +235,10 @@ func extractKnPluginFlags(args []string) (string, bool, error) {
 		}
 
 		if arg == pathFlag {
-			// just --lookup-plugins-in-path   no "="
+			// just --lookup-plugins   no "="
 			lookupPluginsInPath = true
 		} else if strings.HasPrefix(arg, pathFlag+"=") {
-			// Starts with --lookup-plugins-in-path=  so we parse value
+			// Starts with --lookup-plugins=  so we parse value
 			arg = arg[len(pathFlag)+1:]
 			if lookupPluginsInPath, err = strconv.ParseBool(arg); err != nil {
 				return "", false, fmt.Errorf("Invalid boolean value(%q) for %s flag", arg, dirFlag)
@@ -257,8 +257,8 @@ func removeKnPluginFlags(args []string) []string {
 	for _, arg := range args {
 		if arg == "--plugins-dir" ||
 			strings.HasPrefix(arg, "--plugins-dir=") ||
-			arg == "--lookup-plugins-in-path" ||
-			strings.HasPrefix(arg, "--plookup-plugins-in-path=") {
+			arg == "--lookup-plugins" ||
+			strings.HasPrefix(arg, "--lookup-plugins=") {
 			continue
 		} else {
 			remainingArgs = append(remainingArgs, arg)


### PR DESCRIPTION
Removes remaining references to 'lookup-plugins-in-path' which is now renamed to the simpler 'lookup-plugins'

## Proposed Changes

* change references of 'lookup-plugins-in-path' to 'lookup-plugins' (new name for flag)