### PR TITLE
Rename --async to --no-wait and deprecate it

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -28,6 +28,10 @@
 | Add `--cmd` and `--arg` for customization of container entrypoint
 | https://github.com/knative/client/pull/635[#635]
 
+| 🧽
+| Add `no-wait` instead of `--async` and deprecate it
+https://github.com/knative/client/pull/639[#639]
+
 ## v0.12.0 (2020-01-29)
 
 [cols="1,10,3", options="header", width="100%"]

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -44,7 +44,7 @@ kn service create NAME --image IMAGE [flags]
 ```
       --annotation stringArray    Service annotation to set. name=value; you may provide this flag any number of times to set multiple annotations. To unset, specify the annotation name followed by a "-" (e.g., name-).
       --arg stringArray           Add argument to the container command. Example: --arg myArg1 --arg --myArg2 --arg myArg3=3. You can use this flag multiple times.
-      --async                     Create service and don't wait for it to become ready.
+      --async                     DEPRECATED: please use --no-wait instead. Create service and don't wait for it to become ready.
       --autoscale-window string   Duration to look back for making auto-scaling decisions. The service is scaled to zero if no request was received in during that time. (eg: 10s)
       --cmd string                Specify command to be used as entrypoint instead of default one. Example: --cmd /app/start or --cmd /app/start --arg myArg to pass aditional arguments.
       --concurrency-limit int     Hard Limit of concurrent requests to be processed by a single replica.
@@ -63,6 +63,7 @@ kn service create NAME --image IMAGE [flags]
       --mount stringArray         Mount a ConfigMap (prefix cm: or config-map:), a Secret (prefix secret: or sc:), or an existing Volume (without any prefix) on the specified directory. Example: --mount /mydir=cm:myconfigmap, --mount /mydir=secret:mysecret, or --mount /mydir=myvolume. When a configmap or a secret is specified, a corresponding volume is automatically generated. You can use this flag multiple times. For unmounting a directory, append "-", e.g. --mount /mydir-, which also removes any auto-generated volume.
   -n, --namespace string          Specify the namespace to operate in.
       --no-lock-to-digest         do not keep the running image for the service constant when not explicitly specifying the image. (--no-lock-to-digest pulls the image tag afresh with each new revision)
+      --no-wait                   Create service and don't wait for it to become ready.
   -p, --port int32                The port where application listens on.
       --pull-secret string        Image pull secret to set. An empty argument ("") clears the pull secret. The referenced secret must exist in the service's namespace.
       --requests-cpu string       The requested CPU (e.g., 250m).

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -40,7 +40,7 @@ kn service update NAME [flags]
 ```
       --annotation stringArray    Service annotation to set. name=value; you may provide this flag any number of times to set multiple annotations. To unset, specify the annotation name followed by a "-" (e.g., name-).
       --arg stringArray           Add argument to the container command. Example: --arg myArg1 --arg --myArg2 --arg myArg3=3. You can use this flag multiple times.
-      --async                     Update service and don't wait for it to become ready.
+      --async                     DEPRECATED: please use --no-wait instead. Update service and don't wait for it to become ready.
       --autoscale-window string   Duration to look back for making auto-scaling decisions. The service is scaled to zero if no request was received in during that time. (eg: 10s)
       --cmd string                Specify command to be used as entrypoint instead of default one. Example: --cmd /app/start or --cmd /app/start --arg myArg to pass aditional arguments.
       --concurrency-limit int     Hard Limit of concurrent requests to be processed by a single replica.
@@ -58,6 +58,7 @@ kn service update NAME [flags]
       --mount stringArray         Mount a ConfigMap (prefix cm: or config-map:), a Secret (prefix secret: or sc:), or an existing Volume (without any prefix) on the specified directory. Example: --mount /mydir=cm:myconfigmap, --mount /mydir=secret:mysecret, or --mount /mydir=myvolume. When a configmap or a secret is specified, a corresponding volume is automatically generated. You can use this flag multiple times. For unmounting a directory, append "-", e.g. --mount /mydir-, which also removes any auto-generated volume.
   -n, --namespace string          Specify the namespace to operate in.
       --no-lock-to-digest         do not keep the running image for the service constant when not explicitly specifying the image. (--no-lock-to-digest pulls the image tag afresh with each new revision)
+      --no-wait                   Update service and don't wait for it to become ready.
   -p, --port int32                The port where application listens on.
       --pull-secret string        Image pull secret to set. An empty argument ("") clears the pull secret. The referenced secret must exist in the service's namespace.
       --requests-cpu string       The requested CPU (e.g., 250m).

