### PR TITLE
chore: Add version information of eventing

### DIFF
--- a/pkg/kn/commands/version/version.go
+++ b/pkg/kn/commands/version/version.go
@@ -29,6 +29,7 @@ var GitRevision string
 // update this var as we add more deps
 var apiVersions = []string{
 	"serving.knative.dev/v1alpha1 (knative-serving v0.10.0)",
+	"sources.eventing.knative.dev/v1alpha1 (knative-eventing v0.10.0)",
 }
 
 // NewVersionCommand implements 'kn version' command

--- a/pkg/kn/commands/version/version.go
+++ b/pkg/kn/commands/version/version.go
@@ -27,9 +27,13 @@ var BuildDate string
 var GitRevision string
 
 // update this var as we add more deps
-var apiVersions = []string{
-	"serving.knative.dev/v1alpha1 (knative-serving v0.10.0)",
-	"sources.eventing.knative.dev/v1alpha1 (knative-eventing v0.10.0)",
+var apiVersions = map[string][]string{
+	"serving": {
+		"serving.knative.dev/v1alpha1 (knative-serving v0.10.0)",
+	},
+	"eventing": {
+		"sources.eventing.knative.dev/v1alpha1 (knative-eventing v0.10.0)",
+	},
 }
 
 // NewVersionCommand implements 'kn version' command
@@ -43,8 +47,13 @@ func NewVersionCommand(p *commands.KnParams) *cobra.Command {
 			fmt.Fprintf(out, "Build Date:   %s\n", BuildDate)
 			fmt.Fprintf(out, "Git Revision: %s\n", GitRevision)
 			fmt.Fprintf(out, "Supported APIs:\n")
-			for _, api := range apiVersions {
-				fmt.Fprintf(out, "- %s\n", api)
+			fmt.Fprintf(out, "* Serving\n")
+			for _, api := range apiVersions["serving"] {
+				fmt.Fprintf(out, "  - %s\n", api)
+			}
+			fmt.Fprintf(out, "* Eventing\n")
+			for _, api := range apiVersions["eventing"] {
+				fmt.Fprintf(out, "  - %s\n", api)
 			}
 		},
 	}

--- a/pkg/kn/commands/version/version_test.go
+++ b/pkg/kn/commands/version/version_test.go
@@ -36,6 +36,7 @@ Build Date:   {{.BuildDate}}
 Git Revision: {{.GitRevision}}
 Supported APIs:
 - serving.knative.dev/v1alpha1 (knative-serving v0.10.0)
+- sources.eventing.knative.dev/v1alpha1 (knative-eventing v0.10.0)
 `
 
 const (

--- a/pkg/kn/commands/version/version_test.go
+++ b/pkg/kn/commands/version/version_test.go
@@ -35,8 +35,10 @@ var versionOutputTemplate = `Version:      {{.Version}}
 Build Date:   {{.BuildDate}}
 Git Revision: {{.GitRevision}}
 Supported APIs:
-- serving.knative.dev/v1alpha1 (knative-serving v0.10.0)
-- sources.eventing.knative.dev/v1alpha1 (knative-eventing v0.10.0)
+* Serving
+  - serving.knative.dev/v1alpha1 (knative-serving v0.10.0)
+* Eventing
+  - sources.eventing.knative.dev/v1alpha1 (knative-eventing v0.10.0)
 `
 
 const (


### PR DESCRIPTION
Adding sources.eventing.knative.dev to version info (the only eventing API)
for now as this will be the first one used.