### PR TITLE
service describe command : Move Cluster URL to --verbose from default output

### DIFF
--- a/pkg/kn/commands/service/describe.go
+++ b/pkg/kn/commands/service/describe.go
@@ -162,9 +162,11 @@ func describe(w io.Writer, service *v1alpha1.Service, revisions []*revisionDesc,
 func writeService(dw printers.PrefixWriter, service *v1alpha1.Service) {
 	commands.WriteMetadata(dw, &service.ObjectMeta, printDetails)
 	dw.WriteAttribute("URL", extractURL(service))
-	if service.Status.Address != nil {
-		url := service.Status.Address.GetURL()
-		dw.WriteAttribute("Cluster", url.String())
+	if printDetails {
+		if service.Status.Address != nil {
+			url := service.Status.Address.GetURL()
+			dw.WriteAttribute("Cluster", url.String())
+		}
 	}
 	if (service.Spec.Template != nil) && (service.Spec.Template.Spec.ServiceAccountName != "") {
 		dw.WriteAttribute("ServiceAccount", service.Spec.Template.Spec.ServiceAccountName)

--- a/pkg/kn/commands/service/describe_test.go
+++ b/pkg/kn/commands/service/describe_test.go
@@ -452,7 +452,7 @@ func TestServiceDescribeVerbose(t *testing.T) {
 	assert.NilError(t, err)
 
 	validateServiceOutput(t, "foo", output)
-	
+
 	assert.Assert(t, cmp.Regexp("Cluster:\\s+http://foo.default.svc.cluster.local", output))
 	assert.Assert(t, util.ContainsAll(output, "Image", "Name", "gcr.io/test/image (at 123456)", "50%", "(0s)"))
 	assert.Assert(t, util.ContainsAll(output, "Env:", "label1=lval1\n", "label2=lval2\n"))

--- a/pkg/kn/commands/service/describe_test.go
+++ b/pkg/kn/commands/service/describe_test.go
@@ -292,6 +292,7 @@ func TestServiceDescribeScaling(t *testing.T) {
 		} else {
 			assert.Assert(t, !strings.Contains(output, "Concurrency:"))
 		}
+		assert.Assert(t, cmp.Regexp("Cluster:\\s+http://foo.default.svc.cluster.local", output))
 
 		validateOutputLine(t, output, "Scale", data.scaleOut)
 		validateOutputLine(t, output, "Limit", data.limit)
@@ -354,6 +355,8 @@ func TestServiceDescribeResources(t *testing.T) {
 		assert.NilError(t, err)
 
 		validateServiceOutput(t, "foo", output)
+
+		assert.Assert(t, cmp.Regexp("Cluster:\\s+http://foo.default.svc.cluster.local", output))
 
 		validateOutputLine(t, output, "Memory", data.memoryOut)
 		validateOutputLine(t, output, "CPU", data.cpuOut)
@@ -449,7 +452,8 @@ func TestServiceDescribeVerbose(t *testing.T) {
 	assert.NilError(t, err)
 
 	validateServiceOutput(t, "foo", output)
-
+	
+	assert.Assert(t, cmp.Regexp("Cluster:\\s+http://foo.default.svc.cluster.local", output))
 	assert.Assert(t, util.ContainsAll(output, "Image", "Name", "gcr.io/test/image (at 123456)", "50%", "(0s)"))
 	assert.Assert(t, util.ContainsAll(output, "Env:", "label1=lval1\n", "label2=lval2\n"))
 	assert.Assert(t, util.ContainsAll(output, "Annotations:", "anno1=aval1\n", "anno2=aval2\n"))
@@ -489,7 +493,6 @@ func TestServiceDescribeMachineReadable(t *testing.T) {
 func validateServiceOutput(t *testing.T, service string, output string) {
 	assert.Assert(t, cmp.Regexp("Name:\\s+"+service, output))
 	assert.Assert(t, cmp.Regexp("Namespace:\\s+default", output))
-	assert.Assert(t, cmp.Regexp("Cluster:\\s+http://"+service+".default.svc.cluster.local", output))
 	assert.Assert(t, cmp.Regexp("URL:\\s+"+service+".default.example.com", output))
 
 	assert.Assert(t, util.ContainsAll(output, "Age:", "Revisions:", "Conditions:", "Labels:", "Annotations:"))

--- a/test/e2e/basic_workflow_test.go
+++ b/test/e2e/basic_workflow_test.go
@@ -98,7 +98,7 @@ func (test *e2eTest) serviceDescribe(t *testing.T, serviceName string) {
 
 	assert.Assert(t, util.ContainsAll(out, serviceName, test.kn.namespace, KnDefaultTestImage))
 	assert.Assert(t, util.ContainsAll(out, "Conditions", "ConfigurationsReady", "Ready", "RoutesReady"))
-	assert.Assert(t, util.ContainsAll(out, "Name", "Namespace", "URL", "Cluster", "Age", "Revisions"))
+	assert.Assert(t, util.ContainsAll(out, "Name", "Namespace", "URL", "Age", "Revisions"))
 }
 
 func (test *e2eTest) serviceUpdate(t *testing.T, serviceName string, args []string) {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #482 

## Proposed Changes

* Show cluster url only in verbose request in service describe command

<!--
Release Note:

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behaviour
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example.

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->