--- a/pkg/kn/commands/service/create.go
+++ b/pkg/kn/commands/service/create.go
@@ -138,7 +138,7 @@ func replaceService(client clientservingv1.KnServingClient, service *servingv1.S
 func waitIfRequested(client clientservingv1.KnServingClient, service *servingv1.Service, waitFlags commands.WaitFlags, verbDoing string, verbDone string, out io.Writer) error {
 	//TODO: deprecated condition should be removed with --async flag
 	if waitFlags.Async {
-		fmt.Fprintf(out, "\nDEPRECATED WARNING: flag --async is going to be removed in future release, please use --no-wait instead.\n\n")
+		fmt.Fprintf(out, "\nWARNING: flag --async is deprecated and going to be removed in future release, please use --no-wait instead.\n\n")
 		fmt.Fprintf(out, "Service '%s' %s in namespace '%s'.\n", service.Name, verbDone, client.Namespace())
 		return nil
 	}

--- a/pkg/kn/commands/service/create.go
+++ b/pkg/kn/commands/service/create.go
@@ -136,7 +136,13 @@ func replaceService(client clientservingv1.KnServingClient, service *servingv1.S
 }
 
 func waitIfRequested(client clientservingv1.KnServingClient, service *servingv1.Service, waitFlags commands.WaitFlags, verbDoing string, verbDone string, out io.Writer) error {
+	//TODO: deprecated condition should be removed with --async flag
 	if waitFlags.Async {
+		fmt.Fprintf(out, "\nDEPRECATED WARNING: flag --async is going to be removed in future release, please use --no-wait instead.\n\n")
+		fmt.Fprintf(out, "Service '%s' %s in namespace '%s'.\n", service.Name, verbDone, client.Namespace())
+		return nil
+	}
+	if waitFlags.NoWait {
 		fmt.Fprintf(out, "Service '%s' %s in namespace '%s'.\n", service.Name, verbDone, client.Namespace())
 		return nil
 	}

--- a/pkg/kn/commands/service/create_mock_test.go
+++ b/pkg/kn/commands/service/create_mock_test.go
@@ -77,7 +77,7 @@ func TestServiceCreateEnvMock(t *testing.T) {
 	template.Annotations = map[string]string{servinglib.UserImageAnnotationKey: "gcr.io/foo/bar:baz"}
 	r.CreateService(service, nil)
 
-	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz", "-e", "a=mouse", "--env", "b=cookie", "--env=empty", "--async", "--revision-name=")
+	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz", "-e", "a=mouse", "--env", "b=cookie", "--env=empty", "--no-wait", "--revision-name=")
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", "foo", "default"))
 
@@ -105,7 +105,7 @@ func TestServiceCreateLabel(t *testing.T) {
 	template.Spec.Containers[0].Image = "gcr.io/foo/bar:baz"
 	r.CreateService(service, nil)
 
-	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz", "-l", "a=mouse", "--label", "b=cookie", "--label=empty", "--async", "--revision-name=")
+	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz", "-l", "a=mouse", "--label", "b=cookie", "--label=empty", "--no-wait", "--revision-name=")
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", "foo", "default"))
 
@@ -133,7 +133,7 @@ func TestServiceCreateWithEnvFromConfigMap(t *testing.T) {
 	template.Annotations = map[string]string{servinglib.UserImageAnnotationKey: "gcr.io/foo/bar:baz"}
 	r.CreateService(service, nil)
 
-	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz", "--env-from", "config-map:config-map-name", "--async", "--revision-name=")
+	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz", "--env-from", "config-map:config-map-name", "--no-wait", "--revision-name=")
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", "foo", "default"))
 
@@ -153,7 +153,7 @@ func TestServiceCreateWithEnvFromConfigMapRemoval(t *testing.T) {
 	template.Annotations = map[string]string{servinglib.UserImageAnnotationKey: "gcr.io/foo/bar:baz"}
 	r.CreateService(service, nil)
 
-	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz", "--env-from", "config-map:config-map-name-", "--async", "--revision-name=")
+	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz", "--env-from", "config-map:config-map-name-", "--no-wait", "--revision-name=")
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", "foo", "default"))
 
@@ -173,7 +173,7 @@ func TestServiceCreateWithEnvFromEmptyRemoval(t *testing.T) {
 	template.Annotations = map[string]string{servinglib.UserImageAnnotationKey: "gcr.io/foo/bar:baz"}
 	r.CreateService(service, nil)
 
-	_, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz", "--env-from", "-", "--async", "--revision-name=")
+	_, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz", "--env-from", "-", "--no-wait", "--revision-name=")
 	assert.Error(t, err, "\"-\" is not a valid value for \"--env-from\"")
 }
 
@@ -198,7 +198,7 @@ func TestServiceCreateWithEnvFromSecret(t *testing.T) {
 	template.Annotations = map[string]string{servinglib.UserImageAnnotationKey: "gcr.io/foo/bar:baz"}
 	r.CreateService(service, nil)
 
-	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz", "--env-from", "secret:secret-name", "--async", "--revision-name=")
+	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz", "--env-from", "secret:secret-name", "--no-wait", "--revision-name=")
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", "foo", "default"))
 
@@ -218,7 +218,7 @@ func TestServiceCreateWithEnvFromSecretRemoval(t *testing.T) {
 	template.Annotations = map[string]string{servinglib.UserImageAnnotationKey: "gcr.io/foo/bar:baz"}
 	r.CreateService(service, nil)
 
-	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz", "--env-from", "secret:secret-name-", "--async", "--revision-name=")
+	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz", "--env-from", "secret:secret-name-", "--no-wait", "--revision-name=")
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", "foo", "default"))
 
@@ -259,7 +259,7 @@ func TestServiceCreateWithVolumeAndMountConfigMap(t *testing.T) {
 	r.CreateService(service, nil)
 
 	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz",
-		"--mount", "/mount/path=volume-name", "--volume", "volume-name=cm:config-map-name", "--async", "--revision-name=")
+		"--mount", "/mount/path=volume-name", "--volume", "volume-name=cm:config-map-name", "--no-wait", "--revision-name=")
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", "foo", "default"))
 
@@ -300,7 +300,7 @@ func TestServiceCreateWithMountConfigMap(t *testing.T) {
 	r.CreateService(service, nil)
 
 	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz",
-		"--mount", "/mount/path=cm:config-map-name", "--async", "--revision-name=")
+		"--mount", "/mount/path=cm:config-map-name", "--no-wait", "--revision-name=")
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", "foo", "default"))
 
@@ -339,7 +339,7 @@ func TestServiceCreateWithVolumeAndMountSecret(t *testing.T) {
 	r.CreateService(service, nil)
 
 	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz",
-		"--mount", "/mount/path=volume-name", "--volume", "volume-name=secret:secret-name", "--async", "--revision-name=")
+		"--mount", "/mount/path=volume-name", "--volume", "volume-name=secret:secret-name", "--no-wait", "--revision-name=")
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", "foo", "default"))
 
@@ -378,7 +378,7 @@ func TestServiceCreateWithMountSecret(t *testing.T) {
 	r.CreateService(service, nil)
 
 	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz",
-		"--mount", "/mount/path=sc:secret-name", "--async", "--revision-name=")
+		"--mount", "/mount/path=sc:secret-name", "--no-wait", "--revision-name=")
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", "foo", "default"))
 

--- a/pkg/kn/commands/service/create_test.go
+++ b/pkg/kn/commands/service/create_test.go
@@ -117,7 +117,7 @@ func getServiceEvents(name string) []watch.Event {
 
 func TestServiceCreateImage(t *testing.T) {
 	action, created, output, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--async"}, false, false)
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--no-wait"}, false, false)
 	if err != nil {
 		t.Fatal(err)
 	} else if !action.Matches("create", "services") {
@@ -160,7 +160,7 @@ func TestServiceCreateImageSync(t *testing.T) {
 
 func TestServiceCreateCommand(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--cmd", "/app/start", "--async"}, false, false)
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--cmd", "/app/start", "--no-wait"}, false, false)
 	assert.NilError(t, err)
 	assert.Assert(t, action.Matches("create", "services"))
 
@@ -171,7 +171,7 @@ func TestServiceCreateCommand(t *testing.T) {
 
 func TestServiceCreateArg(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--arg", "myArg1", "--arg", "--myArg2", "--arg", "--myArg3=3", "--async"}, false, false)
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--arg", "myArg1", "--arg", "--myArg2", "--arg", "--myArg3=3", "--no-wait"}, false, false)
 	assert.NilError(t, err)
 	assert.Assert(t, action.Matches("create", "services"))
 
@@ -184,7 +184,7 @@ func TestServiceCreateArg(t *testing.T) {
 
 func TestServiceCreateEnv(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "-e", "A=DOGS", "--env", "B=WOLVES", "--env=EMPTY", "--async"}, false, false)
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "-e", "A=DOGS", "--env", "B=WOLVES", "--env=EMPTY", "--no-wait"}, false, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -220,7 +220,7 @@ func TestServiceCreateEnv(t *testing.T) {
 
 func TestServiceCreateWithRequests(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--requests-cpu", "250m", "--requests-memory", "64Mi", "--async"}, false, false)
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--requests-cpu", "250m", "--requests-memory", "64Mi", "--no-wait"}, false, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -246,7 +246,7 @@ func TestServiceCreateWithRequests(t *testing.T) {
 
 func TestServiceCreateWithLimits(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--limits-cpu", "1000m", "--limits-memory", "1024Mi", "--async"}, false, false)
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--limits-cpu", "1000m", "--limits-memory", "1024Mi", "--no-wait"}, false, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -272,7 +272,7 @@ func TestServiceCreateWithLimits(t *testing.T) {
 
 func TestServiceCreateRequestsLimitsCPU(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--requests-cpu", "250m", "--limits-cpu", "1000m", "--async"}, false, false)
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--requests-cpu", "250m", "--limits-cpu", "1000m", "--no-wait"}, false, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -309,7 +309,7 @@ func TestServiceCreateRequestsLimitsCPU(t *testing.T) {
 
 func TestServiceCreateRequestsLimitsMemory(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--requests-memory", "64Mi", "--limits-memory", "1024Mi", "--async"}, false, false)
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--requests-memory", "64Mi", "--limits-memory", "1024Mi", "--no-wait"}, false, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -347,7 +347,7 @@ func TestServiceCreateRequestsLimitsMemory(t *testing.T) {
 func TestServiceCreateMaxMinScale(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
 		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
-		"--min-scale", "1", "--max-scale", "5", "--concurrency-target", "10", "--concurrency-limit", "100", "--async"}, false, false)
+		"--min-scale", "1", "--max-scale", "5", "--concurrency-target", "10", "--concurrency-limit", "100", "--no-wait"}, false, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -384,7 +384,7 @@ func TestServiceCreateRequestsLimitsCPUMemory(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
 		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
 		"--requests-cpu", "250m", "--limits-cpu", "1000m",
-		"--requests-memory", "64Mi", "--limits-memory", "1024Mi", "--async"}, false, false)
+		"--requests-memory", "64Mi", "--limits-memory", "1024Mi", "--no-wait"}, false, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -431,7 +431,7 @@ func parseQuantity(t *testing.T, quantityString string) resource.Quantity {
 
 func TestServiceCreateImageExistsAndNoForce(t *testing.T) {
 	_, _, output, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:v2", "--async"}, true, false)
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:v2", "--no-wait"}, true, false)
 	if err == nil {
 		t.Fatal(err)
 	}
@@ -446,7 +446,7 @@ func TestServiceCreateImageExistsAndNoForce(t *testing.T) {
 
 func TestServiceCreateImageForce(t *testing.T) {
 	action, created, output, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--force", "--image", "gcr.io/foo/bar:v2", "--async"}, true, false)
+		"service", "create", "foo", "--force", "--image", "gcr.io/foo/bar:v2", "--no-wait"}, true, false)
 	if err != nil {
 		t.Fatal(err)
 	} else if !action.Matches("update", "services") {
@@ -464,12 +464,12 @@ func TestServiceCreateImageForce(t *testing.T) {
 
 func TestServiceCreateEnvForce(t *testing.T) {
 	_, _, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:v1", "-e", "A=DOGS", "--env", "B=WOLVES", "--async"}, false, false)
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:v1", "-e", "A=DOGS", "--env", "B=WOLVES", "--no-wait"}, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	action, created, output, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--force", "--image", "gcr.io/foo/bar:v2", "-e", "A=CATS", "--env", "B=LIONS", "--async"}, false, false)
+		"service", "create", "foo", "--force", "--image", "gcr.io/foo/bar:v2", "-e", "A=CATS", "--env", "B=LIONS", "--no-wait"}, false, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -503,7 +503,7 @@ func TestServiceCreateWithServiceAccountName(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
 		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
 		"--service-account", "foo-bar-account",
-		"--async"}, false, false)
+		"--no-wait"}, false, false)
 
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/kn/commands/service/service_update_mock_test.go
+++ b/pkg/kn/commands/service/service_update_mock_test.go
@@ -57,11 +57,11 @@ func TestServiceUpdateEnvMock(t *testing.T) {
 	r.GetService("foo", service, nil)
 	r.UpdateService(updated, nil)
 
-	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz", "-e", "a=mouse", "--env", "b=cookie", "--env=empty", "--async", "--revision-name=")
+	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz", "-e", "a=mouse", "--env", "b=cookie", "--env=empty", "--no-wait", "--revision-name=")
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", "foo", "default"))
 
-	output, err = executeServiceCommand(client, "update", "foo", "-e", "a=rabbit", "--env=empty-", "--async", "--revision-name=")
+	output, err = executeServiceCommand(client, "update", "foo", "-e", "a=rabbit", "--env=empty-", "--no-wait", "--revision-name=")
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "updated", "foo", "default"))
 
@@ -110,7 +110,7 @@ func TestServiceUpdateAnnotationsMock(t *testing.T) {
 		"--annotation", "an1=staysConstant",
 		"--annotation", "an2=getsUpdated",
 		"--annotation", "an3=getsRemoved",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", svcName, "default"))
@@ -119,7 +119,7 @@ func TestServiceUpdateAnnotationsMock(t *testing.T) {
 		"update", svcName,
 		"--annotation", "an2=isUpdated",
 		"--annotation", "an3-",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "updated", svcName, "default"))
@@ -178,7 +178,7 @@ func TestServiceUpdateEnvFromAddingWithConfigMap(t *testing.T) {
 	output, err := executeServiceCommand(client,
 		"create", svcName, "--image", "gcr.io/foo/bar:baz",
 		"--env-from", "config-map:existing-name",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", svcName, "default"))
@@ -186,7 +186,7 @@ func TestServiceUpdateEnvFromAddingWithConfigMap(t *testing.T) {
 	output, err = executeServiceCommand(client,
 		"update", svcName,
 		"--env-from", "config-map:new-name",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "updated", svcName, "default"))
@@ -290,7 +290,7 @@ func TestServiceUpdateEnvFromRemovalWithConfigMap(t *testing.T) {
 		"--env-from", "config-map:existing-name-2",
 		"--env-from", "cm:existing-name-3",
 		"--env-from", "config-map:existing-name-4",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", svcName, "default"))
@@ -300,7 +300,7 @@ func TestServiceUpdateEnvFromRemovalWithConfigMap(t *testing.T) {
 		"--env-from", "config-map:existing-name-1-",
 		"--env-from", "cm:existing-name-2-",
 		"--env-from", "config-map:existing-name-3-",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "updated", svcName, "default"))
@@ -309,14 +309,14 @@ func TestServiceUpdateEnvFromRemovalWithConfigMap(t *testing.T) {
 	output, err = executeServiceCommand(client,
 		"update", svcName,
 		"--env-from", "config-map:-",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.Error(t, err, "the name of config-map cannot be an empty string")
 
 	output, err = executeServiceCommand(client,
 		"update", svcName,
 		"--env-from", "cm:existing-name-4-",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "updated", svcName, "default"))
@@ -376,7 +376,7 @@ func TestServiceUpdateEnvFromRemovalWithEmptyName(t *testing.T) {
 	output, err := executeServiceCommand(client,
 		"create", svcName, "--image", "gcr.io/foo/bar:baz",
 		"--env-from", "config-map:existing-name-1",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", svcName, "default"))
@@ -384,14 +384,14 @@ func TestServiceUpdateEnvFromRemovalWithEmptyName(t *testing.T) {
 	_, err = executeServiceCommand(client,
 		"update", svcName,
 		"--env-from", "-",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.Error(t, err, "\"-\" is not a valid value for \"--env-from\"")
 
 	output, err = executeServiceCommand(client,
 		"update", svcName,
 		"--env-from", "config-map:existing-name-2",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "updated", svcName, "default"))
@@ -463,7 +463,7 @@ func TestServiceUpdateEnvFromExistingWithConfigMap(t *testing.T) {
 		"create", svcName, "--image", "gcr.io/foo/bar:baz",
 		"--env-from", "config-map:existing-name-1",
 		"--env-from", "config-map:existing-name-2",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", svcName, "default"))
@@ -472,7 +472,7 @@ func TestServiceUpdateEnvFromExistingWithConfigMap(t *testing.T) {
 		"update", svcName,
 		"--env-from", "config-map:existing-name-1",
 		"--env-from", "config-map:new-name",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "updated", svcName, "default"))
@@ -531,7 +531,7 @@ func TestServiceUpdateEnvFromAddingWithSecret(t *testing.T) {
 	output, err := executeServiceCommand(client,
 		"create", svcName, "--image", "gcr.io/foo/bar:baz",
 		"--env-from", "secret:existing-name",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", svcName, "default"))
@@ -539,7 +539,7 @@ func TestServiceUpdateEnvFromAddingWithSecret(t *testing.T) {
 	output, err = executeServiceCommand(client,
 		"update", svcName,
 		"--env-from", "sc:new-name",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "updated", svcName, "default"))
@@ -642,7 +642,7 @@ func TestServiceUpdateEnvFromRemovalWithSecret(t *testing.T) {
 		"--env-from", "secret:existing-name-2",
 		"--env-from", "sc:existing-name-3",
 		"--env-from", "secret:existing-name-4",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", svcName, "default"))
@@ -652,7 +652,7 @@ func TestServiceUpdateEnvFromRemovalWithSecret(t *testing.T) {
 		"--env-from", "secret:existing-name-1-",
 		"--env-from", "sc:existing-name-2-",
 		"--env-from", "secret:existing-name-3-",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "updated", svcName, "default"))
@@ -661,14 +661,14 @@ func TestServiceUpdateEnvFromRemovalWithSecret(t *testing.T) {
 	output, err = executeServiceCommand(client,
 		"update", svcName,
 		"--env-from", "secret:-",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.Error(t, err, "the name of secret cannot be an empty string")
 
 	output, err = executeServiceCommand(client,
 		"update", svcName,
 		"--env-from", "sc:existing-name-4-",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "updated", svcName, "default"))
@@ -742,7 +742,7 @@ func TestServiceUpdateEnvFromExistingWithSecret(t *testing.T) {
 		"create", svcName, "--image", "gcr.io/foo/bar:baz",
 		"--env-from", "sc:existing-name-1",
 		"--env-from", "secret:existing-name-2",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", svcName, "default"))
@@ -751,7 +751,7 @@ func TestServiceUpdateEnvFromExistingWithSecret(t *testing.T) {
 		"update", svcName,
 		"--env-from", "secret:existing-name-1",
 		"--env-from", "secret:new-name",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "updated", svcName, "default"))
@@ -844,7 +844,7 @@ func TestServiceUpdateWithAddingVolume(t *testing.T) {
 		"create", svcName, "--image", "gcr.io/foo/bar:baz",
 		"--volume", "vol-1=cm:existing-config-map-1",
 		"--volume", "vol-2=secret:existing-secret-1",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", svcName, "default"))
@@ -853,7 +853,7 @@ func TestServiceUpdateWithAddingVolume(t *testing.T) {
 		"update", svcName,
 		"--volume", "vol-3=cm:existing-config-map-2",
 		"--volume", "vol-4=secret:existing-secret-2",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "updated", svcName, "default"))
@@ -946,7 +946,7 @@ func TestServiceUpdateWithUpdatingVolume(t *testing.T) {
 		"create", svcName, "--image", "gcr.io/foo/bar:baz",
 		"--volume", "vol-1=cm:existing-config-map-1",
 		"--volume", "vol-2=secret:existing-secret-1",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", svcName, "default"))
@@ -957,7 +957,7 @@ func TestServiceUpdateWithUpdatingVolume(t *testing.T) {
 		"--volume", "vol-2=secret:existing-secret-3",
 		"--volume", "vol-3=cm:existing-config-map-2",
 		"--volume", "vol-4=secret:existing-secret-2",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "updated", svcName, "default"))
@@ -1052,7 +1052,7 @@ func TestServiceUpdateWithRemovingVolume(t *testing.T) {
 		"--volume", "vol-2=secret:existing-secret-1",
 		"--volume", "vol-3=cm:existing-config-map-2",
 		"--volume", "vol-4=secret:existing-secret-2",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", svcName, "default"))
@@ -1061,7 +1061,7 @@ func TestServiceUpdateWithRemovingVolume(t *testing.T) {
 		"update", svcName,
 		"--volume", "vol-3-",
 		"--volume", "vol-2-",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "updated", svcName, "default"))
@@ -1126,7 +1126,7 @@ func TestServiceUpdateWithAddingMount(t *testing.T) {
 
 	output, err := executeServiceCommand(client,
 		"create", svcName, "--image", "gcr.io/foo/bar:baz",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", svcName, "default"))
@@ -1135,7 +1135,7 @@ func TestServiceUpdateWithAddingMount(t *testing.T) {
 		"update", svcName,
 		"--mount", "/mount/config-map-path=cm:config-map-name",
 		"--mount", "/mount/secret-path=secret:secret-name",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "updated", svcName, "default"))
@@ -1236,7 +1236,7 @@ func TestServiceUpdateWithUpdatingMount(t *testing.T) {
 		"create", svcName, "--image", "gcr.io/foo/bar:baz",
 		"--mount", "/mount/config-map-path=cm:config-map-name-1",
 		"--mount", "/mount/secret-path=secret:secret-name-1",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", svcName, "default"))
@@ -1247,7 +1247,7 @@ func TestServiceUpdateWithUpdatingMount(t *testing.T) {
 		"update", svcName,
 		"--mount", "/mount/secret-path=secret:secret-name-2",
 		"--mount", "/mount/config-map-path=cm:config-map-name-2",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "updated", svcName, "default"))
@@ -1418,7 +1418,7 @@ func TestServiceUpdateWithRemovingMount(t *testing.T) {
 		"--mount", "/mount/secret-path-2=secret:secret-name-2",
 		"--mount", "/mount/custom-path=custom-vol",
 		"--volume", "custom-vol=cm:config-map",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "created", svcName, "default"))
@@ -1440,7 +1440,7 @@ func TestServiceUpdateWithRemovingMount(t *testing.T) {
 		"update", svcName,
 		"--mount", "/mount/config-map-path-2-",
 		"--mount", "/mount/secret-path-1-",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "updated", svcName, "default"))
@@ -1450,7 +1450,7 @@ func TestServiceUpdateWithRemovingMount(t *testing.T) {
 		"--mount", "/mount/config-map-path-1-",
 		"--mount", "/mount/secret-path-2-",
 		"--mount", "/mount/custom-path-",
-		"--async", "--revision-name=",
+		"--no-wait", "--revision-name=",
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "updated", svcName, "default"))

--- a/pkg/kn/commands/service/update.go
+++ b/pkg/kn/commands/service/update.go
@@ -115,7 +115,8 @@ func NewServiceUpdateCommand(p *commands.KnParams) *cobra.Command {
 				}
 
 				out := cmd.OutOrStdout()
-				if !waitFlags.Async {
+				//TODO: deprecated condition should be once --async is gone
+				if !waitFlags.Async && !waitFlags.NoWait {
 					fmt.Fprintf(out, "Updating Service '%s' in namespace '%s':\n", args[0], namespace)
 					fmt.Fprintln(out, "")
 					err := waitForService(client, name, out, waitFlags.TimeoutInSeconds)
@@ -125,6 +126,9 @@ func NewServiceUpdateCommand(p *commands.KnParams) *cobra.Command {
 					fmt.Fprintln(out, "")
 					return showUrl(client, name, latestRevisionBeforeUpdate, "updated", out)
 				} else {
+					if waitFlags.Async {
+						fmt.Fprintf(out, "\nDEPRECATED WARNING: flag --async is going to be removed in future release, please use --no-wait instead.\n\n")
+					}
 					fmt.Fprintf(out, "Service '%s' updated in namespace '%s'.\n", args[0], namespace)
 				}
 

--- a/pkg/kn/commands/service/update.go
+++ b/pkg/kn/commands/service/update.go
@@ -127,7 +127,7 @@ func NewServiceUpdateCommand(p *commands.KnParams) *cobra.Command {
 					return showUrl(client, name, latestRevisionBeforeUpdate, "updated", out)
 				} else {
 					if waitFlags.Async {
-						fmt.Fprintf(out, "\nDEPRECATED WARNING: flag --async is going to be removed in future release, please use --no-wait instead.\n\n")
+						fmt.Fprintf(out, "\nWARNING: flag --async is deprecated and going to be removed in future release, please use --no-wait instead.\n\n")
 					}
 					fmt.Fprintf(out, "Service '%s' updated in namespace '%s'.\n", args[0], namespace)
 				}

--- a/pkg/kn/commands/service/update_test.go
+++ b/pkg/kn/commands/service/update_test.go
@@ -167,7 +167,7 @@ func TestServiceUpdateImage(t *testing.T) {
 	}
 
 	action, updated, output, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "--image", "gcr.io/foo/quux:xyzzy", "--namespace", "bar", "--async"}, false)
+		"service", "update", "foo", "--image", "gcr.io/foo/quux:xyzzy", "--namespace", "bar", "--no-wait"}, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -199,7 +199,7 @@ func TestServiceUpdateCommand(t *testing.T) {
 	err := servinglib.UpdateContainerCommand(origTemplate, "./start")
 
 	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "--cmd", "/app/start", "--async"}, false)
+		"service", "update", "foo", "--cmd", "/app/start", "--no-wait"}, false)
 	assert.NilError(t, err)
 	assert.Assert(t, action.Matches("update", "services"))
 
@@ -216,7 +216,7 @@ func TestServiceUpdateArg(t *testing.T) {
 	assert.NilError(t, err)
 
 	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "--arg", "myArg1", "--arg", "--myArg2", "--arg", "--myArg3=3", "--async"}, false)
+		"service", "update", "foo", "--arg", "myArg1", "--arg", "--myArg2", "--arg", "--myArg3=3", "--no-wait"}, false)
 	assert.NilError(t, err)
 	assert.Assert(t, action.Matches("update", "services"))
 
@@ -232,7 +232,7 @@ func TestServiceUpdateRevisionNameExplicit(t *testing.T) {
 
 	// Test user provides prefix
 	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "--revision-name", "foo-dogs", "--namespace", "bar", "--async"}, false)
+		"service", "update", "foo", "--revision-name", "foo-dogs", "--namespace", "bar", "--no-wait"}, false)
 	assert.NilError(t, err)
 	if !action.Matches("update", "services") {
 		t.Fatalf("Bad action %v", action)
@@ -250,7 +250,7 @@ func TestServiceUpdateRevisionNameGenerated(t *testing.T) {
 
 	// Test prefix added by command
 	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "--image", "gcr.io/foo/quux:xyzzy", "--namespace", "bar", "--async"}, false)
+		"service", "update", "foo", "--image", "gcr.io/foo/quux:xyzzy", "--namespace", "bar", "--no-wait"}, false)
 	assert.NilError(t, err)
 	if !action.Matches("update", "services") {
 		t.Fatalf("Bad action %v", action)
@@ -268,7 +268,7 @@ func TestServiceUpdateRevisionNameCleared(t *testing.T) {
 	template.Name = "foo-asdf"
 
 	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "--image", "gcr.io/foo/quux:xyzzy", "--namespace", "bar", "--revision-name=", "--async"}, false)
+		"service", "update", "foo", "--image", "gcr.io/foo/quux:xyzzy", "--namespace", "bar", "--revision-name=", "--no-wait"}, false)
 
 	assert.NilError(t, err)
 	if !action.Matches("update", "services") {
@@ -287,7 +287,7 @@ func TestServiceUpdateRevisionNameNoMutationNoChange(t *testing.T) {
 
 	// Test prefix added by command
 	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "--namespace", "bar", "--async"}, false)
+		"service", "update", "foo", "--namespace", "bar", "--no-wait"}, false)
 	assert.NilError(t, err)
 	if !action.Matches("update", "services") {
 		t.Fatalf("Bad action %v", action)
@@ -302,7 +302,7 @@ func TestServiceUpdateMaxMinScale(t *testing.T) {
 
 	action, updated, _, err := fakeServiceUpdate(original, []string{
 		"service", "update", "foo",
-		"--min-scale", "1", "--max-scale", "5", "--concurrency-target", "10", "--concurrency-limit", "100", "--async"}, false)
+		"--min-scale", "1", "--max-scale", "5", "--concurrency-target", "10", "--concurrency-limit", "100", "--no-wait"}, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -348,7 +348,7 @@ func TestServiceUpdateEnv(t *testing.T) {
 	servinglib.UpdateImage(template, "gcr.io/foo/bar:baz")
 
 	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "-e", "TARGET=Awesome", "--env", "EXISTING-", "--env=OTHEREXISTING-=whatever", "--async"}, false)
+		"service", "update", "foo", "-e", "TARGET=Awesome", "--env", "EXISTING-", "--env=OTHEREXISTING-=whatever", "--no-wait"}, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -377,7 +377,7 @@ func TestServiceUpdatePinsToDigestWhenAsked(t *testing.T) {
 	}
 
 	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "-e", "TARGET=Awesome", "--lock-to-digest", "--async"}, false)
