### PR TITLE
Add description for PingSource for 'kn source list-types'

### DIFF
--- a/pkg/kn/commands/source/human_readable_flags.go
+++ b/pkg/kn/commands/source/human_readable_flags.go
@@ -26,10 +26,11 @@ import (
 )
 
 var sourceTypeDescription = map[string]string{
-	"ApiServerSource": "Kubernetes API Server events source",
-	"ContainerSource": "Container events source",
-	"CronJobSource":   "CronJob events source",
-	"SinkBinding":     "Binding Pattern for ContainerSource",
+	"ApiServerSource": "Watch and send Kubernetes API events to a sink",
+	"ContainerSource": "Connect a custom container image to a sink",
+	"CronJobSource":   "Send periodically constant data to a sink",
+	"SinkBinding":     "Binding for connecting a PodSpecable to a sink",
+	"PingSource":      "Send periodically ping events to a sink",
 }
 
 func getSourceTypeDescription(kind string) string {


### PR DESCRIPTION
## Proposed Changes
 - also update the description for other source types

```
./kn source list-types 
TYPE              NAME                                            DESCRIPTION
ApiServerSource   apiserversources.sources.eventing.knative.dev   Watch and send Kubernetes API events to a sink
ApiServerSource   apiserversources.sources.knative.dev            Watch and send Kubernetes API events to a sink
ContainerSource   containersources.sources.eventing.knative.dev   Connect a custom container image to a sink
CronJobSource     cronjobsources.sources.eventing.knative.dev     Send periodically constant data to a sink
PingSource        pingsources.sources.knative.dev                 Send periodically ping events to a sink
SinkBinding       sinkbindings.sources.eventing.knative.dev       Binding for connecting a PodSpecable to a sink
SinkBinding       sinkbindings.sources.knative.dev                Binding for connecting a PodSpecable to a sink
```