### PR TITLE
Tests: refactor delete service unit tests to use KnClient mock (#358)

### DIFF
--- a/pkg/kn/commands/service/service_delete_mock_test.go
+++ b/pkg/kn/commands/service/service_delete_mock_test.go
@@ -1,0 +1,73 @@
+// Copyright © 2019 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+
+	knclient "knative.dev/client/pkg/serving/v1alpha1"
+	"knative.dev/client/pkg/util"
+)
+
+func TestServiceDeleteMock(t *testing.T) {
+	// New mock client
+	client := knclient.NewMockKnClient(t)
+
+	// Recording:
+	r := client.Recorder()
+
+	r.DeleteService("foo", nil)
+
+	output, err := executeServiceCommand(client, "delete", "foo")
+	assert.NilError(t, err)
+	assert.Assert(t, util.ContainsAll(output, "deleted", "foo", "default"))
+
+	r.Validate()
+
+}
+
+func TestMultipleServiceDeleteMock(t *testing.T) {
+	// New mock client
+	client := knclient.NewMockKnClient(t)
+
+	// Recording:
+	r := client.Recorder()
+
+	r.DeleteService("foo", nil)
+	r.DeleteService("bar", nil)
+	r.DeleteService("baz", nil)
+
+	output, err := executeServiceCommand(client, "delete", "foo", "bar", "baz")
+	assert.NilError(t, err)
+	assert.Assert(t, util.ContainsAll(output, "deleted", "foo", "bar", "baz", "default"))
+
+	r.Validate()
+}
+
+func TestServiceDeleteNoSvcNameMock(t *testing.T) {
+	// New mock client
+	client := knclient.NewMockKnClient(t)
+
+	// Recording:
+	r := client.Recorder()
+
+	output, _ := executeServiceCommand(client, "delete")
+	assert.Assert(t, util.ContainsAll(output, "requires", "the", "service", "name"))
+
+	r.Validate()
+
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #358 

## Proposed Changes

* refactors the delete service unit tests to use knclient mock
* This pr partially fixes #358 

<!--
Release Note:

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behaviour
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example.

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->
