### PR TITLE
Add E2E test for "kn source binding" commands

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,7 +22,11 @@
 
 | 🐛
 | Show envFrom when running describe service or revision
-| https://github.com/knative/client/pull/630
+| https://github.com/knative/client/pull/630[#630]
+
+| 🎁
+| Add E2E test for `kn source binding` commands
+| https://github.com/knative/client/pull/634[#634]
 
 ## v0.12.0 (2020-01-29)
 

--- a/docs/cmd/kn_source_binding_create.md
+++ b/docs/cmd/kn_source_binding_create.md
@@ -15,7 +15,7 @@ kn source binding create NAME --subject SCHEDULE --sink SINK --ce-override KEY=V
 ```
 
   # Create a sink binding which connects a deployment 'myapp' with a Knative service 'mysvc'
-  kn source binding create my-binding --subject Deployemnt:apps/v1:myapp --sink svc:mysvc
+  kn source binding create my-binding --subject Deployment:apps/v1:myapp --sink svc:mysvc
 ```
 
 ### Options

--- a/pkg/kn/commands/source/binding/create.go
+++ b/pkg/kn/commands/source/binding/create.go
@@ -35,7 +35,7 @@ func NewBindingCreateCommand(p *commands.KnParams) *cobra.Command {
 		Short: "Create a sink binding.",
 		Example: `
   # Create a sink binding which connects a deployment 'myapp' with a Knative service 'mysvc'
-  kn source binding create my-binding --subject Deployemnt:apps/v1:myapp --sink svc:mysvc`,
+  kn source binding create my-binding --subject Deployment:apps/v1:myapp --sink svc:mysvc`,
 
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {

--- a/test/e2e/source_binding_test.go
+++ b/test/e2e/source_binding_test.go
@@ -1,0 +1,73 @@
+// Copyright 2020 The Knative Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or im
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build e2e
+// +build !serving
+
+package e2e
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+	"knative.dev/client/pkg/util"
+)
+
+func TestSourceBinding(t *testing.T) {
+	t.Parallel()
+	test := NewE2eTest(t)
+	test.Setup(t)
+	defer test.Teardown(t)
+
+	test.serviceCreate(t, "testsvc0")
+
+	t.Run("create source binding", func(t *testing.T) {
+		test.sourceBindingCreate(t, "my-binding0", "Deployment:apps/v1:myapp", "svc:testsvc0")
+	})
+
+	t.Run("delete source binding", func(t *testing.T) {
+		test.sourceBindingDelete(t, "my-binding0")
+	})
+
+	t.Run("update source binding", func(t *testing.T) {
+		test.sourceBindingCreate(t, "my-binding1", "Deployment:apps/v1:myapp", "svc:testsvc0")
+		test.serviceCreate(t, "testsvc1")
+		test.sourceBindingUpdate(t, "my-binding1", "Deployment:apps/v1:myapp", "svc:testsvc1")
+		jpSinkRefNameInSpec := "jsonpath={.spec.sink.ref.name}"
+		out, err := test.getResourceFieldsWithJSONPath(t, "sinkbindings.sources.knative.dev", "my-binding1", jpSinkRefNameInSpec)
+		assert.NilError(t, err)
+		assert.Equal(t, out, "testsvc1")
+	})
+
+}
+
+func (test *e2eTest) sourceBindingCreate(t *testing.T, bindingName string, subject string, sink string) {
+	out, err := test.kn.RunWithOpts([]string{"source", "binding", "create", bindingName,
+		"--subject", subject, "--sink", sink}, runOpts{NoNamespace: false})
+	assert.NilError(t, err)
+	assert.Check(t, util.ContainsAllIgnoreCase(out, "Sink", "binding", bindingName, "created", "namespace", test.kn.namespace))
+}
+
+func (test *e2eTest) sourceBindingDelete(t *testing.T, bindingName string) {
+	out, err := test.kn.RunWithOpts([]string{"source", "binding", "delete", bindingName}, runOpts{NoNamespace: false})
+	assert.NilError(t, err)
+	assert.Check(t, util.ContainsAllIgnoreCase(out, "Sink", "binding", bindingName, "deleted", "namespace", test.kn.namespace))
+}
+
+func (test *e2eTest) sourceBindingUpdate(t *testing.T, bindingName string, subject string, sink string) {
+	out, err := test.kn.RunWithOpts([]string{"source", "binding", "update", bindingName,
+		"--subject", subject, "--sink", sink}, runOpts{})
+	assert.NilError(t, err)
+	assert.Check(t, util.ContainsAll(out, bindingName, "updated", "namespace", test.kn.namespace))
+}


### PR DESCRIPTION
Fixes #631

## Proposed Changes
* Add E2E test for "kn source binding" commands.
* Fix typo.

Release Note:
- 🎁 Add new feature
Add E2E test for "kn source binding" commands.

