### PR TITLE
tests: Avoid downloading deps in unit tests

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -46,6 +46,11 @@ function post_build_tests() {
   fi
 }
 
+# Run the unit tests with an additional flag '-mod=vendor' to avoid
+# downloading the deps in unit tests CI job
+function unit_tests() {
+  report_go_test -race -mod=vendor ./... || failed=1
+}
 
-# We use the default build, unit and integration test runners.
+# We use the default build and integration test runners.
 main $@


### PR DESCRIPTION
## Proposed Changes
 - Uses custom `unit_tests` function in presubmit-tests.sh to run unit tests
 - Custom function adds a flag `-mod=vendor` in addition to default unit tests runner
 - The deps are already downloaded part of the source repo, mentioned flag uses it (vendor dir)
   and avoids downloading the deps afresh
 - This prevents(in unit tests) the flake we see 'go: error loading module requirements' which occurs
   due to download error