### PR TITLE
Improve error message

### DIFF
--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -361,7 +361,8 @@ func (p *ConfigurationEditFlags) computeResources(resourceFlags ResourceFlags) (
 	if resourceFlags.CPU != "" {
 		cpuQuantity, err := resource.ParseQuantity(resourceFlags.CPU)
 		if err != nil {
-			return corev1.ResourceList{}, err
+			return corev1.ResourceList{},
+				errors.Wrapf(err, "Error parsing %q", resourceFlags.CPU)
 		}
 
 		resourceList[corev1.ResourceCPU] = cpuQuantity
@@ -370,7 +371,8 @@ func (p *ConfigurationEditFlags) computeResources(resourceFlags ResourceFlags) (
 	if resourceFlags.Memory != "" {
 		memoryQuantity, err := resource.ParseQuantity(resourceFlags.Memory)
 		if err != nil {
-			return corev1.ResourceList{}, err
+			return corev1.ResourceList{},
+				errors.Wrapf(err, "Error parsing %q", resourceFlags.Memory)
 		}
 
 		resourceList[corev1.ResourceMemory] = memoryQuantity


### PR DESCRIPTION
While testing I specified this on the `kn` command line:

```
./kn service create echo --concurrency-limit=1 --concurrency-target=1 --env foo=bar --limits-cpu=1000m --limits-memory=1024m --max-scale=1 --min-scale=1 --port=9999 --requests-cpu=250m --requests-memory=64mi --image duglin/echo
```
and it returned:
```
unable to parse quantity's suffix
```

I had no idea which value it didn't like. So this PR makes it so the output
is now this:
```
Error parsing "64mi": unable to parse quantity's suffix
```

Still not perfect since I still had to think way too hard to realize that it
didn't like the lower-case `m`, but that's a different issue.

Signed-off-by: Doug Davis <dug@us.ibm.com>

/lint
