### PR TITLE
Remove redundant cleanup in Tekton tests

### DIFF
--- a/test/e2e/tekton_test.go
+++ b/test/e2e/tekton_test.go
@@ -35,7 +35,6 @@ const (
 
 func TestTektonPipeline(t *testing.T) {
 	test := NewE2eTest(t)
-	defer test.Teardown(t)
 	test.Setup(t)
 
 	kubectl := kubectl{t, Logger{}}


### PR DESCRIPTION
* tear down only if the test passes, we want to keep the pods otherwise
so that the dump will show their errors

Currently, the teardown happens twice and the tests fail because the second teardown cannot find the namespace.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

*
*
*

<!--
Release Note:

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behaviour
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example.

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->
