### PR TITLE
fix(e2e): Removes explicit timeout flag in smoke tests

### DIFF
--- a/test/e2e-smoke-tests.sh
+++ b/test/e2e-smoke-tests.sh
@@ -49,8 +49,8 @@ kubectl create ns $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 sleep 4 # Wait for the namespace to get initialized by kube-controller-manager
 
 ./kn service create svc1 --async --image gcr.io/knative-samples/helloworld-go -e TARGET=Knative -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
-./kn service create hello --image gcr.io/knative-samples/helloworld-go -e TARGET=Knative -n $KN_E2E_SMOKE_TESTS_NAMESPACE --wait-timeout 240 || fail_test
-./kn service list hello -n $KN_E2E_SMOKE_TESTS_NAMESPACE -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
+./kn service create hello --image gcr.io/knative-samples/helloworld-go -e TARGET=Knative -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
+./kn service list hello -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 ./kn service update hello --env TARGET=kn -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 ./kn revision list hello -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 ./kn service list -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test


### PR DESCRIPTION
Fixes #507

## Proposed Changes
 - removes `--wait-timeout` flag, was set to 240 seconds which is lesser than the default timeout (600 seconds)
 - removes duplication of namespace flag in another smoke test command