### PR TITLE
fix(#632): refactored UT to remove need of specifying sync twice

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -38,7 +38,12 @@
 
 | 🧽
 | Add `no-wait` instead of `--async` and deprecate it
-https://github.com/knative/client/pull/639[#639]
+| https://github.com/knative/client/pull/639[#639]
+
+| 🧽
+| Refactor service `create_test.go` and `update_test.go` to
+| remove unecessary `sync` parameter in setup call
+| https://github.com/knative/client/pull/656[#656]
 
 ## v0.12.0 (2020-01-29)
 

--- a/pkg/kn/commands/service/create_test.go
+++ b/pkg/kn/commands/service/create_test.go
@@ -38,13 +38,14 @@ import (
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
-func fakeServiceCreate(args []string, withExistingService bool, sync bool) (
+func fakeServiceCreate(args []string, withExistingService bool) (
 	action clienttesting.Action,
 	service *servingv1.Service,
 	output string,
 	err error) {
 	knParams := &commands.KnParams{}
 	nrGetCalled := 0
+	sync := !noWait(args)
 	cmd, fakeServing, buf := commands.CreateTestKnCommand(NewServiceCommand(knParams), knParams)
 	fakeServing.AddReactor("get", "services",
 		func(a clienttesting.Action) (bool, runtime.Object, error) {
@@ -117,7 +118,7 @@ func getServiceEvents(name string) []watch.Event {
 
 func TestServiceCreateImage(t *testing.T) {
 	action, created, output, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--no-wait"}, false, false)
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--no-wait"}, false)
 	if err != nil {
 		t.Fatal(err)
 	} else if !action.Matches("create", "services") {
@@ -136,7 +137,7 @@ func TestServiceCreateImage(t *testing.T) {
 
 func TestServiceCreateImageSync(t *testing.T) {
 	action, created, output, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz"}, false, true)
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz"}, false)
 	if err != nil {
 		t.Fatal(err)
 	} else if !action.Matches("create", "services") {
@@ -160,7 +161,7 @@ func TestServiceCreateImageSync(t *testing.T) {
 
 func TestServiceCreateCommand(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--cmd", "/app/start", "--no-wait"}, false, false)
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--cmd", "/app/start", "--no-wait"}, false)
 	assert.NilError(t, err)
 	assert.Assert(t, action.Matches("create", "services"))
 
@@ -171,7 +172,9 @@ func TestServiceCreateCommand(t *testing.T) {
 
 func TestServiceCreateArg(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--arg", "myArg1", "--arg", "--myArg2", "--arg", "--myArg3=3", "--no-wait"}, false, false)
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
+		"--arg", "myArg1", "--arg", "--myArg2", "--arg", "--myArg3=3",
+		"--no-wait"}, false)
 	assert.NilError(t, err)
 	assert.Assert(t, action.Matches("create", "services"))
 
@@ -184,7 +187,8 @@ func TestServiceCreateArg(t *testing.T) {
 
 func TestServiceCreateEnv(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "-e", "A=DOGS", "--env", "B=WOLVES", "--env=EMPTY", "--no-wait"}, false, false)
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
+		"-e", "A=DOGS", "--env", "B=WOLVES", "--env=EMPTY", "--no-wait"}, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -220,7 +224,9 @@ func TestServiceCreateEnv(t *testing.T) {
 
 func TestServiceCreateWithRequests(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--requests-cpu", "250m", "--requests-memory", "64Mi", "--no-wait"}, false, false)
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
+		"--requests-cpu", "250m", "--requests-memory", "64Mi",
+		"--no-wait"}, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -246,7 +252,9 @@ func TestServiceCreateWithRequests(t *testing.T) {
 
 func TestServiceCreateWithLimits(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--limits-cpu", "1000m", "--limits-memory", "1024Mi", "--no-wait"}, false, false)
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
+		"--limits-cpu", "1000m", "--limits-memory", "1024Mi",
+		"--no-wait"}, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -272,7 +280,9 @@ func TestServiceCreateWithLimits(t *testing.T) {
 
 func TestServiceCreateRequestsLimitsCPU(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--requests-cpu", "250m", "--limits-cpu", "1000m", "--no-wait"}, false, false)
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
+		"--requests-cpu", "250m", "--limits-cpu", "1000m",
+		"--no-wait"}, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -309,7 +319,10 @@ func TestServiceCreateRequestsLimitsCPU(t *testing.T) {
 
 func TestServiceCreateRequestsLimitsMemory(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--requests-memory", "64Mi", "--limits-memory", "1024Mi", "--no-wait"}, false, false)
+		"service", "create", "foo",
+		"--image", "gcr.io/foo/bar:baz",
+		"--requests-memory", "64Mi",
+		"--limits-memory", "1024Mi", "--no-wait"}, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -347,7 +360,9 @@ func TestServiceCreateRequestsLimitsMemory(t *testing.T) {
 func TestServiceCreateMaxMinScale(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
 		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
-		"--min-scale", "1", "--max-scale", "5", "--concurrency-target", "10", "--concurrency-limit", "100", "--no-wait"}, false, false)
+		"--min-scale", "1", "--max-scale", "5",
+		"--concurrency-target", "10", "--concurrency-limit", "100",
+		"--no-wait"}, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -384,7 +399,8 @@ func TestServiceCreateRequestsLimitsCPUMemory(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
 		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
 		"--requests-cpu", "250m", "--limits-cpu", "1000m",
-		"--requests-memory", "64Mi", "--limits-memory", "1024Mi", "--no-wait"}, false, false)
+		"--requests-memory", "64Mi", "--limits-memory", "1024Mi",
+		"--no-wait"}, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -431,7 +447,7 @@ func parseQuantity(t *testing.T, quantityString string) resource.Quantity {
 
 func TestServiceCreateImageExistsAndNoForce(t *testing.T) {
 	_, _, output, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:v2", "--no-wait"}, true, false)
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:v2", "--no-wait"}, true)
 	if err == nil {
 		t.Fatal(err)
 	}
@@ -446,7 +462,7 @@ func TestServiceCreateImageExistsAndNoForce(t *testing.T) {
 
 func TestServiceCreateImageForce(t *testing.T) {
 	action, created, output, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--force", "--image", "gcr.io/foo/bar:v2", "--no-wait"}, true, false)
+		"service", "create", "foo", "--force", "--image", "gcr.io/foo/bar:v2", "--no-wait"}, true)
 	if err != nil {
 		t.Fatal(err)
 	} else if !action.Matches("update", "services") {
@@ -464,12 +480,14 @@ func TestServiceCreateImageForce(t *testing.T) {
 
 func TestServiceCreateEnvForce(t *testing.T) {
 	_, _, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:v1", "-e", "A=DOGS", "--env", "B=WOLVES", "--no-wait"}, false, false)
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:v1",
+		"-e", "A=DOGS", "--env", "B=WOLVES", "--no-wait"}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	action, created, output, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--force", "--image", "gcr.io/foo/bar:v2", "-e", "A=CATS", "--env", "B=LIONS", "--no-wait"}, false, false)
+		"service", "create", "foo", "--force", "--image", "gcr.io/foo/bar:v2",
+		"-e", "A=CATS", "--env", "B=LIONS", "--no-wait"}, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -503,7 +521,7 @@ func TestServiceCreateWithServiceAccountName(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
 		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
 		"--service-account", "foo-bar-account",
-		"--no-wait"}, false, false)
+		"--no-wait"}, false)
 
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/kn/commands/service/update_test.go
+++ b/pkg/kn/commands/service/update_test.go
@@ -42,13 +42,14 @@ var exampleImageByDigest = "gcr.io/foo/bar@sha256:deadbeefdeadbeef"
 var exampleRevisionName = "foo-asdf"
 var exampleRevisionName2 = "foo-xyzzy"
 
-func fakeServiceUpdate(original *servingv1.Service, args []string, sync bool) (
+func fakeServiceUpdate(original *servingv1.Service, args []string) (
 	action clienttesting.Action,
 	updated *servingv1.Service,
 	output string,
 	err error) {
 	var reconciled servingv1.Service
 	knParams := &commands.KnParams{}
+	sync := !noWait(args)
 	cmd, fakeServing, buf := commands.CreateTestKnCommand(NewServiceCommand(knParams), knParams)
 	fakeServing.AddReactor("update", "*",
 		func(a clienttesting.Action) (bool, runtime.Object, error) {
@@ -88,6 +89,7 @@ func fakeServiceUpdate(original *servingv1.Service, args []string, sync bool) (
 			rev.Status.ImageDigest = exampleImageByDigest
 			return true, rev, nil
 		})
+
 	if sync {
 		fakeServing.AddWatchReactor("services",
 			func(a clienttesting.Action) (bool, watch.Interface, error) {
@@ -118,9 +120,7 @@ func fakeServiceUpdate(original *servingv1.Service, args []string, sync bool) (
 func TestServcieUpdateNoFlags(t *testing.T) {
 	orig := newEmptyService()
 
-	action, _, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo"}, false)
-
+	action, _, _, err := fakeServiceUpdate(orig, []string{"service", "update", "foo"})
 	if action != nil {
 		t.Errorf("Unexpected action if no flag(s) set")
 	}
@@ -145,7 +145,7 @@ func TestServiceUpdateImageSync(t *testing.T) {
 	}
 
 	action, updated, output, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "--image", "gcr.io/foo/quux:xyzzy", "--namespace", "bar"}, true)
+		"service", "update", "foo", "--image", "gcr.io/foo/quux:xyzzy", "--namespace", "bar"})
 
 	assert.NilError(t, err)
 	assert.Assert(t, action.Matches("update", "services"))
@@ -167,7 +167,7 @@ func TestServiceUpdateImage(t *testing.T) {
 	}
 
 	action, updated, output, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "--image", "gcr.io/foo/quux:xyzzy", "--namespace", "bar", "--no-wait"}, false)
+		"service", "update", "foo", "--image", "gcr.io/foo/quux:xyzzy", "--namespace", "bar", "--no-wait"})
 
 	if err != nil {
 		t.Fatal(err)
@@ -199,7 +199,7 @@ func TestServiceUpdateCommand(t *testing.T) {
 	err := servinglib.UpdateContainerCommand(origTemplate, "./start")
 
 	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "--cmd", "/app/start", "--no-wait"}, false)
+		"service", "update", "foo", "--cmd", "/app/start", "--no-wait"})
 	assert.NilError(t, err)
 	assert.Assert(t, action.Matches("update", "services"))
 
@@ -216,7 +216,7 @@ func TestServiceUpdateArg(t *testing.T) {
 	assert.NilError(t, err)
 
 	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "--arg", "myArg1", "--arg", "--myArg2", "--arg", "--myArg3=3", "--no-wait"}, false)
+		"service", "update", "foo", "--arg", "myArg1", "--arg", "--myArg2", "--arg", "--myArg3=3", "--no-wait"})
 	assert.NilError(t, err)
 	assert.Assert(t, action.Matches("update", "services"))
 
@@ -232,7 +232,7 @@ func TestServiceUpdateRevisionNameExplicit(t *testing.T) {
 
 	// Test user provides prefix
 	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "--revision-name", "foo-dogs", "--namespace", "bar", "--no-wait"}, false)
+		"service", "update", "foo", "--revision-name", "foo-dogs", "--namespace", "bar", "--no-wait"})
 	assert.NilError(t, err)
 	if !action.Matches("update", "services") {
 		t.Fatalf("Bad action %v", action)
@@ -250,7 +250,7 @@ func TestServiceUpdateRevisionNameGenerated(t *testing.T) {
 
 	// Test prefix added by command
 	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "--image", "gcr.io/foo/quux:xyzzy", "--namespace", "bar", "--no-wait"}, false)
+		"service", "update", "foo", "--image", "gcr.io/foo/quux:xyzzy", "--namespace", "bar", "--no-wait"})
 	assert.NilError(t, err)
 	if !action.Matches("update", "services") {
 		t.Fatalf("Bad action %v", action)
@@ -268,7 +268,7 @@ func TestServiceUpdateRevisionNameCleared(t *testing.T) {
 	template.Name = "foo-asdf"
 
 	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "--image", "gcr.io/foo/quux:xyzzy", "--namespace", "bar", "--revision-name=", "--no-wait"}, false)
+		"service", "update", "foo", "--image", "gcr.io/foo/quux:xyzzy", "--namespace", "bar", "--revision-name=", "--no-wait"})
 
 	assert.NilError(t, err)
 	if !action.Matches("update", "services") {
@@ -287,7 +287,7 @@ func TestServiceUpdateRevisionNameNoMutationNoChange(t *testing.T) {
 
 	// Test prefix added by command
 	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "--namespace", "bar", "--no-wait"}, false)
+		"service", "update", "foo", "--namespace", "bar", "--no-wait"})
 	assert.NilError(t, err)
 	if !action.Matches("update", "services") {
 		t.Fatalf("Bad action %v", action)
@@ -302,7 +302,7 @@ func TestServiceUpdateMaxMinScale(t *testing.T) {
 
 	action, updated, _, err := fakeServiceUpdate(original, []string{
 		"service", "update", "foo",
-		"--min-scale", "1", "--max-scale", "5", "--concurrency-target", "10", "--concurrency-limit", "100", "--no-wait"}, false)
+		"--min-scale", "1", "--max-scale", "5", "--concurrency-target", "10", "--concurrency-limit", "100", "--no-wait"})
 
 	if err != nil {
 		t.Fatal(err)
@@ -348,7 +348,7 @@ func TestServiceUpdateEnv(t *testing.T) {
 	servinglib.UpdateImage(template, "gcr.io/foo/bar:baz")
 
 	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "-e", "TARGET=Awesome", "--env", "EXISTING-", "--env=OTHEREXISTING-=whatever", "--no-wait"}, false)
