### PR TITLE
Update vendor/knative.dev/test-infra

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	knative.dev/eventing v0.10.0
 	knative.dev/pkg v0.0.0-20191107185656-884d50f09454
 	knative.dev/serving v0.10.0
-	knative.dev/test-infra v0.0.0-20191106182702-a6a34418ff33
+	knative.dev/test-infra v0.0.0-20191113204928-e381f11dc722
 	sigs.k8s.io/yaml v1.1.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -530,8 +530,8 @@ knative.dev/pkg v0.0.0-20191107185656-884d50f09454 h1:nkslWFyRWaJp3nPDm+GSQOSvN8
 knative.dev/pkg v0.0.0-20191107185656-884d50f09454/go.mod h1:pgODObA1dTyhNoFxPZTTjNWfx6F0aKsKzn+vaT9XO/Q=
 knative.dev/serving v0.10.0 h1:T1csznAQrc/DvCE4KROz4NqOtJ24mnU9eF9RMeeYaCc=
 knative.dev/serving v0.10.0/go.mod h1:x2n255JS2XBI39tmjZ8CwTxIf9EKNMCrkVuiOttLRm0=
-knative.dev/test-infra v0.0.0-20191106182702-a6a34418ff33 h1:qoTgY6ZKEMs3MUV8hQWhMUjdyecKZsLqYCxFIP8eYwo=
-knative.dev/test-infra v0.0.0-20191106182702-a6a34418ff33/go.mod h1:xcdUkMJrLlBswIZqL5zCuBFOC22WIPMQoVX1L35i0vQ=
+knative.dev/test-infra v0.0.0-20191113204928-e381f11dc722 h1:MnOoRxxPk7Hs8NIBhuUinJGgP8gCqKJKQQJWa+rZgao=
+knative.dev/test-infra v0.0.0-20191113204928-e381f11dc722/go.mod h1:xcdUkMJrLlBswIZqL5zCuBFOC22WIPMQoVX1L35i0vQ=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/knative.dev/test-infra/scripts/e2e-tests.sh
+++ b/vendor/knative.dev/test-infra/scripts/e2e-tests.sh
@@ -325,6 +325,9 @@ function setup_test_cluster() {
   set -o errexit
   set -o pipefail
 
+  header "Test cluster setup"
+  kubectl get nodes
+
   header "Setting up test cluster"
 
   # Set the actual project the test cluster resides in

--- a/vendor/knative.dev/test-infra/scripts/release.sh
+++ b/vendor/knative.dev/test-infra/scripts/release.sh
@@ -212,7 +212,7 @@ function prepare_dot_release() {
     echo "Dot release will be generated for ${version_filter}"
     releases="$(echo "${releases}" | grep ^${version_filter})"
   fi
-  local last_version="$(echo "${releases}" | grep '^v[0-9]\+\.[0-9]\+\.[0-9]\+$' | sort -r | head -1)"
+  local last_version="$(echo "${releases}" | grep '^v[0-9]\+\.[0-9]\+\.[0-9]\+$' | sort -r -V | head -1)"
   [[ -n "${last_version}" ]] || abort "no previous release exist"
   local major_minor_version=""
   if [[ -z "${RELEASE_BRANCH}" ]]; then

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -667,7 +667,7 @@ knative.dev/serving/pkg/apis/serving/v1
 knative.dev/serving/pkg/apis/serving/v1beta1
 knative.dev/serving/pkg/gc
 knative.dev/serving/pkg/network
-# knative.dev/test-infra v0.0.0-20191106182702-a6a34418ff33
+# knative.dev/test-infra v0.0.0-20191113204928-e381f11dc722
 knative.dev/test-infra/scripts
 # sigs.k8s.io/kustomize v2.0.3+incompatible
 sigs.k8s.io/kustomize/pkg/fs


### PR DESCRIPTION
Major changes:
* display E2E cluster setup during tests
* fix parsing error for autogenerated code in flaky test reporter
* fix automatic dot releases for 0.10+ branches

Part of https://github.com/knative/test-infra/issues/1542

/cc @grantr