### PR TITLE
fixes(#586): simplifies service update message to user

### DIFF
--- a/pkg/kn/commands/service/service.go
+++ b/pkg/kn/commands/service/service.go
@@ -66,8 +66,13 @@ func showUrl(client serving_kn_v1alpha1.KnServingClient, serviceName string, ori
 	revisionUpdateStatus := ""
 	newRevision := service.Status.LatestReadyRevisionName
 	if originalRevision != "" && originalRevision == newRevision {
-		revisionUpdateStatus = " (unchanged)"
+		revisionUpdateStatus = "unchanged"
 	}
-	fmt.Fprintf(out, "Service '%s' %s with latest revision '%s'%s and URL:\n%s\n", serviceName, what, newRevision, revisionUpdateStatus, url)
+	if revisionUpdateStatus == "unchanged" {
+		fmt.Fprintf(out, "Service '%s' with latest revision '%s' (unchanged) is available at URL:\n%s\n", serviceName, newRevision, url)
+	} else {
+		fmt.Fprintf(out, "Service '%s' %s to latest revision '%s' is available at URL:\n%s\n", serviceName, what, newRevision, url)
+	}
+
 	return nil
 }


### PR DESCRIPTION
Fixes #586

## Proposed Changes

* splits final service update to user to make clear what changed and what has not

```bash
➜  client git:(master) ✗ ./kn service update summary-fn --untag sync1
Using kn config file: /Users/maximilien/.kn/config.yaml
Updating Service 'summary-fn' in namespace 'default':

  0.089s Ready to serve.

Service 'summary-fn' with latest revision 'summary-fn-nxqwb-41' (unchanged) is available at URL:
http://summary-fn-default.kndemo-267179.sjc03.containers.appdomain.cloud
```

This is a case when service is updated with tags and revision remained unchanged.

```bash
➜  client git:(master) ✗ ./kn service update summary-fn --image docker.io/drmax/summary-fn:latest
Using kn config file: /Users/maximilien/.kn/config.yaml
Updating Service 'summary-fn' in namespace 'default':

  0.091s The Configuration is still working to reflect the latest desired specification.
  6.317s Ready to serve.

Service 'summary-fn' updated to latest revision 'summary-fn-jfjcy-42' is available at URL:
http://summary-fn-default.kndemo-267179.sjc03.containers.appdomain.cloud
```

This is the case when service updated to new revision.

Release Note:

- 🧽 clarifies service update message