+		"service", "update", "foo", "-e", "TARGET=Awesome", "--env", "EXISTING-", "--env=OTHEREXISTING-=whatever", "--no-wait"})
 
 	if err != nil {
 		t.Fatal(err)
@@ -377,7 +377,7 @@ func TestServiceUpdatePinsToDigestWhenAsked(t *testing.T) {
 	}
 
 	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "-e", "TARGET=Awesome", "--lock-to-digest", "--no-wait"}, false)
+		"service", "update", "foo", "-e", "TARGET=Awesome", "--lock-to-digest", "--no-wait"})
 
 	if err != nil {
 		t.Fatal(err)
@@ -400,7 +400,7 @@ func TestServiceUpdatePinsToDigestWhenPreviouslyDidSo(t *testing.T) {
 	}
 
 	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "-e", "TARGET=Awesome", "--no-wait"}, false)
+		"service", "update", "foo", "-e", "TARGET=Awesome", "--no-wait"})
 
 	if err != nil {
 		t.Fatal(err)
@@ -420,7 +420,7 @@ func TestServiceUpdateDoesntPinToDigestWhenUnAsked(t *testing.T) {
 	err := servinglib.UpdateImage(&template, "gcr.io/foo/bar:baz")
 
 	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "-e", "TARGET=Awesome", "--no-lock-to-digest", "--no-wait"}, false)
