### PR TITLE
With sync update, get revision name with latestReadyRevisionName

### DIFF
--- a/test/e2e/traffic_split_test.go
+++ b/test/e2e/traffic_split_test.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"gotest.tools/assert"
 	"knative.dev/client/pkg/util"
@@ -360,6 +361,7 @@ func TestTrafficSplit(t *testing.T) {
 }
 
 func (test *e2eTest) verifyTargets(t *testing.T, serviceName string, expectedTargets []TargetFields) {
+	time.Sleep(3 * time.Second)
 	out := test.serviceDescribeWithJsonPath(t, serviceName, targetsJsonPath)
 	assert.Check(t, out != "")
 	actualTargets, err := splitTargets(out, targetsSeparator, len(expectedTargets))


### PR DESCRIPTION
/lint

~Fixes # 500~ Check #506 

## Proposed Changes
 - We got synchronous service update operation, ensuring the requested
   config change is reconciled before service update operation returns. #271

 - Traffic splitting e2e tests, do sync service update to generate the
   revisions.

 - With every service update, we need to grab the revision
   name generated with this update (for subsequent operations),
   which we can grab using `latestReadyRevisionName` since sync service updated returned.