### PR TITLE
Retrurn error if exist duplicate key in filter option

### DIFF
--- a/pkg/kn/commands/trigger/update_flags.go
+++ b/pkg/kn/commands/trigger/update_flags.go
@@ -54,6 +54,9 @@ func (f *TriggerUpdateFlags) GetFilters() (map[string]string, error) {
 		if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
 			return nil, fmt.Errorf("invalid filter %s", f.Filters)
 		} else {
+			if _, ok := filters[parts[0]]; ok {
+				return nil, fmt.Errorf("duplicate key '%s' in filters %s", parts[0], f.Filters)
+			}
 			filters[parts[0]] = parts[1]
 		}
 	}
@@ -71,6 +74,9 @@ func (f *TriggerUpdateFlags) GetUpdateFilters() (map[string]string, []string, er
 			parts := strings.Split(item, "=")
 			if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
 				return nil, nil, fmt.Errorf("invalid filter %s", f.Filters)
+			}
+			if _, ok := filters[parts[0]]; ok {
+				return nil, nil, fmt.Errorf("duplicate key '%s' in filters %s", parts[0], f.Filters)
 			}
 			filters[parts[0]] = parts[1]
 		}

--- a/pkg/kn/commands/trigger/update_flags_test.go
+++ b/pkg/kn/commands/trigger/update_flags_test.go
@@ -59,6 +59,14 @@ func TestGetFilters(t *testing.T) {
 		_, err = createFlag.GetFilters()
 		assert.ErrorContains(t, err, "invalid filter")
 	})
+
+	t.Run("get duplicate filters", func(t *testing.T) {
+		createFlag := TriggerUpdateFlags{
+			Filters: filterArray{"type=foo", "type=bar"},
+		}
+		_, err := createFlag.GetFilters()
+		assert.ErrorContains(t, err, "duplicate key")
+	})
 }
 
 func TestGetUpdateFilters(t *testing.T) {
@@ -100,5 +108,13 @@ func TestGetUpdateFilters(t *testing.T) {
 		assert.NilError(t, err, "UpdateFilter should be created")
 		assert.DeepEqual(t, wantedRemoved, removed)
 		assert.DeepEqual(t, wantedUpdated, updated)
+	})
+
+	t.Run("update duplicate filters", func(t *testing.T) {
+		createFlag := TriggerUpdateFlags{
+			Filters: filterArray{"type=foo", "type=bar"},
+		}
+		_, _, err := createFlag.GetUpdateFilters()
+		assert.ErrorContains(t, err, "duplicate key")
 	})
 }


### PR DESCRIPTION
Fixes #569

## Proposed Changes

*Return error if user set duplicate key in `--filter` option. For example, `kn trigger create --filter type=bla --filter type=blub test`.
