### PR TITLE
chore(e2e): Update tektoncd pipeline release to v0.9.2

### DIFF
--- a/test/e2e/tekton_test.go
+++ b/test/e2e/tekton_test.go
@@ -50,7 +50,7 @@ func TestTektonPipeline(t *testing.T) {
 	_, err = kubectl.RunWithOpts([]string{"apply", "-n", test.env.Namespace, "-f", basedir + "/kn-deployer-rbac.yaml"}, runOpts{})
 	assert.NilError(t, err)
 
-	_, err = kubectl.RunWithOpts([]string{"apply", "-n", test.env.Namespace, "-f", "https://raw.githubusercontent.com/tektoncd/catalog/master/buildah/buildah.yaml"}, runOpts{})
+	_, err = kubectl.RunWithOpts([]string{"apply", "-n", test.env.Namespace, "-f", basedir + "/buildah.yaml"}, runOpts{})
 	assert.NilError(t, err)
 
 	_, err = kubectl.RunWithOpts([]string{"apply", "-n", test.env.Namespace, "-f", "https://raw.githubusercontent.com/tektoncd/catalog/master/kn/kn.yaml"}, runOpts{})

--- a/test/resources/tekton/buildah.yaml
+++ b/test/resources/tekton/buildah.yaml
@@ -1,0 +1,66 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Define a ServiceAccount named kn-deployer-account that has permission to
+# manage Knative services.
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: buildah
+spec:
+  inputs:
+    params:
+    - name: BUILDER_IMAGE
+      description: The location of the buildah builder image.
+      default: quay.io/buildah/stable:v1.11.0
+    - name: DOCKERFILE
+      description: Path to the Dockerfile to build.
+      default: ./Dockerfile
+    - name: TLSVERIFY
+      description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
+      default: "true"
+
+    resources:
+    - name: source
+      type: git
+
+  outputs:
+    resources:
+    - name: image
+      type: image
+
+  steps:
+  - name: build
+    image: $(inputs.params.BUILDER_IMAGE)
+    workingDir: /workspace/source
+    command: ['buildah', 'bud', '--format=docker', '--tls-verify=$(inputs.params.TLSVERIFY)', '--layers', '-f', '$(inputs.params.DOCKERFILE)', '-t', '$(outputs.resources.image.url)', '.']
+    volumeMounts:
+    - name: varlibcontainers
+      mountPath: /var/lib/containers
+    securityContext:
+      privileged: true
+
+  - name: push
+    image: $(inputs.params.BUILDER_IMAGE)
+    workingDir: /workspace/source
+    command: ['buildah', 'push', '--tls-verify=$(inputs.params.TLSVERIFY)', '$(outputs.resources.image.url)', 'docker://$(outputs.resources.image.url)']
+    volumeMounts:
+    - name: varlibcontainers
+      mountPath: /var/lib/containers
+    securityContext:
+      privileged: true
+
+  volumes:
+  - name: varlibcontainers
+    emptyDir: {}

--- a/test/resources/tekton/kn-pipeline-run.yaml
+++ b/test/resources/tekton/kn-pipeline-run.yaml
@@ -16,7 +16,7 @@ kind: PipelineRun
 metadata:
   generateName: buildah-build-kn-create-
 spec:
-  serviceAccount: kn-deployer-account
+  serviceAccountName: kn-deployer-account
   pipelineRef:
     name: buildah-build-kn-create
   resources:

--- a/test/resources/tekton/kn-pipeline.yaml
+++ b/test/resources/tekton/kn-pipeline.yaml
@@ -41,6 +41,8 @@ spec:
     params:
     - name: DOCKERFILE
       value: ./test/test_images/helloworld/Dockerfile
+    - name: BUILDER_IMAGE
+      value: "quay.io/buildah/stable:latest"
   - name: kn-service-create
     taskRef:
       name: kn

--- a/test/tekton-tests.sh
+++ b/test/tekton-tests.sh
@@ -28,7 +28,7 @@ export PATH=$PATH:${REPO_ROOT_DIR}
 # Script entry point.
 initialize $@
 
-export TEKTON_VERSION=${TEKTON_VERSION:-v0.8.0}
+export TEKTON_VERSION=${TEKTON_VERSION:-v0.9.2}
 export KN_E2E_NAMESPACE=tkn-kn
 
 header "Running integration tests for Tekton"

--- a/test/test_images/helloworld/Dockerfile
+++ b/test/test_images/helloworld/Dockerfile
@@ -1,23 +1,26 @@
-# Use the offical Golang image to create a build artifact.
+# Use the official Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.12 as builder
+FROM golang:1.13 as builder
+
+# Create and change to the app directory.
+WORKDIR /app
 
 # Copy local code to the container image.
-WORKDIR /go/src/knative.dev/client/test/test_images/helloworld
-COPY ./test/test_images/helloworld/helloworld.go .
+COPY ./test/test_images/helloworld/ .
 
-# Build the command inside the container.
-# (You may fetch or manage dependencies here,
-# either manually or with a tool like "godep".)
-RUN CGO_ENABLED=0 GOOS=linux go build -v -o helloworld
+# Build the binary.
+# -mod=readonly ensures immutable go.mod and go.sum in container builds.
+RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o server
 
-# Use a Docker multi-stage build to create a lean production image.
+# Use the official Alpine image for a lean production container.
+# https://hub.docker.com/_/alpine
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM scratch
+FROM alpine:3
+RUN apk add --no-cache ca-certificates
 
 # Copy the binary to the production image from the builder stage.
-COPY --from=builder /go/src/knative.dev/client/test/test_images/helloworld/helloworld /helloworld
+COPY --from=builder /app/server /server
 
 # Run the web service on container startup.
-CMD ["/helloworld"]
+CMD ["/server"]

--- a/test/test_images/helloworld/go.mod
+++ b/test/test_images/helloworld/go.mod
@@ -1,0 +1,3 @@
+module knative.dev/client/test/test_images/helloworld
+
+go 1.13

--- a/test/test_images/helloworld/helloworld.go
+++ b/test/test_images/helloworld/helloworld.go
@@ -22,7 +22,7 @@ import (
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {
-	log.Print("Hello world received a request.")
+	log.Print("helloworld: received a request")
 	target := os.Getenv("TARGET")
 	if target == "" {
 		target = "World"
@@ -31,7 +31,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	log.Print("Hello world sample started.")
+	log.Print("helloworld: starting server...")
 
 	http.HandleFunc("/", handler)
 
@@ -40,5 +40,6 @@ func main() {
 		port = "8080"
 	}
 
+	log.Printf("helloworld: listening on port %s", port)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), nil))
 }


### PR DESCRIPTION
Fixes #601

## Proposed Changes 
- Update tektoncd/pipeline setup to version to 0.9.2 for tekton e2e tests
- Also replace deprecated `serviceAccount` with `serviceAccountName`
- Sync helloworld test image code from https://github.com/knative/docs/tree/master/docs/serving/samples/hello-world/helloworld-go
- Use local version of buildah task instead of one from catalog, adding `--format=docker` in `buildah bud` command
  - to build and push the image to registry in docker format to match the manifestype `application/vnd.docker.distribution.manifest.v2+json`
  - Update pipeline to add parameter BUILDER_IMAGE and sets it to quay.io/buildah/stable:latest