### PR TITLE
feature(#580): adds traffic and tags information to revision list

### DIFF
--- a/pkg/kn/commands/revision/human_readable_flags.go
+++ b/pkg/kn/commands/revision/human_readable_flags.go
@@ -23,11 +23,18 @@ import (
 	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
 )
 
+const (
+	RevisionTrafficAnnotation = "client.knative.dev/traffic"
+	RevisionTagsAnnotation    = "client.knative.dev/tags"
+)
+
 // RevisionListHandlers adds print handlers for revision list command
 func RevisionListHandlers(h hprinters.PrintHandler) {
 	RevisionColumnDefinitions := []metav1beta1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Description: "Name of the revision.", Priority: 1},
 		{Name: "Service", Type: "string", Description: "Name of the Knative service.", Priority: 1},
+		{Name: "Traffic", Type: "string", Description: "Percentage of traffic assigned to this revision.", Priority: 1},
+		{Name: "Tags", Type: "string", Description: "Set of tags assigned to this revision.", Priority: 1},
 		{Name: "Generation", Type: "string", Description: "Generation of the revision", Priority: 1},
 		{Name: "Age", Type: "string", Description: "Age of the revision.", Priority: 1},
 		{Name: "Conditions", Type: "string", Description: "Conditions describing statuses of the revision.", Priority: 1},
@@ -57,6 +64,8 @@ func printRevisionList(revisionList *servingv1alpha1.RevisionList, options hprin
 func printRevision(revision *servingv1alpha1.Revision, options hprinters.PrintOptions) ([]metav1beta1.TableRow, error) {
 	name := revision.Name
 	service := revision.Labels[serving.ServiceLabelKey]
+	traffic := revision.Annotations[RevisionTrafficAnnotation]
+	tags := revision.Annotations[RevisionTagsAnnotation]
 	generation := revision.Labels[serving.ConfigurationGenerationLabelKey]
 	age := commands.TranslateTimestampSince(revision.CreationTimestamp)
 	conditions := commands.ConditionsValue(revision.Status.Conditions)
@@ -68,6 +77,8 @@ func printRevision(revision *servingv1alpha1.Revision, options hprinters.PrintOp
 	row.Cells = append(row.Cells,
 		name,
 		service,
+		traffic,
+		tags,
 		generation,
 		age,
 		conditions,

--- a/pkg/kn/commands/revision/list_flags.go
+++ b/pkg/kn/commands/revision/list_flags.go
@@ -26,7 +26,7 @@ import (
 type RevisionListFlags struct {
 	GenericPrintFlags  *genericclioptions.PrintFlags
 	HumanReadableFlags *commands.HumanPrintFlags
-	ServiceRefFlags    ServiceReferenceFlags
+	ServiceRefFlags    *ServiceReferenceFlags
 }
 
 // AllowedFormats is the list of formats in which data can be displayed
@@ -70,6 +70,7 @@ func NewRevisionListFlags() *RevisionListFlags {
 	return &RevisionListFlags{
 		GenericPrintFlags:  genericclioptions.NewPrintFlags(""),
 		HumanReadableFlags: commands.NewHumanPrintFlags(),
+		ServiceRefFlags:    &ServiceReferenceFlags{},
 	}
 }
 


### PR DESCRIPTION
Fixes #580

## Proposed Changes

* adds traffic information of revision as an annotation in revision list
* adds tags information of revision as an annotation in revision list
* show traffic and tags when listing revisions

With this change, invocation of `kn revision list` will look like:

```bash
➜  client git:(issue580) ✗ ./kn revision list
Using kn config file: /Users/maximilien/.kn/config.yaml
NAME                  SERVICE       GENERATION   AGE   CONDITIONS   READY   TRAFFIC   TAGS    REASON
twitter-fn-ycybl-1    twitter-fn    26           28d   3 OK / 4     True    100%
summary-fn-hwkll-31   summary-fn    20           23d   3 OK / 4     True    50%       async
summary-fn-qwfdb-1    summary-fn    19           23d   3 OK / 4     True    50%       sync
watson-fn-wxpyf-15    watson-fn     15           28d   3 OK / 4     True    100%
hello-world-tndhb-2   hello-world   2            28d   3 OK / 4     True    100%

➜  client git:(issue580) ✗ ./kn revision list -s summary-fn
Using kn config file: /Users/maximilien/.kn/config.yaml
NAME                  SERVICE      GENERATION   AGE   CONDITIONS   READY   TRAFFIC   TAGS    REASON
summary-fn-hwkll-31   summary-fn   20           23d   3 OK / 4     True    50%       async
summary-fn-qwfdb-1    summary-fn   19           23d   3 OK / 4     True    50%       sync
```

<!--
Release Note:

- 🎁 adds revision traffic and tags information when listing revisions