### PR TITLE
Shorten the --log-http Authorization mask value

### DIFF
--- a/pkg/util/logging_http_transport.go
+++ b/pkg/util/logging_http_transport.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"os"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -56,11 +55,7 @@ func (t *LoggingHttpTransport) RoundTrip(r *http.Request) (*http.Response, error
 	for k, v := range r.Header {
 		if sensitiveRequestHeaders.Has(k) {
 			redacted[k] = v
-			l := 0
-			for _, h := range v {
-				l += len(h)
-			}
-			r.Header.Set(k, strings.Repeat("*", l))
+			r.Header.Set(k, "********")
 		}
 	}
 	reqBytes, err := httputil.DumpRequestOut(r, true)

--- a/pkg/util/logging_http_transport_test.go
+++ b/pkg/util/logging_http_transport_test.go
@@ -87,6 +87,8 @@ func TestElideAuthorizationHeader(t *testing.T) {
 	assert.NilError(t, e)
 	s := out.String()
 	assert.Assert(t, strings.Contains(s, "REQUEST"))
+	assert.Assert(t, strings.Contains(s, "Authorization"))
+	assert.Assert(t, strings.Contains(s, "********"))
 	assert.Assert(t, strings.Contains(s, "la la normal text"))
 	assert.Assert(t, !strings.Contains(s, "SECRET"))
 	assert.Assert(t, strings.Contains(s, "RESPONSE"))


### PR DESCRIPTION
Fixes #391

## Proposed Changes

* display `--log-http` Authorization as `********`