### PR TITLE
fix(help): initialize default help cmd early

### DIFF
--- a/pkg/kn/core/root.go
+++ b/pkg/kn/core/root.go
@@ -152,6 +152,9 @@ func NewKnCommand(params ...commands.KnParams) *cobra.Command {
 	rootCmd.AddCommand(source.NewSourceCommand(p))
 	rootCmd.AddCommand(trigger.NewTriggerCommand(p))
 
+	// Initialize default `help` cmd early to prevent unknown command errors
+	rootCmd.InitDefaultHelpCmd()
+
 	// Deal with empty and unknown sub command groups
 	EmptyAndUnknownSubCommands(rootCmd)
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
The default behaviour of Cobra library is to add default `help` cmd as late as possible to allow modifications. However, in case of `kn` initialization of help is superseded by [plugin parsing](https://github.com/knative/client/blob/7573a07a249cad63262903c722b2f914be340266/pkg/kn/core/root.go#L85) and fails with `unknown command` error.

```
➜  client git:(issue-533) kn help
Error: unknown command 'help' 
Run 'kn --help' for usage.
```

This change brings back `help` as a command and enables usage of both `kn help` and `kn help <sub-command>`.

  


## Proposed Changes

* Add early initialization of default help command.



<!--
Release Note:

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behaviour
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example.

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->
