### PR TITLE
feature(service update): Add generic mechanism to include retries on conflicts

### DIFF
--- a/pkg/kn/commands/service/service_update_mock_test.go
+++ b/pkg/kn/commands/service/service_update_mock_test.go
@@ -25,7 +25,6 @@ import (
 
 	clientserving "knative.dev/client/pkg/serving"
 	clientservingv1 "knative.dev/client/pkg/serving/v1"
-
 	"knative.dev/client/pkg/util"
 )
 
@@ -52,10 +51,7 @@ func TestServiceUpdateEnvMock(t *testing.T) {
 	template.Annotations = map[string]string{clientserving.UserImageAnnotationKey: "gcr.io/foo/bar:baz"}
 
 	r := client.Recorder()
-	r.GetService("foo", nil, errors.NewNotFound(servingv1.Resource("service"), "foo"))
-	r.CreateService(service, nil)
-	r.GetService("foo", service, nil)
-	r.UpdateService(updated, nil)
+	recordServiceUpdateWithSuccess(r, "foo", service, updated)
 
 	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz", "-e", "a=mouse", "--env", "b=cookie", "--env=empty", "--no-wait", "--revision-name=")
 	assert.NilError(t, err)
@@ -100,10 +96,7 @@ func TestServiceUpdateAnnotationsMock(t *testing.T) {
 	}
 
 	r := client.Recorder()
-	r.GetService(svcName, nil, errors.NewNotFound(servingv1.Resource("service"), svcName))
-	r.CreateService(newService, nil)
-	r.GetService(svcName, newService, nil)
-	r.UpdateService(updatedService, nil)
+	recordServiceUpdateWithSuccess(r, svcName, newService, updatedService)
 
 	output, err := executeServiceCommand(client,
 		"create", svcName, "--image", "gcr.io/foo/bar:baz",
@@ -125,6 +118,13 @@ func TestServiceUpdateAnnotationsMock(t *testing.T) {
 	assert.Assert(t, util.ContainsAll(output, "updated", svcName, "default"))
 
 	r.Validate()
+}
+
+func recordServiceUpdateWithSuccess(r *clientservingv1.ServingRecorder, svcName string, newService *servingv1.Service, updatedService *servingv1.Service) {
+	r.GetService(svcName, nil, errors.NewNotFound(servingv1.Resource("service"), svcName))
+	r.CreateService(newService, nil)
+	r.GetService(svcName, newService, nil)
+	r.UpdateService(updatedService, nil)
 }
 
 func TestServiceUpdateEnvFromAddingWithConfigMap(t *testing.T) {
@@ -170,10 +170,7 @@ func TestServiceUpdateEnvFromAddingWithConfigMap(t *testing.T) {
 	}
 
 	r := client.Recorder()
-	r.GetService(svcName, nil, errors.NewNotFound(servingv1.Resource("service"), svcName))
-	r.CreateService(newService, nil)
-	r.GetService(svcName, newService, nil)
-	r.UpdateService(updatedService, nil)
+	recordServiceUpdateWithSuccess(r, svcName, newService, updatedService)
 
 	output, err := executeServiceCommand(client,
 		"create", svcName, "--image", "gcr.io/foo/bar:baz",
@@ -275,10 +272,7 @@ func TestServiceUpdateEnvFromRemovalWithConfigMap(t *testing.T) {
 	template.Spec.Containers[0].EnvFrom = nil
 
 	r := client.Recorder()
-	r.GetService(svcName, nil, errors.NewNotFound(servingv1.Resource("service"), svcName))
-	r.CreateService(newService, nil)
-	r.GetService(svcName, newService, nil)
-	r.UpdateService(updatedService1, nil)
+	recordServiceUpdateWithSuccess(r, svcName, newService, updatedService1)
 	r.GetService(svcName, updatedService1, nil)
 	//r.UpdateService(updatedService2, nil) // since an error happens, update is not triggered here
 	r.GetService(svcName, updatedService2, nil)
@@ -454,10 +448,7 @@ func TestServiceUpdateEnvFromExistingWithConfigMap(t *testing.T) {
 	}
 
 	r := client.Recorder()
-	r.GetService(svcName, nil, errors.NewNotFound(servingv1.Resource("service"), svcName))
-	r.CreateService(newService, nil)
-	r.GetService(svcName, newService, nil)
-	r.UpdateService(updatedService, nil)
+	recordServiceUpdateWithSuccess(r, svcName, newService, updatedService)
 
 	output, err := executeServiceCommand(client,
 		"create", svcName, "--image", "gcr.io/foo/bar:baz",
@@ -523,10 +514,7 @@ func TestServiceUpdateEnvFromAddingWithSecret(t *testing.T) {
 	}
 
 	r := client.Recorder()
-	r.GetService(svcName, nil, errors.NewNotFound(servingv1.Resource("service"), svcName))
-	r.CreateService(newService, nil)
-	r.GetService(svcName, newService, nil)
-	r.UpdateService(updatedService, nil)
+	recordServiceUpdateWithSuccess(r, svcName, newService, updatedService)
 
 	output, err := executeServiceCommand(client,
 		"create", svcName, "--image", "gcr.io/foo/bar:baz",
@@ -733,10 +721,7 @@ func TestServiceUpdateEnvFromExistingWithSecret(t *testing.T) {
 	}
 
 	r := client.Recorder()
-	r.GetService(svcName, nil, errors.NewNotFound(servingv1.Resource("service"), svcName))
-	r.CreateService(newService, nil)
-	r.GetService(svcName, newService, nil)
-	r.UpdateService(updatedService, nil)
+	recordServiceUpdateWithSuccess(r, svcName, newService, updatedService)
 
 	output, err := executeServiceCommand(client,
 		"create", svcName, "--image", "gcr.io/foo/bar:baz",
@@ -835,10 +820,7 @@ func TestServiceUpdateWithAddingVolume(t *testing.T) {
 	}
 
 	r := client.Recorder()
-	r.GetService(svcName, nil, errors.NewNotFound(servingv1.Resource("service"), svcName))
-	r.CreateService(newService, nil)
-	r.GetService(svcName, newService, nil)
-	r.UpdateService(updatedService, nil)
+	recordServiceUpdateWithSuccess(r, svcName, newService, updatedService)
 
 	output, err := executeServiceCommand(client,
 		"create", svcName, "--image", "gcr.io/foo/bar:baz",
@@ -937,10 +919,7 @@ func TestServiceUpdateWithUpdatingVolume(t *testing.T) {
 	}
 
 	r := client.Recorder()
-	r.GetService(svcName, nil, errors.NewNotFound(servingv1.Resource("service"), svcName))
-	r.CreateService(newService, nil)
-	r.GetService(svcName, newService, nil)
-	r.UpdateService(updatedService, nil)
+	recordServiceUpdateWithSuccess(r, svcName, newService, updatedService)
 
 	output, err := executeServiceCommand(client,
 		"create", svcName, "--image", "gcr.io/foo/bar:baz",
@@ -1041,10 +1020,7 @@ func TestServiceUpdateWithRemovingVolume(t *testing.T) {
 	}
 
 	r := client.Recorder()
-	r.GetService(svcName, nil, errors.NewNotFound(servingv1.Resource("service"), svcName))
-	r.CreateService(newService, nil)
-	r.GetService(svcName, newService, nil)
-	r.UpdateService(updatedService, nil)
+	recordServiceUpdateWithSuccess(r, svcName, newService, updatedService)
 
 	output, err := executeServiceCommand(client,
 		"create", svcName, "--image", "gcr.io/foo/bar:baz",
@@ -1119,10 +1095,7 @@ func TestServiceUpdateWithAddingMount(t *testing.T) {
 	}
 
 	r := client.Recorder()
-	r.GetService(svcName, nil, errors.NewNotFound(servingv1.Resource("service"), svcName))
-	r.CreateService(newService, nil)
-	r.GetService(svcName, newService, nil)
-	r.UpdateService(updatedService, nil)
+	recordServiceUpdateWithSuccess(r, svcName, newService, updatedService)
 
 	output, err := executeServiceCommand(client,
 		"create", svcName, "--image", "gcr.io/foo/bar:baz",
@@ -1227,10 +1200,7 @@ func TestServiceUpdateWithUpdatingMount(t *testing.T) {
 	}
 
 	r := client.Recorder()
-	r.GetService(svcName, nil, errors.NewNotFound(servingv1.Resource("service"), svcName))
-	r.CreateService(newService, nil)
-	r.GetService(svcName, newService, nil)
-	r.UpdateService(updatedService, nil)
+	recordServiceUpdateWithSuccess(r, svcName, newService, updatedService)
 
 	output, err := executeServiceCommand(client,
 		"create", svcName, "--image", "gcr.io/foo/bar:baz",

--- a/pkg/kn/commands/service/update.go
+++ b/pkg/kn/commands/service/update.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"knative.dev/client/pkg/kn/commands/flags"
 	"knative.dev/client/pkg/kn/traffic"
@@ -74,15 +73,12 @@ func NewServiceUpdateCommand(p *commands.KnParams) *cobra.Command {
 				return err
 			}
 
-			var retries = 0
-			for {
-				name := args[0]
-				service, err := client.GetService(name)
-				if err != nil {
-					return err
-				}
-				service = service.DeepCopy()
-				latestRevisionBeforeUpdate := service.Status.LatestReadyRevisionName
+			// Use to store the latest revision name
+			var latestRevisionBeforeUpdate string
+			name := args[0]
+
+			updateFunc := func(service *servingv1.Service) (*servingv1.Service, error) {
+				latestRevisionBeforeUpdate = service.Status.LatestReadyRevisionName
 				var baseRevision *servingv1.Revision
 				if !cmd.Flags().Changed("image") && editFlags.LockToDigest {
 					baseRevision, err = client.GetBaseRevision(service)
@@ -92,48 +88,46 @@ func NewServiceUpdateCommand(p *commands.KnParams) *cobra.Command {
 				}
 				err = editFlags.Apply(service, baseRevision, cmd)
 				if err != nil {
-					return err
+					return nil, err
 				}
 
 				if trafficFlags.Changed(cmd) {
 					traffic, err := traffic.Compute(cmd, service.Spec.Traffic, &trafficFlags)
 					if err != nil {
-						return err
+						return nil, err
 					}
 
 					service.Spec.Traffic = traffic
 				}
+				return service, nil
+			}
 
-				err = client.UpdateService(service)
+			// Do the actual update with retry in case of conflicts
+			err = client.UpdateServiceWithRetry(name, updateFunc, MaxUpdateRetries)
+			if err != nil {
+				return err
+			}
+
+			out := cmd.OutOrStdout()
+			//TODO: deprecated condition should be once --async is gone
+			if !waitFlags.Async && !waitFlags.NoWait {
+				fmt.Fprintf(out, "Updating Service '%s' in namespace '%s':\n", args[0], namespace)
+				fmt.Fprintln(out, "")
+				err := waitForService(client, name, out, waitFlags.TimeoutInSeconds)
 				if err != nil {
-					// Retry to update when a resource version conflict exists
-					if apierrors.IsConflict(err) && retries < MaxUpdateRetries {
-						retries++
-						continue
-					}
 					return err
 				}
-
-				out := cmd.OutOrStdout()
-				//TODO: deprecated condition should be once --async is gone
-				if !waitFlags.Async && !waitFlags.NoWait {
-					fmt.Fprintf(out, "Updating Service '%s' in namespace '%s':\n", args[0], namespace)
-					fmt.Fprintln(out, "")
-					err := waitForService(client, name, out, waitFlags.TimeoutInSeconds)
-					if err != nil {
-						return err
-					}
-					fmt.Fprintln(out, "")
-					return showUrl(client, name, latestRevisionBeforeUpdate, "updated", out)
-				} else {
-					if waitFlags.Async {
-						fmt.Fprintf(out, "\nWARNING: flag --async is deprecated and going to be removed in future release, please use --no-wait instead.\n\n")
-					}
-					fmt.Fprintf(out, "Service '%s' updated in namespace '%s'.\n", args[0], namespace)
+				fmt.Fprintln(out, "")
+				return showUrl(client, name, latestRevisionBeforeUpdate, "updated", out)
+			} else {
+				if waitFlags.Async {
+					fmt.Fprintf(out, "\nWARNING: flag --async is deprecated and going to be removed in future release, please use --no-wait instead.\n\n")
 				}
-
-				return nil
+				fmt.Fprintf(out, "Service '%s' updated in namespace '%s'.\n", args[0], namespace)
 			}
+
+			return nil
+
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return preCheck(cmd, args)

--- a/pkg/serving/v1/client_mock.go
+++ b/pkg/serving/v1/client_mock.go
@@ -100,6 +100,16 @@ func (c *MockKnServingClient) UpdateService(service *servingv1.Service) error {
 	return mock.ErrorOrNil(call.Result[0])
 }
 
+// Update the given service with retries
+func (sr *ServingRecorder) UpdateServiceWithRetry(name string, serviceFunc interface{}, retries int, err error) {
+	sr.r.Add("UpdateServiceWithRetry", []interface{}{name, serviceFunc, retries}, []interface{}{err})
+}
+
+func (c *MockKnServingClient) UpdateServiceWithRetry(name string, updateFunc serviceUpdateFunc, maxRetry int) error {
+	call := c.recorder.r.VerifyCall("UpdateServiceWithRetry", name, updateFunc, maxRetry)
+	return mock.ErrorOrNil(call.Result[0])
+}
+
 // Delete a service by name
 func (sr *ServingRecorder) DeleteService(name interface{}, err error) {
 	sr.r.Add("DeleteService", []interface{}{name}, []interface{}{err})

--- a/pkg/serving/v1/client_mock.go
+++ b/pkg/serving/v1/client_mock.go
@@ -100,14 +100,9 @@ func (c *MockKnServingClient) UpdateService(service *servingv1.Service) error {
 	return mock.ErrorOrNil(call.Result[0])
 }
 
-// Update the given service with retries
-func (sr *ServingRecorder) UpdateServiceWithRetry(name string, serviceFunc interface{}, retries int, err error) {
-	sr.r.Add("UpdateServiceWithRetry", []interface{}{name, serviceFunc, retries}, []interface{}{err})
-}
-
+// Delegate to shared retry method
 func (c *MockKnServingClient) UpdateServiceWithRetry(name string, updateFunc serviceUpdateFunc, maxRetry int) error {
-	call := c.recorder.r.VerifyCall("UpdateServiceWithRetry", name, updateFunc, maxRetry)
-	return mock.ErrorOrNil(call.Result[0])
+	return updateServiceWithRetry(c, name, updateFunc, maxRetry)
 }
 
 // Delete a service by name


### PR DESCRIPTION
Move the retry logic for retrying in case of a resource conflict into the KnClient.

This is wip (e.g. unit tests are not working yet), but demonstrate how to move the retry logic into the client. If we decided that its worth the effort, I will update the tests, too.

/hold