### PR TITLE
fix(serving): Add an error window for ReadyCondition

### DIFF
--- a/pkg/wait/wait_for_ready.go
+++ b/pkg/wait/wait_for_ready.go
@@ -25,7 +25,7 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-// Window for how long to wait until a ReadyCondition == false has to stay
+// Window for how long a ReadyCondition == false has to stay
 // for being considered as an error
 var ErrorWindow = 2 * time.Second
 

--- a/pkg/wait/wait_for_ready_test.go
+++ b/pkg/wait/wait_for_ready_test.go
@@ -79,7 +79,7 @@ func prepareTestCases(name string) []waitForReadyTestCase {
 		tc(peError, name, true),
 		tc(peWrongGeneration, name, true),
 		tc(peTimeout, name, true),
-		tc(peReadFalseWithinErrorWindow, name, false),
+		tc(peReadyFalseWithinErrorWindow, name, false),
 	}
 }
 
@@ -133,7 +133,7 @@ func peWrongGeneration(name string) ([]watch.Event, int) {
 	}, len(messages)
 }
 
-func peReadFalseWithinErrorWindow(name string) ([]watch.Event, int) {
+func peReadyFalseWithinErrorWindow(name string) ([]watch.Event, int) {
 	messages := pMessages(1)
 	return []watch.Event{
 		{watch.Added, CreateTestServiceWithConditions(name, corev1.ConditionFalse, corev1.ConditionFalse, "Route not ready", messages[0])},

--- a/pkg/wait/wait_for_ready_test.go
+++ b/pkg/wait/wait_for_ready_test.go
@@ -79,6 +79,7 @@ func prepareTestCases(name string) []waitForReadyTestCase {
 		tc(peError, name, true),
 		tc(peWrongGeneration, name, true),
 		tc(peTimeout, name, true),
+		tc(peReadFalseWithinErrorWindow, name, false),
 	}
 }
 
@@ -129,5 +130,13 @@ func peWrongGeneration(name string) ([]watch.Event, int) {
 	return []watch.Event{
 		{watch.Added, CreateTestServiceWithConditions(name, corev1.ConditionUnknown, corev1.ConditionUnknown, "", messages[0])},
 		{watch.Modified, CreateTestServiceWithConditions(name, corev1.ConditionTrue, corev1.ConditionTrue, "", "", 1, 2)},
+	}, len(messages)
+}
+
+func peReadFalseWithinErrorWindow(name string) ([]watch.Event, int) {
+	messages := pMessages(1)
+	return []watch.Event{
+		{watch.Added, CreateTestServiceWithConditions(name, corev1.ConditionFalse, corev1.ConditionFalse, "Route not ready", messages[0])},
+		{watch.Modified, CreateTestServiceWithConditions(name, corev1.ConditionTrue, corev1.ConditionTrue, "Route ready", "")},
 	}, len(messages)
 }


### PR DESCRIPTION
A default error window of 2 seconds (not sure if this should be made configurable
as it is hard to explain/document) cause return an error during
sync operations only, if a ReadyCondition == false stays for that
long in false. This is needed to compensate situation where the
condition is false when a race between revision and route creation
occurse during a service creation.

This should fix the flakes we have in our E2E tests as described in #544.