+		"service", "update", "foo", "-e", "TARGET=Awesome", "--no-lock-to-digest", "--no-wait"})
 
 	if err != nil {
 		t.Fatal(err)
@@ -446,7 +446,7 @@ func TestServiceUpdateDoesntPinToDigestWhenPreviouslyDidnt(t *testing.T) {
 	}
 
 	action, updated, _, err := fakeServiceUpdate(orig, []string{
-		"service", "update", "foo", "-e", "TARGET=Awesome", "--no-wait"}, false)
+		"service", "update", "foo", "-e", "TARGET=Awesome", "--no-wait"})
 
 	if err != nil {
 		t.Fatal(err)
@@ -465,7 +465,7 @@ func TestServiceUpdateRequestsLimitsCPU(t *testing.T) {
 	service := createMockServiceWithResources(t, "250", "64Mi", "1000m", "1024Mi")
 
 	action, updated, _, err := fakeServiceUpdate(service, []string{
-		"service", "update", "foo", "--requests-cpu", "500m", "--limits-cpu", "1000m", "--no-wait"}, false)
+		"service", "update", "foo", "--requests-cpu", "500m", "--limits-cpu", "1000m", "--no-wait"})
 	if err != nil {
 		t.Fatal(err)
 	} else if !action.Matches("update", "services") {
@@ -503,7 +503,7 @@ func TestServiceUpdateRequestsLimitsMemory(t *testing.T) {
 	service := createMockServiceWithResources(t, "100m", "64Mi", "1000m", "1024Mi")
 
 	action, updated, _, err := fakeServiceUpdate(service, []string{
-		"service", "update", "foo", "--requests-memory", "128Mi", "--limits-memory", "2048Mi", "--no-wait"}, false)
+		"service", "update", "foo", "--requests-memory", "128Mi", "--limits-memory", "2048Mi", "--no-wait"})
 	if err != nil {
 		t.Fatal(err)
 	} else if !action.Matches("update", "services") {
@@ -543,7 +543,7 @@ func TestServiceUpdateRequestsLimitsCPU_and_Memory(t *testing.T) {
 	action, updated, _, err := fakeServiceUpdate(service, []string{
 		"service", "update", "foo",
 		"--requests-cpu", "500m", "--limits-cpu", "2000m",
-		"--requests-memory", "128Mi", "--limits-memory", "2048Mi", "--no-wait"}, false)
+		"--requests-memory", "128Mi", "--limits-memory", "2048Mi", "--no-wait"})
 	if err != nil {
 		t.Fatal(err)
 	} else if !action.Matches("update", "services") {
@@ -587,7 +587,7 @@ func TestServiceUpdateLabelWhenEmpty(t *testing.T) {
 	origContainer.Image = "gcr.io/foo/bar:latest"
 
 	action, updated, _, err := fakeServiceUpdate(original, []string{
-		"service", "update", "foo", "-l", "a=mouse", "--label", "b=cookie", "-l=single", "--no-wait"}, false)
+		"service", "update", "foo", "-l", "a=mouse", "--label", "b=cookie", "-l=single", "--no-wait"})
 
 	if err != nil {
 		t.Fatal(err)
@@ -620,7 +620,7 @@ func TestServiceUpdateLabelExisting(t *testing.T) {
 	originalTemplate.ObjectMeta.Labels = map[string]string{"already": "here", "tobe": "removed"}
 
 	action, updated, _, err := fakeServiceUpdate(original, []string{
-		"service", "update", "foo", "-l", "already=gone", "--label=tobe-", "--label", "b=", "--no-wait"}, false)
+		"service", "update", "foo", "-l", "already=gone", "--label=tobe-", "--label", "b=", "--no-wait"})
 
 	if err != nil {
 		t.Fatal(err)
@@ -677,4 +677,13 @@ func createMockServiceWithResources(t *testing.T, requestCPU, requestMemory, lim
 	}
 
 	return service
+}
+
+func noWait(args []string) bool {
+	for _, arg := range args {
+		if arg == "--no-wait" {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Fixes #632 

## Proposed Changes

* infer the `sync` param from `fakeServiceUpdate` and `fakeServiceCreate` by the
parameter `--no-wait`.
* simplifies the UTs and also avoids a nasty NPE if the sync param was not (in sync :)
with the `--no-wait` flag.