+		"service", "update", "foo", "-e", "TARGET=Awesome", "--lock-to-digest", "--no-wait"}, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -400,7 +400,7 @@ func TestServiceUpdatePinsToDigestWhenPreviouslyDidSo(t *testing.T) {
 	}
 
 	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "-e", "TARGET=Awesome", "--async"}, false)
+		"service", "update", "foo", "-e", "TARGET=Awesome", "--no-wait"}, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -420,7 +420,7 @@ func TestServiceUpdateDoesntPinToDigestWhenUnAsked(t *testing.T) {
 	err := servinglib.UpdateImage(&template, "gcr.io/foo/bar:baz")
 
 	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "-e", "TARGET=Awesome", "--no-lock-to-digest", "--async"}, false)
+		"service", "update", "foo", "-e", "TARGET=Awesome", "--no-lock-to-digest", "--no-wait"}, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -446,7 +446,7 @@ func TestServiceUpdateDoesntPinToDigestWhenPreviouslyDidnt(t *testing.T) {
 	}
 
 	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "-e", "TARGET=Awesome", "--async"}, false)
+		"service", "update", "foo", "-e", "TARGET=Awesome", "--no-wait"}, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -465,7 +465,7 @@ func TestServiceUpdateRequestsLimitsCPU(t *testing.T) {
 	service := createMockServiceWithResources(t, "250", "64Mi", "1000m", "1024Mi")
 
 	action, updated, _, err := fakeServiceUpdate(service, []string{
-		"service", "update", "foo", "--requests-cpu", "500m", "--limits-cpu", "1000m", "--async"}, false)
+		"service", "update", "foo", "--requests-cpu", "500m", "--limits-cpu", "1000m", "--no-wait"}, false)
 	if err != nil {
 		t.Fatal(err)
 	} else if !action.Matches("update", "services") {
@@ -503,7 +503,7 @@ func TestServiceUpdateRequestsLimitsMemory(t *testing.T) {
 	service := createMockServiceWithResources(t, "100m", "64Mi", "1000m", "1024Mi")
 
 	action, updated, _, err := fakeServiceUpdate(service, []string{
-		"service", "update", "foo", "--requests-memory", "128Mi", "--limits-memory", "2048Mi", "--async"}, false)
+		"service", "update", "foo", "--requests-memory", "128Mi", "--limits-memory", "2048Mi", "--no-wait"}, false)
 	if err != nil {
 		t.Fatal(err)
 	} else if !action.Matches("update", "services") {
@@ -543,7 +543,7 @@ func TestServiceUpdateRequestsLimitsCPU_and_Memory(t *testing.T) {
 	action, updated, _, err := fakeServiceUpdate(service, []string{
 		"service", "update", "foo",
 		"--requests-cpu", "500m", "--limits-cpu", "2000m",
-		"--requests-memory", "128Mi", "--limits-memory", "2048Mi", "--async"}, false)
+		"--requests-memory", "128Mi", "--limits-memory", "2048Mi", "--no-wait"}, false)
 	if err != nil {
 		t.Fatal(err)
 	} else if !action.Matches("update", "services") {
@@ -587,7 +587,7 @@ func TestServiceUpdateLabelWhenEmpty(t *testing.T) {
 	origContainer.Image = "gcr.io/foo/bar:latest"
 
 	action, updated, _, err := fakeServiceUpdate(original, []string{
-		"service", "update", "foo", "-l", "a=mouse", "--label", "b=cookie", "-l=single", "--async"}, false)
+		"service", "update", "foo", "-l", "a=mouse", "--label", "b=cookie", "-l=single", "--no-wait"}, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -620,7 +620,7 @@ func TestServiceUpdateLabelExisting(t *testing.T) {
 	originalTemplate.ObjectMeta.Labels = map[string]string{"already": "here", "tobe": "removed"}
 
 	action, updated, _, err := fakeServiceUpdate(original, []string{
-		"service", "update", "foo", "-l", "already=gone", "--label=tobe-", "--label", "b=", "--async"}, false)
+		"service", "update", "foo", "-l", "already=gone", "--label=tobe-", "--label", "b=", "--no-wait"}, false)
 
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/kn/commands/wait_flags.go
+++ b/pkg/kn/commands/wait_flags.go
@@ -31,6 +31,8 @@ type WaitFlags struct {
 	TimeoutInSeconds int
 
 	// If set then just apply resources and don't wait
+	NoWait bool
+	//TODO: deprecated variable should be removed with --async flag
 	Async bool
 }
 
