### PR TITLE
Support multiple arguments on revision delete

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,10 @@
 |===
 | | Description | PR
 
+| 🧽
+| Support multiple revisions on `kn revision delete`
+| https://github.com/knative/client/pull/657[#657]
+
 | 🎁
 | Add human readable `kn route describe`
 | https://github.com/knative/client/pull/643[#643]

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -42,7 +42,8 @@
 
 | 🧽
 | Add `no-wait` instead of `--async` and deprecate it
-https://github.com/knative/client/pull/639[#639]
+| https://github.com/knative/client/pull/639[#639]
+|===
 
 ## v0.12.0 (2020-01-29)
 

--- a/pkg/kn/commands/revision/delete.go
+++ b/pkg/kn/commands/revision/delete.go
@@ -32,8 +32,8 @@ func NewRevisionDeleteCommand(p *commands.KnParams) *cobra.Command {
   # Delete a revision 'svc1-abcde' in default namespace
   kn revision delete svc1-abcde`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				return errors.New("'revision delete' requires the revision name given as single argument")
+			if len(args) < 1 {
+				return errors.New("'revision delete' requires the revision name(s)")
 			}
 			namespace, err := p.GetNamespace(cmd)
 			if err != nil {
@@ -43,11 +43,15 @@ func NewRevisionDeleteCommand(p *commands.KnParams) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			err = client.DeleteRevision(args[0])
-			if err != nil {
-				return err
+
+			for _, name := range args {
+				err = client.DeleteRevision(name)
+				if err != nil {
+					fmt.Fprintf(cmd.OutOrStdout(), "%s.\n", err)
+				} else {
+					fmt.Fprintf(cmd.OutOrStdout(), "Revision '%s' successfully deleted in namespace '%s'.\n", name, namespace)
+				}
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Revision '%s' successfully deleted in namespace '%s'.\n", args[0], namespace)
 			return nil
 		},
 	}

--- a/pkg/kn/commands/revision/delete.go
+++ b/pkg/kn/commands/revision/delete.go
@@ -49,7 +49,7 @@ func NewRevisionDeleteCommand(p *commands.KnParams) *cobra.Command {
 				if err != nil {
 					fmt.Fprintf(cmd.OutOrStdout(), "%s.\n", err)
 				} else {
-					fmt.Fprintf(cmd.OutOrStdout(), "Revision '%s' successfully deleted in namespace '%s'.\n", name, namespace)
+					fmt.Fprintf(cmd.OutOrStdout(), "Revision '%s' deleted in namespace '%s'.\n", name, namespace)
 				}
 			}
 			return nil

--- a/pkg/kn/commands/revision/delete.go
+++ b/pkg/kn/commands/revision/delete.go
@@ -33,7 +33,7 @@ func NewRevisionDeleteCommand(p *commands.KnParams) *cobra.Command {
   kn revision delete svc1-abcde`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				return errors.New("'kn revision delete' requires the revision name(s)")
+				return errors.New("'kn revision delete' requires one or more revision name")
 			}
 			namespace, err := p.GetNamespace(cmd)
 			if err != nil {

--- a/pkg/kn/commands/revision/delete.go
+++ b/pkg/kn/commands/revision/delete.go
@@ -33,7 +33,7 @@ func NewRevisionDeleteCommand(p *commands.KnParams) *cobra.Command {
   kn revision delete svc1-abcde`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				return errors.New("'revision delete' requires the revision name(s)")
+				return errors.New("'kn revision delete' requires the revision name(s)")
 			}
 			namespace, err := p.GetNamespace(cmd)
 			if err != nil {

--- a/pkg/kn/commands/revision/delete_test.go
+++ b/pkg/kn/commands/revision/delete_test.go
@@ -60,3 +60,22 @@ func TestRevisionDelete(t *testing.T) {
 	}
 	assert.Check(t, util.ContainsAll(output, "Revision", revName, "deleted", "namespace", commands.FakeNamespace))
 }
+
+func TestMultipleRevisionDelete(t *testing.T) {
+	revName1 := "foo-12345"
+	revName2 := "foo-67890"
+	revName3 := "foo-abcde"
+	action, _, output, err := fakeRevisionDelete([]string{"revision", "delete", revName1, revName2, revName3})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if action == nil {
+		t.Errorf("No action")
+	} else if !action.Matches("delete", "revisions") {
+		t.Errorf("Bad action %v", action)
+	}
+	assert.Check(t, util.ContainsAll(output, "Revision", revName1, "deleted", "namespace", commands.FakeNamespace))
+	assert.Check(t, util.ContainsAll(output, "Revision", revName2, "deleted", "namespace", commands.FakeNamespace))
+	assert.Check(t, util.ContainsAll(output, "Revision", revName3, "deleted", "namespace", commands.FakeNamespace))
+}

--- a/test/e2e/revision_test.go
+++ b/test/e2e/revision_test.go
@@ -108,14 +108,6 @@ func (test *e2eTest) revisionMultipleDelete(t *testing.T, revisionNames []string
 
 	out, err = test.kn.RunWithOpts([]string{"revision", "delete", existRevision1, existRevision2, nonexistRevision}, runOpts{NoNamespace: false})
 
-	// expectedSuccess1 := fmt.Sprintf(`Revision '%s' successfully deleted in namespace '%s'`, existRevision1, test.kn.namespace)
-	// expectedSuccess2 := fmt.Sprintf(`Revision '%s' successfully deleted in namespace '%s'`, existRevision2, test.kn.namespace)
-	// expectedErr := fmt.Sprintf(`revisions.serving.knative.dev "%s" not found.`, nonexistRevision)
-
-	// assert.Check(t, strings.Contains(out, expectedSuccess1), "Failed to get 'successfully deleted' first revision message")
-	// assert.Check(t, strings.Contains(out, expectedSuccess2), "Failed to get 'successfully deleted' second revision message")
-	// assert.Check(t, strings.Contains(out, expectedErr), "Failed to get 'not found' error")
-
 	assert.Check(t, util.ContainsAll(out, "Revision", existRevision1, "successfully", "deleted", "namespace", test.kn.namespace), "Failed to get 'successfully deleted' first revision message")
 	assert.Check(t, util.ContainsAll(out, "Revision", existRevision2, "successfully", "deleted", "namespace", test.kn.namespace), "Failed to get 'successfully deleted' second revision message")
 	assert.Check(t, util.ContainsAll(out, "revisions.serving.knative.dev", nonexistRevision, "not found"), "Failed to get 'not found' error")

--- a/test/e2e/revision_test.go
+++ b/test/e2e/revision_test.go
@@ -99,12 +99,10 @@ func (test *e2eTest) revisionDelete(t *testing.T, revName string) {
 func (test *e2eTest) revisionMultipleDelete(t *testing.T, revisionNames []string) {
 	existRevision1 := revisionNames[0]
 	existRevision2 := revisionNames[1]
-	nonexistRevision := revisionNames[2]
 	out, err := test.kn.RunWithOpts([]string{"revision", "list"}, runOpts{NoNamespace: false})
 	assert.NilError(t, err)
 	assert.Check(t, strings.Contains(out, existRevision1), "Required revision1 does not exist")
 	assert.Check(t, strings.Contains(out, existRevision2), "Required revision2 does not exist")
-	assert.Check(t, !strings.Contains(out, nonexistRevision), "Nonexistent revision does exist")
 
 	out, err = test.kn.RunWithOpts([]string{"revision", "delete", existRevision1, existRevision2, nonexistRevision}, runOpts{NoNamespace: false})
 

--- a/test/e2e/revision_test.go
+++ b/test/e2e/revision_test.go
@@ -38,7 +38,8 @@ func TestRevision(t *testing.T) {
 	})
 
 	t.Run("describe revision from hello service with print flags", func(t *testing.T) {
-		test.revisionDescribeWithPrintFlags(t, "hello")
+		revName := test.findRevision(t, "hello")
+		test.revisionDescribeWithPrintFlags(t, revName)
 	})
 
 	t.Run("update hello service and increase the count of configuration generation", func(t *testing.T) {
@@ -50,7 +51,23 @@ func TestRevision(t *testing.T) {
 	})
 
 	t.Run("delete latest revision from hello service and return no error", func(t *testing.T) {
-		test.revisionDelete(t, "hello")
+		revName := test.findRevision(t, "hello")
+		test.revisionDelete(t, revName)
+	})
+
+	// t.Run("delete hello service and return no error", func(t *testing.T) {
+	// 	test.serviceDelete(t, "hello")
+	// })
+
+	t.Run("delete three revisions with one revision a nonexistent", func(t *testing.T) {
+		// increase count to 2 revisions
+		test.serviceUpdate(t, "hello", []string{"--env", "TARGET=kn", "--port", "8888"})
+
+		existRevision1 := test.findRevisionByGeneration(t, "hello", 1)
+		existRevision2 := test.findRevisionByGeneration(t, "hello", 2)
+		nonexistRevision := "hello-nonexist"
+
+		test.revisionMultipleDelete(t, []string{existRevision1, existRevision2, nonexistRevision})
 	})
 
 	t.Run("delete hello service and return no error", func(t *testing.T) {
@@ -76,18 +93,34 @@ func (test *e2eTest) revisionListWithService(t *testing.T, serviceNames ...strin
 	}
 }
 
-func (test *e2eTest) revisionDelete(t *testing.T, serviceName string) {
-	revName := test.findRevision(t, serviceName)
-
+func (test *e2eTest) revisionDelete(t *testing.T, revName string) {
 	out, err := test.kn.RunWithOpts([]string{"revision", "delete", revName}, runOpts{})
 	assert.NilError(t, err)
 
 	assert.Check(t, util.ContainsAll(out, "Revision", revName, "deleted", "namespace", test.kn.namespace))
 }
 
-func (test *e2eTest) revisionDescribeWithPrintFlags(t *testing.T, serviceName string) {
-	revName := test.findRevision(t, serviceName)
+func (test *e2eTest) revisionMultipleDelete(t *testing.T, revisionNames []string) {
+	existRevision1 := revisionNames[0]
+	existRevision2 := revisionNames[1]
+	nonexistRevision := revisionNames[2]
+	out, err := test.kn.RunWithOpts([]string{"revision", "list"}, runOpts{NoNamespace: false})
+	assert.NilError(t, err)
+	assert.Check(t, strings.Contains(out, existRevision1), "Required revision1 does not exist")
+	assert.Check(t, strings.Contains(out, existRevision2), "Required revision2 does not exist")
+	assert.Check(t, !strings.Contains(out, nonexistRevision), "Nonexistent revision does exist")
 
+	out, err = test.kn.RunWithOpts([]string{"revision", "delete", existRevision1, existRevision2, nonexistRevision}, runOpts{NoNamespace: false})
+
+	expectedSuccess1 := fmt.Sprintf(`Revision '%s' successfully deleted in namespace '%s'`, existRevision1, test.kn.namespace)
+	expectedSuccess2 := fmt.Sprintf(`Revision '%s' successfully deleted in namespace '%s'`, existRevision2, test.kn.namespace)
+	expectedErr := fmt.Sprintf(`revisions.serving.knative.dev "%s" not found.`, nonexistRevision)
+	assert.Check(t, strings.Contains(out, expectedSuccess1), "Failed to get 'successfully deleted' first revision message")
+	assert.Check(t, strings.Contains(out, expectedSuccess2), "Failed to get 'successfully deleted' second revision message")
+	assert.Check(t, strings.Contains(out, expectedErr), "Failed to get 'not found' error")
+}
+
+func (test *e2eTest) revisionDescribeWithPrintFlags(t *testing.T, revName string) {
 	out, err := test.kn.RunWithOpts([]string{"revision", "describe", revName, "-o=name"}, runOpts{})
 	assert.NilError(t, err)
 

--- a/test/e2e/revision_test.go
+++ b/test/e2e/revision_test.go
@@ -55,10 +55,6 @@ func TestRevision(t *testing.T) {
 		test.revisionDelete(t, revName)
 	})
 
-	// t.Run("delete hello service and return no error", func(t *testing.T) {
-	// 	test.serviceDelete(t, "hello")
-	// })
-
 	t.Run("delete three revisions with one revision a nonexistent", func(t *testing.T) {
 		// increase count to 2 revisions
 		test.serviceUpdate(t, "hello", []string{"--env", "TARGET=kn", "--port", "8888"})
@@ -112,12 +108,17 @@ func (test *e2eTest) revisionMultipleDelete(t *testing.T, revisionNames []string
 
 	out, err = test.kn.RunWithOpts([]string{"revision", "delete", existRevision1, existRevision2, nonexistRevision}, runOpts{NoNamespace: false})
 
-	expectedSuccess1 := fmt.Sprintf(`Revision '%s' successfully deleted in namespace '%s'`, existRevision1, test.kn.namespace)
-	expectedSuccess2 := fmt.Sprintf(`Revision '%s' successfully deleted in namespace '%s'`, existRevision2, test.kn.namespace)
-	expectedErr := fmt.Sprintf(`revisions.serving.knative.dev "%s" not found.`, nonexistRevision)
-	assert.Check(t, strings.Contains(out, expectedSuccess1), "Failed to get 'successfully deleted' first revision message")
-	assert.Check(t, strings.Contains(out, expectedSuccess2), "Failed to get 'successfully deleted' second revision message")
-	assert.Check(t, strings.Contains(out, expectedErr), "Failed to get 'not found' error")
+	// expectedSuccess1 := fmt.Sprintf(`Revision '%s' successfully deleted in namespace '%s'`, existRevision1, test.kn.namespace)
+	// expectedSuccess2 := fmt.Sprintf(`Revision '%s' successfully deleted in namespace '%s'`, existRevision2, test.kn.namespace)
+	// expectedErr := fmt.Sprintf(`revisions.serving.knative.dev "%s" not found.`, nonexistRevision)
+
+	// assert.Check(t, strings.Contains(out, expectedSuccess1), "Failed to get 'successfully deleted' first revision message")
+	// assert.Check(t, strings.Contains(out, expectedSuccess2), "Failed to get 'successfully deleted' second revision message")
+	// assert.Check(t, strings.Contains(out, expectedErr), "Failed to get 'not found' error")
+
+	assert.Check(t, util.ContainsAll(out, "Revision", existRevision1, "successfully", "deleted", "namespace", test.kn.namespace), "Failed to get 'successfully deleted' first revision message")
+	assert.Check(t, util.ContainsAll(out, "Revision", existRevision2, "successfully", "deleted", "namespace", test.kn.namespace), "Failed to get 'successfully deleted' second revision message")
+	assert.Check(t, util.ContainsAll(out, "revisions.serving.knative.dev", nonexistRevision, "not found"), "Failed to get 'not found' error")
 }
 
 func (test *e2eTest) revisionDescribeWithPrintFlags(t *testing.T, revName string) {

--- a/test/e2e/revision_test.go
+++ b/test/e2e/revision_test.go
@@ -108,8 +108,8 @@ func (test *e2eTest) revisionMultipleDelete(t *testing.T, revisionNames []string
 
 	out, err = test.kn.RunWithOpts([]string{"revision", "delete", existRevision1, existRevision2, nonexistRevision}, runOpts{NoNamespace: false})
 
-	assert.Check(t, util.ContainsAll(out, "Revision", existRevision1, "successfully", "deleted", "namespace", test.kn.namespace), "Failed to get 'successfully deleted' first revision message")
-	assert.Check(t, util.ContainsAll(out, "Revision", existRevision2, "successfully", "deleted", "namespace", test.kn.namespace), "Failed to get 'successfully deleted' second revision message")
+	assert.Check(t, util.ContainsAll(out, "Revision", existRevision1, "deleted", "namespace", test.kn.namespace), "Failed to get 'deleted' first revision message")
+	assert.Check(t, util.ContainsAll(out, "Revision", existRevision2, "deleted", "namespace", test.kn.namespace), "Failed to get 'deleted' second revision message")
 	assert.Check(t, util.ContainsAll(out, "revisions.serving.knative.dev", nonexistRevision, "not found"), "Failed to get 'not found' error")
 }
 

--- a/test/e2e/revision_test.go
+++ b/test/e2e/revision_test.go
@@ -99,6 +99,8 @@ func (test *e2eTest) revisionDelete(t *testing.T, revName string) {
 func (test *e2eTest) revisionMultipleDelete(t *testing.T, revisionNames []string) {
 	existRevision1 := revisionNames[0]
 	existRevision2 := revisionNames[1]
+	nonexistRevision := revisionNames[2]
+
 	out, err := test.kn.RunWithOpts([]string{"revision", "list"}, runOpts{NoNamespace: false})
 	assert.NilError(t, err)
 	assert.Check(t, strings.Contains(out, existRevision1), "Required revision1 does not exist")


### PR DESCRIPTION
Addresses #317 


Release note:

- 🧽 Support multiple revision names on `kn revision delete`