### PR TITLE
Remove unused emit-metrics flag for e2e tests

### DIFF
--- a/test/e2e/e2e_flags.go
+++ b/test/e2e/e2e_flags.go
@@ -27,15 +27,11 @@ var Flags = initializeFlags()
 
 // ClientFlags define the flags that are needed to run the e2e tests.
 type ClientFlags struct {
-	EmitMetrics      bool
 	DockerConfigJSON string
 }
 
 func initializeFlags() *ClientFlags {
 	var f ClientFlags
-	// emitmetrics is a required flag for running periodic test jobs, add it here as a no-op to avoid the error
-	flag.BoolVar(&f.EmitMetrics, "emitmetrics", false,
-		"Set this flag to true if you would like tests to emit metrics, e.g. latency of resources being realized in the system.")
 
 	dockerConfigJSON := os.Getenv("DOCKER_CONFIG_JSON")
 	flag.StringVar(&f.DockerConfigJSON, "dockerconfigjson", dockerConfigJSON,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes https://github.com/knative/test-infra/issues/1568

## Proposed Changes
The `--emit-metrics` can be safely removed now as the relevant job has been deprecated.

<!--
Release Note:

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behaviour
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example.

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

/cc @adrcunha 
/cc @chaodaiG 