### PR TITLE
Support multiple NAMEs on service delete

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,17 @@
 |===
 ////
 
+## v0.11.0 (unreleased)
+
+[cols="1,10,3", options="header", width="100%"]
+|===
+| | Description | PR
+
+| 🧽
+| Support multiple NAMEs on kn service delete
+| https://github.com/knative/client/pull/492[#492]
+|===
+
 ## v0.10.0 (2019-11-06)
 
 [cols="1,10,3", options="header", width="100%"]

--- a/pkg/kn/commands/service/delete.go
+++ b/pkg/kn/commands/service/delete.go
@@ -35,9 +35,10 @@ func NewServiceDeleteCommand(p *commands.KnParams) *cobra.Command {
   kn service delete svc2 -n ns1`,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
+			if len(args) < 1 {
 				return errors.New("requires the service name.")
 			}
+
 			namespace, err := p.GetNamespace(cmd)
 			if err != nil {
 				return err
@@ -47,11 +48,13 @@ func NewServiceDeleteCommand(p *commands.KnParams) *cobra.Command {
 				return err
 			}
 
-			err = client.DeleteService(args[0])
-			if err != nil {
-				return err
+			for _, name := range args {
+				err = client.DeleteService(name)
+				if err != nil {
+					return err
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "Service '%s' successfully deleted in namespace '%s'.\n", name, namespace)
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Service '%s' successfully deleted in namespace '%s'.\n", args[0], namespace)
 			return nil
 		},
 	}

--- a/pkg/kn/commands/service/delete.go
+++ b/pkg/kn/commands/service/delete.go
@@ -36,7 +36,7 @@ func NewServiceDeleteCommand(p *commands.KnParams) *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				return errors.New("requires the service name.")
+				return errors.New("requires the service name")
 			}
 
 			namespace, err := p.GetNamespace(cmd)
@@ -51,9 +51,10 @@ func NewServiceDeleteCommand(p *commands.KnParams) *cobra.Command {
 			for _, name := range args {
 				err = client.DeleteService(name)
 				if err != nil {
-					return err
+					fmt.Fprintf(cmd.OutOrStdout(), "%s.\n", err)
+				} else {
+					fmt.Fprintf(cmd.OutOrStdout(), "Service '%s' successfully deleted in namespace '%s'.\n", name, namespace)
 				}
-				fmt.Fprintf(cmd.OutOrStdout(), "Service '%s' successfully deleted in namespace '%s'.\n", name, namespace)
 			}
 			return nil
 		},

--- a/pkg/kn/commands/service/delete_test.go
+++ b/pkg/kn/commands/service/delete_test.go
@@ -59,3 +59,22 @@ func TestServiceDelete(t *testing.T) {
 	}
 	assert.Check(t, util.ContainsAll(output, "Service", sevName, "deleted", "namespace", commands.FakeNamespace))
 }
+
+func TestMultipleServiceDelete(t *testing.T) {
+	sevName1 := "sev-12345"
+	sevName2 := "sev-67890"
+	sevName3 := "sev-abcde"
+	action, _, output, err := fakeServiceDelete([]string{"service", "delete", sevName1, sevName2, sevName3})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if action == nil {
+		t.Errorf("No action")
+	} else if !action.Matches("delete", "services") {
+		t.Errorf("Bad action %v", action)
+	}
+	assert.Check(t, util.ContainsAll(output, "Service", sevName1, "deleted", "namespace", commands.FakeNamespace))
+	assert.Check(t, util.ContainsAll(output, "Service", sevName2, "deleted", "namespace", commands.FakeNamespace))
+	assert.Check(t, util.ContainsAll(output, "Service", sevName3, "deleted", "namespace", commands.FakeNamespace))
+}

--- a/test/e2e/service_test.go
+++ b/test/e2e/service_test.go
@@ -43,6 +43,11 @@ func TestService(t *testing.T) {
 		test.serviceDelete(t, "hello")
 		test.serviceDeleteNonexistent(t, "hello")
 	})
+
+	t.Run("delete two services with a service nonexistent", func(t *testing.T) {
+		test.serviceCreate(t, "hello")
+		test.serviceMultipleDelete(t, []string{"hello123", "hello"})
+	})
 }
 
 func (test *e2eTest) serviceCreateDuplicate(t *testing.T, serviceName string) {
@@ -69,8 +74,24 @@ func (test *e2eTest) serviceDeleteNonexistent(t *testing.T, serviceName string) 
 	assert.NilError(t, err)
 	assert.Check(t, !strings.Contains(out, serviceName), "The service exists")
 
-	_, err = test.kn.RunWithOpts([]string{"service", "delete", serviceName}, runOpts{NoNamespace: false, AllowError: true})
+	out, err = test.kn.RunWithOpts([]string{"service", "delete", serviceName}, runOpts{NoNamespace: false, AllowError: true})
 
 	expectedErr := fmt.Sprintf(`services.serving.knative.dev "%s" not found`, serviceName)
-	assert.ErrorContains(t, err, expectedErr)
+	assert.Check(t, strings.Contains(out, expectedErr), "Failed to get 'not found' error")
+}
+
+func (test *e2eTest) serviceMultipleDelete(t *testing.T, serviceName []string) {
+	existService := serviceName[1]
+	nonexistService := serviceName[0]
+	out, err := test.kn.RunWithOpts([]string{"service", "list"}, runOpts{NoNamespace: false})
+	assert.NilError(t, err)
+	assert.Check(t, strings.Contains(out, existService), "The service not exists")
+	assert.Check(t, !strings.Contains(out, nonexistService), "The service exists")
+
+	out, err = test.kn.RunWithOpts([]string{"service", "delete", serviceName[0], serviceName[1]}, runOpts{NoNamespace: false, AllowError: true})
+
+	expectedSuccess := fmt.Sprintf(`Service '%s' successfully deleted in namespace '%s'.`, existService, test.kn.namespace)
+	expectedErr := fmt.Sprintf(`services.serving.knative.dev "%s" not found`, nonexistService)
+	assert.Check(t, strings.Contains(out, expectedSuccess), "Failed to get 'successfully deleted' message")
+	assert.Check(t, strings.Contains(out, expectedErr), "Failed to get 'not found' error")
 }


### PR DESCRIPTION
Partially address #317

## Proposed Changes

* Support multiple NAMEs on `kn service delete`

Release Note:

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🧽 Support multiple NAMEs on `kn service delete`
