### PR TITLE
Eventing setup in CI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	knative.dev/eventing v0.10.0
 	knative.dev/pkg v0.0.0-20191107185656-884d50f09454
 	knative.dev/serving v0.10.0
-	knative.dev/test-infra v0.0.0-20191203152035-98a7b3bbed2d
+	knative.dev/test-infra v0.0.0-20191205012837-30f1a1f7b77e
 	sigs.k8s.io/yaml v1.1.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -534,8 +534,8 @@ knative.dev/pkg v0.0.0-20191107185656-884d50f09454 h1:nkslWFyRWaJp3nPDm+GSQOSvN8
 knative.dev/pkg v0.0.0-20191107185656-884d50f09454/go.mod h1:pgODObA1dTyhNoFxPZTTjNWfx6F0aKsKzn+vaT9XO/Q=
 knative.dev/serving v0.10.0 h1:T1csznAQrc/DvCE4KROz4NqOtJ24mnU9eF9RMeeYaCc=
 knative.dev/serving v0.10.0/go.mod h1:x2n255JS2XBI39tmjZ8CwTxIf9EKNMCrkVuiOttLRm0=
-knative.dev/test-infra v0.0.0-20191203152035-98a7b3bbed2d h1:g6tN3ufvEsQ3NxhsHQRi6q+q3xBDCwbSMUUIrCnQeRU=
-knative.dev/test-infra v0.0.0-20191203152035-98a7b3bbed2d/go.mod h1:xcdUkMJrLlBswIZqL5zCuBFOC22WIPMQoVX1L35i0vQ=
+knative.dev/test-infra v0.0.0-20191205012837-30f1a1f7b77e h1:QTlOxV+M072CNdbKkqn6gmLWPETuLs+EiZ/pOv1jcrw=
+knative.dev/test-infra v0.0.0-20191205012837-30f1a1f7b77e/go.mod h1:xcdUkMJrLlBswIZqL5zCuBFOC22WIPMQoVX1L35i0vQ=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -22,12 +22,21 @@ function cluster_setup() {
 }
 
 function knative_setup() {
-  local version=${KNATIVE_VERSION:-latest}
-  header "Installing Knative serving (${version})"
+  local serving_version=${KNATIVE_SERVING_VERSION:-latest}
+  header "Installing Knative Serving (${serving_version})"
 
   if [ "${version}" = "latest" ]; then
     start_latest_knative_serving
   else
-    start_release_knative_serving "${version}"
+    start_release_knative_serving "${serving_version}"
+  fi
+
+  local eventing_version=${KNATIVE_EVENTING_VERSION:-latest}
+  header "Installing Knative Eventing (${eventing_version})"
+
+  if ["${eventing_version}" = "latest"]; then
+    start_latest_knative_eventing
+  else
+    start_release_knative_eventing "${eventing_version}"
   fi
 }

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -25,7 +25,7 @@ function knative_setup() {
   local serving_version=${KNATIVE_SERVING_VERSION:-latest}
   header "Installing Knative Serving (${serving_version})"
 
-  if [ "${version}" = "latest" ]; then
+  if [ "${serving_version}" = "latest" ]; then
     start_latest_knative_serving
   else
     start_release_knative_serving "${serving_version}"
@@ -34,7 +34,7 @@ function knative_setup() {
   local eventing_version=${KNATIVE_EVENTING_VERSION:-latest}
   header "Installing Knative Eventing (${eventing_version})"
 
-  if ["${eventing_version}" = "latest"]; then
+  if [ "${eventing_version}" = "latest" ]; then
     start_latest_knative_eventing
   else
     start_release_knative_eventing "${eventing_version}"

--- a/test/e2e-smoke-tests.sh
+++ b/test/e2e-smoke-tests.sh
@@ -24,7 +24,6 @@
 # project $PROJECT_ID, start Knative serving, run the tests and delete
 # the cluster.
 
-source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/e2e-tests.sh
 source $(dirname $0)/e2e-common.sh
 
 # Will create and delete this namespace and use it for smoke tests

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -25,10 +25,11 @@
 # the cluster.
 
 # If you call this script after configuring the environment variable
-# $KNATIVE_VERSION with a valid release, e.g. 0.6.0, Knative serving
-# of this specified version will be installed in the Kubernetes cluster, and
-# all the tests will run against Knative serving of this specific version.
-source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/e2e-tests.sh
+# $KNATIVE_SERVING_VERSION / $KNATIVE_EVENTING_VERSION with a valid release,
+# e.g. 0.10.0, Knative Serving / Eventing of this specified version will be
+# installed in the Kubernetes cluster, and all the tests will run against
+# Knative Serving / Eventing of this specific version.
+
 source $(dirname $0)/e2e-common.sh
 
 # Add local dir to have access to built kn
@@ -38,7 +39,7 @@ export PATH=$PATH:${REPO_ROOT_DIR}
 
 initialize $@
 
-header "Running tests for Knative serving $KNATIVE_VERSION"
+header "Running tests for Knative Serving $KNATIVE_SERVING_VERSION and Eventing $KNATIVE_EVENTING_VERSION"
 
 go_test_e2e -timeout=30m ./test/e2e || fail_test
 success

--- a/test/presubmit-integration-tests-latest-release.sh
+++ b/test/presubmit-integration-tests-latest-release.sh
@@ -15,8 +15,10 @@
 # limitations under the License.
 
 # This script is used in Knative/test-infra as a custom prow job to run the
-# integration tests against Knative serving of a specific version. We
-# currently take 0.6.0 as the latest release version.
+# integration tests against Knative Serving / Eventing of a specific version.
+# We currently take 0.10.0 for Serving and 0.10.2 for Eventing as the
+# latest release version.
 
-export KNATIVE_VERSION="0.10.0"
+export KNATIVE_SERVING_VERSION="0.10.0"
+export KNATIVE_EVENTING_VERSION="0.10.2"
 $(dirname $0)/presubmit-tests.sh --integration-tests

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -25,14 +25,17 @@
 # in a net-negative contributor experience.
 # Tracked by https://github.com/knative/test-infra/issues/428
 
-# If you call this script after configuring the environment variable
-# $KNATIVE_VERSION with a valid release, e.g. 0.6.0, Knative serving
-# of this specified version will be installed in the Kubernetes cluster, and
-# all the tests will run against Knative serving of this specific version.
+# If you call this script after configuring the environment variables
+# $KNATIVE_SERVING_VERSION / $KNATIVE_EVENTING_VERSION with a valid release,
+# e.g. 0.6.0, Knative Serving / Eventing of this specified version will be installed
+# in the Kubernetes cluster, and all the tests will run against Knative
+# Serving / Eventing of this specific version.
+
 export DISABLE_MD_LINTING=1
 
 export GO111MODULE=on
-export KNATIVE_VERSION=${KNATIVE_VERSION:-latest}
+export KNATIVE_SERVING_VERSION=${KNATIVE_SERVING_VERSION:-latest}
+export KNATIVE_EVENTING_VERSION=${KNATIVE_EVENTING_VERSION:-latest}
 source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/presubmit-tests.sh
 
 # Run cross platform build to ensure kn compiles for Linux, macOS and Windows

--- a/vendor/knative.dev/test-infra/scripts/library.sh
+++ b/vendor/knative.dev/test-infra/scripts/library.sh
@@ -443,6 +443,29 @@ function start_latest_knative_serving() {
   start_knative_serving "${KNATIVE_SERVING_RELEASE}"
 }
 
+# Install Knative Eventing in the current cluster.
+# Parameters: $1 - Knative Eventing manifest.
+function start_knative_eventing() {
+  header "Starting Knative Eventing"
+  subheader "Installing Knative Eventing"
+  echo "Installing Eventing CRDs from $1"
+  kubectl apply --selector knative.dev/crd-install=true -f "$1"
+  echo "Installing the rest of eventing components from $1"
+  kubectl apply -f "$1"
+  wait_until_pods_running knative-eventing || return 1
+}
+
+# Install the stable release Knative/eventing in the current cluster.
+# Parameters: $1 - Knative Eventing version number, e.g. 0.6.0.
+function start_release_knative_eventing() {
+  start_knative_eventing "https://storage.googleapis.com/knative-releases/eventing/previous/v$1/release.yaml"
+}
+
+# Install the latest stable Knative Eventing in the current cluster.
+function start_latest_knative_eventing() {
+  start_knative_eventing "${KNATIVE_EVENTING_RELEASE}"
+}
+
 # Run a go tool, installing it first if necessary.
 # Parameters: $1 - tool package/dir for go get/install.
 #             $2 - tool to run.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -668,7 +668,7 @@ knative.dev/serving/pkg/apis/serving/v1
 knative.dev/serving/pkg/apis/serving/v1beta1
 knative.dev/serving/pkg/gc
 knative.dev/serving/pkg/network
-# knative.dev/test-infra v0.0.0-20191203152035-98a7b3bbed2d
+# knative.dev/test-infra v0.0.0-20191205012837-30f1a1f7b77e
 knative.dev/test-infra/scripts
 # sigs.k8s.io/kustomize v2.0.3+incompatible
 sigs.k8s.io/kustomize/pkg/fs


### PR DESCRIPTION
## Proposed Changes
  - Update test-infra
  - Use library functions for setting up released and latest Eventing
  - Set up Eventing 0.10.2 and nightly release in `latest-release` and default e2e tests CI job respectively