### PR TITLE
Show envFrom when running describe service or revision

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,16 @@
 ////
 
 
+## v0.13.0 (unreleased)
+
+[cols="1,10,3", options="header", width="100%"]
+|===
+| | Description | PR
+
+| 🐛
+| Show envFrom when running describe service or revision
+| https://github.com/knative/client/pull/630
+
 ## v0.12.0 (2020-01-29)
 
 [cols="1,10,3", options="header", width="100%"]

--- a/pkg/kn/commands/revision/describe_test.go
+++ b/pkg/kn/commands/revision/describe_test.go
@@ -124,6 +124,7 @@ func TestDescribeRevisionBasic(t *testing.T) {
 	}
 
 	assert.Assert(t, util.ContainsAll(data, "Image:", "gcr.io/test/image", "++ Ready", "Port:", "8080"))
+	assert.Assert(t, util.ContainsAll(data, "EnvFrom:", "cm:test1, cm:test2"))
 }
 
 func createTestRevision(revision string, gen int64) v1alpha1.Revision {
@@ -152,6 +153,10 @@ func createTestRevision(revision string, gen int64) v1alpha1.Revision {
 							Env: []v1.EnvVar{
 								{Name: "env1", Value: "eval1"},
 								{Name: "env2", Value: "eval2"},
+							},
+							EnvFrom: []v1.EnvFromSource{
+								{ConfigMapRef: &v1.ConfigMapEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: "test1"}}},
+								{ConfigMapRef: &v1.ConfigMapEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: "test2"}}},
 							},
 							Ports: []v1.ContainerPort{
 								{ContainerPort: 8080},

--- a/pkg/kn/commands/service/describe.go
+++ b/pkg/kn/commands/service/describe.go
@@ -201,6 +201,7 @@ func writeRevisions(dw printers.PrefixWriter, revisions []*revisionDesc, printDe
 		if printDetails {
 			revision.WritePort(section, revisionDesc.revision)
 			revision.WriteEnv(section, revisionDesc.revision, printDetails)
+			revision.WriteEnvFrom(section, revisionDesc.revision, printDetails)
 			revision.WriteScale(section, revisionDesc.revision)
 			revision.WriteConcurrencyOptions(section, revisionDesc.revision)
 			revision.WriteResources(section, revisionDesc.revision)

--- a/pkg/kn/commands/service/describe_test.go
+++ b/pkg/kn/commands/service/describe_test.go
@@ -455,7 +455,8 @@ func TestServiceDescribeVerbose(t *testing.T) {
 
 	assert.Assert(t, cmp.Regexp("Cluster:\\s+http://foo.default.svc.cluster.local", output))
 	assert.Assert(t, util.ContainsAll(output, "Image", "Name", "gcr.io/test/image (at 123456)", "50%", "(0s)"))
-	assert.Assert(t, util.ContainsAll(output, "Env:", "label1=lval1\n", "label2=lval2\n"))
+	assert.Assert(t, util.ContainsAll(output, "Env:", "env1=eval1\n", "env2=eval2\n"))
+	assert.Assert(t, util.ContainsAll(output, "EnvFrom:", "cm:test1\n", "cm:test2\n"))
 	assert.Assert(t, util.ContainsAll(output, "Annotations:", "anno1=aval1\n", "anno2=aval2\n"))
 	assert.Assert(t, util.ContainsAll(output, "Labels:", "label1=lval1\n", "label2=lval2\n"))
 	assert.Assert(t, util.ContainsAll(output, "[1]", "[2]"))
@@ -635,6 +636,10 @@ func createTestRevision(revision string, gen int64) v1alpha1.Revision {
 							Env: []v1.EnvVar{
 								{Name: "env1", Value: "eval1"},
 								{Name: "env2", Value: "eval2"},
+							},
+							EnvFrom: []v1.EnvFromSource{
+								{ConfigMapRef: &v1.ConfigMapEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: "test1"}}},
+								{ConfigMapRef: &v1.ConfigMapEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: "test2"}}},
 							},
 							Ports: []v1.ContainerPort{
 								{ContainerPort: 8080},


### PR DESCRIPTION
Fixes #626

## Proposed Changes

* Show envFrom when running describe revison. The result like:
`EnvFrom:    ConfigMap:(testConfig), Secret:(testSecret)`

Release Note:
- 🐛 Fix bug #626 by showing envFrom when running describe revision.