### PR TITLE
Delete k8s resource if error happen at setup step

### DIFF
--- a/test/e2e/basic_workflow_test.go
+++ b/test/e2e/basic_workflow_test.go
@@ -28,8 +28,8 @@ import (
 func TestBasicWorkflow(t *testing.T) {
 	t.Parallel()
 	test := NewE2eTest(t)
-	test.Setup(t)
 	defer test.Teardown(t)
+	test.Setup(t)
 
 	t.Run("returns no service before running tests", func(t *testing.T) {
 		test.serviceListEmpty(t)

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -92,7 +92,7 @@ func (test *e2eTest) CreateTestNamespace(t *testing.T, namespace string) {
 	expectedOutputRegexp := fmt.Sprintf("namespace?.+%s.+created", namespace)
 	out, err := createNamespace(t, namespace, MaxRetries, logger)
 	if err != nil {
-		logger.Fatalf("Could not create namespace, giving up")
+		t.Fatalf("Could not create namespace, giving up\n")
 	}
 
 	// check that last output indeed show created namespace
@@ -159,12 +159,12 @@ func createNamespace(t *testing.T, namespace string, maxRetries int, logger Logg
 	)
 
 	for retries < maxRetries {
-		out, err := kubectlCreateNamespace()
+		out, err = kubectlCreateNamespace()
 		if err == nil {
 			return out, nil
 		}
 		retries++
-		logger.Debugf("Could not create namespace, waiting %ds, and trying again: %d of %d\n", int(RetrySleepDuration.Seconds()), retries, maxRetries)
+		logger.Debugf("Could not create namespace with error %v, waiting %ds, and trying again: %d of %d\n", err, int(RetrySleepDuration.Seconds()), retries, maxRetries)
 		time.Sleep(RetrySleepDuration)
 	}
 

--- a/test/e2e/revision_test.go
+++ b/test/e2e/revision_test.go
@@ -30,8 +30,8 @@ import (
 func TestRevision(t *testing.T) {
 	t.Parallel()
 	test := NewE2eTest(t)
-	test.Setup(t)
 	defer test.Teardown(t)
+	test.Setup(t)
 
 	t.Run("create hello service and return no error", func(t *testing.T) {
 		test.serviceCreate(t, "hello")

--- a/test/e2e/route_test.go
+++ b/test/e2e/route_test.go
@@ -29,8 +29,8 @@ import (
 func TestRoute(t *testing.T) {
 	t.Parallel()
 	test := NewE2eTest(t)
-	test.Setup(t)
 	defer test.Teardown(t)
+	test.Setup(t)
 
 	t.Run("create hello service and return no error", func(t *testing.T) {
 		test.serviceCreate(t, "hello")

--- a/test/e2e/service_options_test.go
+++ b/test/e2e/service_options_test.go
@@ -28,8 +28,8 @@ import (
 func TestServiceOptions(t *testing.T) {
 	t.Parallel()
 	test := NewE2eTest(t)
-	test.Setup(t)
 	defer test.Teardown(t)
+	test.Setup(t)
 
 	t.Run("create and validate service with concurrency options", func(t *testing.T) {
 		test.serviceCreateWithOptions(t, "svc1", []string{"--concurrency-limit", "250", "--concurrency-target", "300"})

--- a/test/e2e/service_test.go
+++ b/test/e2e/service_test.go
@@ -28,8 +28,8 @@ import (
 func TestService(t *testing.T) {
 	t.Parallel()
 	test := NewE2eTest(t)
-	test.Setup(t)
 	defer test.Teardown(t)
+	test.Setup(t)
 
 	t.Run("create hello service duplicate and get service already exists error", func(t *testing.T) {
 		test.serviceCreate(t, "hello")

--- a/test/e2e/source_list_types_test.go
+++ b/test/e2e/source_list_types_test.go
@@ -27,8 +27,8 @@ import (
 func TestSourceListTypes(t *testing.T) {
 	t.Parallel()
 	test := NewE2eTest(t)
-	test.Setup(t)
 	defer test.Teardown(t)
+	test.Setup(t)
 
 	t.Run("List available source types", func(t *testing.T) {
 		output := test.sourceListTypes(t)

--- a/test/e2e/tekton_test.go
+++ b/test/e2e/tekton_test.go
@@ -35,6 +35,7 @@ const (
 
 func TestTektonPipeline(t *testing.T) {
 	test := NewE2eTest(t)
+	defer test.Teardown(t)
 	test.Setup(t)
 
 	kubectl := kubectl{t, Logger{}}

--- a/test/e2e/traffic_split_test.go
+++ b/test/e2e/traffic_split_test.go
@@ -77,8 +77,8 @@ func formatActualTargets(t *testing.T, actualTargets []string) (formattedTargets
 func TestTrafficSplit(t *testing.T) {
 	t.Parallel()
 	test := NewE2eTest(t)
-	test.Setup(t)
 	defer test.Teardown(t)
+	test.Setup(t)
 
 	serviceBase := "echo"
 	t.Run("tag two revisions as v1 and v2 and give 50-50% share",


### PR DESCRIPTION
Fixes #576

## Proposed Changes

* Delete k8s cluster resource: `clusterrole`, `clusterrolebinding`.
* Adjust `defer` function position at Test case. The `defer` function can run, if `t.Fatalf` called in `Setup` function. Otherwise, the `defer` func will not run when  `t.Fatalf` called.

<!--
Release Note:

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:
- 🐛 Fix bug


See other entries in CHANGELOG.adoc as an example.

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->