@@ -39,7 +41,9 @@ type WaitFlags struct {
 // Use `what` for describing what is waited for.
 func (p *WaitFlags) AddConditionWaitFlags(command *cobra.Command, waitTimeoutDefault int, action string, what string) {
 	waitUsage := fmt.Sprintf("%s %s and don't wait for it to become ready.", action, what)
-	command.Flags().BoolVar(&p.Async, "async", false, waitUsage)
+	//TODO: deprecated flag should be removed in next release
+	command.Flags().BoolVar(&p.Async, "async", false, "DEPRECATED: please use --no-wait instead. "+waitUsage)
+	command.Flags().BoolVar(&p.NoWait, "no-wait", false, waitUsage)
 
 	timeoutUsage := fmt.Sprintf("Seconds to wait before giving up on waiting for %s to be ready.", what)
 	command.Flags().IntVar(&p.TimeoutInSeconds, "wait-timeout", waitTimeoutDefault, timeoutUsage)

--- a/test/e2e-smoke-tests.sh
+++ b/test/e2e-smoke-tests.sh
@@ -39,7 +39,9 @@ kubectl create ns $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 
 sleep 4 # Wait for the namespace to get initialized by kube-controller-manager
 
+#TODO: deprecated tests remove once --async is gone
 ./kn service create svc1 --async --image gcr.io/knative-samples/helloworld-go -e TARGET=Knative -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
+./kn service create svc2 --no-wait --image gcr.io/knative-samples/helloworld-go -e TARGET=Knative -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 ./kn service create hello --image gcr.io/knative-samples/helloworld-go -e TARGET=Knative -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 ./kn service list hello -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test
 ./kn service update hello --env TARGET=kn -n $KN_E2E_SMOKE_TESTS_NAMESPACE || fail_test


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #438

## Proposed Changes

* Add `--no-wait` flag with same behaviour as `--async`
* Mark `--async` as deprecated in documentation and display warning message when used


Example of deprecation warning:
```bash
➜  client git:(issue-438) kn service create svc-test --image gcr.io/knative-samples/helloworld-go --async  

DEPRECATED WARNING: flag --async is going to be removed in future release, please use --no-wait instead.

Service 'svc-test' created in namespace 'default'.
➜  client git:(issue-438) kn service update svc-test --image gcr.io/knative-samples/helloworld-go --async

DEPRECATED WARNING: flag --async is going to be removed in future release, please use --no-wait instead.

Service 'svc-test' updated in namespace 'default'.
➜  client git:(issue-438) kn service update svc-test --image gcr.io/knative-samples/helloworld-go --no-wait
Service 'svc-test' updated in namespace 'default'.

```
<!--
Release Note:

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behaviour
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example.

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->
