### PR TITLE
Delete k8s cluster resource in e2e test

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -92,7 +92,7 @@ func (test *e2eTest) CreateTestNamespace(t *testing.T, namespace string) {
 	expectedOutputRegexp := fmt.Sprintf("namespace?.+%s.+created", namespace)
 	out, err := createNamespace(t, namespace, MaxRetries, logger)
 	if err != nil {
-		logger.Fatalf("Could not create namespace, giving up")
+		logger.Fatalf("Could not create namespace with error %v, giving up\n", err)
 	}
 
 	// check that last output indeed show created namespace
@@ -159,12 +159,12 @@ func createNamespace(t *testing.T, namespace string, maxRetries int, logger Logg
 	)
 
 	for retries < maxRetries {
-		out, err := kubectlCreateNamespace()
+		out, err = kubectlCreateNamespace()
 		if err == nil {
 			return out, nil
 		}
 		retries++
-		logger.Debugf("Could not create namespace, waiting %ds, and trying again: %d of %d\n", int(RetrySleepDuration.Seconds()), retries, maxRetries)
+		logger.Debugf("Could not create namespace with error %v, waiting %ds, and trying again: %d of %d\n", err, int(RetrySleepDuration.Seconds()), retries, maxRetries)
 		time.Sleep(RetrySleepDuration)
 	}
 

--- a/test/e2e/source_apiserver_test.go
+++ b/test/e2e/source_apiserver_test.go
@@ -29,7 +29,10 @@ func TestSourceApiServer(t *testing.T) {
 	t.Parallel()
 	test := NewE2eTest(t)
 	test.Setup(t)
-	defer test.Teardown(t)
+	defer func() {
+		test.deleteServiceAccountForApiserver(t, "testsa")
+		test.Teardown(t)
+	}()
 
 	test.setupServiceAccountForApiserver(t, "testsa")
 	test.serviceCreate(t, "testsvc0")
@@ -88,11 +91,28 @@ func (test *e2eTest) setupServiceAccountForApiserver(t *testing.T, name string) 
 	}
 	_, err = kubectl.RunWithOpts([]string{"create", "clusterrole", "testsa-role", "--verb=get,list,watch", "--resource=events,namespaces"}, runOpts{})
 	if err != nil {
-		t.Fatalf(fmt.Sprintf("Error executing 'kubectl clusterrole testsa-role'. Error: %s", err.Error()))
+		t.Fatalf(fmt.Sprintf("Error executing 'kubectl create clusterrole testsa-role'. Error: %s", err.Error()))
 	}
 	_, err = kubectl.RunWithOpts([]string{"create", "clusterrolebinding", "testsa-binding", "--clusterrole=testsa-role", "--serviceaccount=" + test.kn.namespace + ":" + name}, runOpts{})
 	if err != nil {
-		t.Fatalf(fmt.Sprintf("Error executing 'kubectl clusterrolebinding testsa-binding'. Error: %s", err.Error()))
+		t.Fatalf(fmt.Sprintf("Error executing 'kubectl create clusterrolebinding testsa-binding'. Error: %s", err.Error()))
+	}
+}
+
+func (test *e2eTest) deleteServiceAccountForApiserver(t *testing.T, name string) {
+	kubectl := kubectl{t, Logger{}}
+
+	_, err := kubectl.RunWithOpts([]string{"delete", "serviceaccount", name, "--namespace", test.kn.namespace}, runOpts{})
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("Error executing 'kubectl delete serviceaccount test-sa'. Error: %s", err.Error()))
+	}
+	_, err = kubectl.RunWithOpts([]string{"delete", "clusterrole", "testsa-role"}, runOpts{})
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("Error executing 'kubectl delete clusterrole testsa-role'. Error: %s", err.Error()))
+	}
+	_, err = kubectl.RunWithOpts([]string{"delete", "clusterrolebinding", "testsa-binding"}, runOpts{})
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("Error executing 'kubectl delete clusterrolebinding testsa-binding'. Error: %s", err.Error()))
 	}
 }
 

--- a/test/e2e/tekton_test.go
+++ b/test/e2e/tekton_test.go
@@ -35,6 +35,7 @@ const (
 
 func TestTektonPipeline(t *testing.T) {
 	test := NewE2eTest(t)
+	defer test.Teardown(t)
 	test.Setup(t)
 
 	kubectl := kubectl{t, Logger{}}


### PR DESCRIPTION
Fixes #576

## Proposed Changes

* Delete k8s cluster resource: `clusterrole`, `clusterrolebinding` after e2e test finish.

<!--
Release Note:

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🐛 Fix bug


See other entries in CHANGELOG.adoc as an example.

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->
