### PR TITLE
Remove Printing Err When Running Root Command

### DIFF
--- a/cmd/kn/main.go
+++ b/cmd/kn/main.go
@@ -35,7 +35,9 @@ func main() {
 	rand.Seed(time.Now().UnixNano())
 	err = core.NewDefaultKnCommand().Execute()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		if err.Error() != "subcommand is required" {
+			fmt.Fprintln(os.Stderr, err)
+		}
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Fixes #612

## Proposed Changes

* Remove printing err when running `kn` root command

### Release

`Fix subcommand is required error from showing when running kn by itself`
