### PR TITLE
feat(XDG home): use XDG_CONFIG_HOME as default config location

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,13 +42,13 @@ There are a set of configuration parameters you can setup to better customize `k
 
 ### Location
 
-The default location `kn` looks for config is under the home directory of the user at `$HOME/.kn/config.yaml`. It is not created for you as part of the `kn` installation. You can create this file elsewhere and use the `--config` flag to specify its path.
+The default location `kn` looks for config is under the home directory of the user at `$HOME/.config/kn/config.yaml`. It is not created for you as part of the `kn` installation. You can create this file elsewhere and use the `--config` flag to specify its path.
 
 ### Options
 
 Below are the options you can specify in the `kn` config file.
 
-1. `pluginsDir` which is the same as the persistent flag `--plugins-dir` and specifies the kn plugins directory. It defaults to: `~/.kn/plugins`. By using the persistent flag (when you issue a command) or by specifying the value in the `kn` config, a user can select which directory to find `kn` plugins. It can be any directory that is visible to the user.
+1. `pluginsDir` which is the same as the persistent flag `--plugins-dir` and specifies the kn plugins directory. It defaults to: `~/.config/kn/plugins`. By using the persistent flag (when you issue a command) or by specifying the value in the `kn` config, a user can select which directory to find `kn` plugins. It can be any directory that is visible to the user.
 
 2. `lookupPluginsInPath` which is the same as the persistent flag `--lookup-plugins-in-path` and specficies if `kn` should look for plugins anywhere in the specified `PATH` environment variable. This is a boolean configuration option and the default value is `false`.
 
@@ -58,13 +58,13 @@ Below are the options you can specify in the `kn` config file.
     3. `version`: The version of Kubernetes resources.
     4. `resource`: The plural name of Kubernetes resources (for example: services). 
 
-For example, the following `kn` config will look for `kn` plugins in the user's `PATH` and also execute plugin in `~/.kn/plugins`.
+For example, the following `kn` config will look for `kn` plugins in the user's `PATH` and also execute plugin in `~/kn/.config/plugins`.
 It also defines a sink prefix `myprefix` which refers to `brokers` in `eventing.knative.dev/v1alpha1`. With this configuration, you can use `myprefix:default` to describe a Broker `default` in `kn` command line.
 
 ```bash
-cat ~/.kn/config.yaml
+cat ~/.config/kn/config.yaml
 lookupPluginsInPath: true
-pluginsdir: ~/.kn/plugins
+pluginsdir: ~/.config/kn/plugins
 sink:
 - prefix: myprefix
   group: eventing.knative.dev

--- a/docs/cmd/kn.md
+++ b/docs/cmd/kn.md
@@ -12,12 +12,12 @@ Manage your Knative building blocks:
 ### Options
 
 ```
-      --config string        kn config file (default is $HOME/.kn/config.yaml)
+      --config string        kn config file (default is ~/.config/kn/config.yaml)
   -h, --help                 help for kn
-      --kubeconfig string    kubectl config file (default is $HOME/.kube/config)
+      --kubeconfig string    kubectl config file (default is ~/.kube/config)
       --log-http             log http traffic
       --lookup-plugins       look for kn plugins in $PATH
-      --plugins-dir string   kn plugins directory (default "~/.kn/plugins")
+      --plugins-dir string   kn plugins directory (default "~/.config/kn/plugins")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_completion.md
+++ b/docs/cmd/kn_completion.md
@@ -36,8 +36,8 @@ kn completion [SHELL] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_plugin.md
+++ b/docs/cmd/kn_plugin.md
@@ -18,14 +18,14 @@ kn plugin [flags]
 ```
   -h, --help                 help for plugin
       --lookup-plugins       look for kn plugins in $PATH
-      --plugins-dir string   kn plugins directory (default "~/.kn/plugins")
+      --plugins-dir string   kn plugins directory (default "~/.config/kn/plugins")
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_plugin_list.md
+++ b/docs/cmd/kn_plugin_list.md
@@ -9,7 +9,7 @@ List all installed plugins.
 Available plugins are those that are:
 - executable
 - begin with "kn-"
-- Kn's plugin directory ~/.kn/plugins
+- Kn's plugin directory ~/.config/kn/plugins
 - Anywhere in the execution $PATH (if lookupInPath config variable is enabled)
 
 ```
@@ -22,15 +22,15 @@ kn plugin list [flags]
   -h, --help                 help for list
       --lookup-plugins       look for kn plugins in $PATH
       --name-only            If true, display only the binary name of each plugin, rather than its full path
-      --plugins-dir string   kn plugins directory (default "~/.kn/plugins")
+      --plugins-dir string   kn plugins directory (default "~/.config/kn/plugins")
       --verbose              verbose output
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_revision.md
+++ b/docs/cmd/kn_revision.md
@@ -19,8 +19,8 @@ kn revision [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_revision_delete.md
+++ b/docs/cmd/kn_revision_delete.md
@@ -28,8 +28,8 @@ kn revision delete NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_revision_describe.md
+++ b/docs/cmd/kn_revision_describe.md
@@ -24,8 +24,8 @@ kn revision describe NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_revision_list.md
+++ b/docs/cmd/kn_revision_list.md
@@ -43,8 +43,8 @@ kn revision list [name] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_route.md
+++ b/docs/cmd/kn_route.md
@@ -19,8 +19,8 @@ kn route [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_route_describe.md
+++ b/docs/cmd/kn_route_describe.md
@@ -24,8 +24,8 @@ kn route describe NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_route_list.md
+++ b/docs/cmd/kn_route_list.md
@@ -39,8 +39,8 @@ kn route list NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_service.md
+++ b/docs/cmd/kn_service.md
@@ -19,8 +19,8 @@ kn service [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -77,8 +77,8 @@ kn service create NAME --image IMAGE [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_service_delete.md
+++ b/docs/cmd/kn_service_delete.md
@@ -34,8 +34,8 @@ kn service delete NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_service_describe.md
+++ b/docs/cmd/kn_service_describe.md
@@ -24,8 +24,8 @@ kn service describe NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_service_list.md
+++ b/docs/cmd/kn_service_list.md
@@ -39,8 +39,8 @@ kn service list [name] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -75,8 +75,8 @@ kn service update NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_source.md
+++ b/docs/cmd/kn_source.md
@@ -19,8 +19,8 @@ kn source [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_source_apiserver.md
+++ b/docs/cmd/kn_source_apiserver.md
@@ -19,8 +19,8 @@ kn source apiserver [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_source_apiserver_create.md
+++ b/docs/cmd/kn_source_apiserver_create.md
@@ -35,8 +35,8 @@ kn source apiserver create NAME --resource RESOURCE --service-account ACCOUNTNAM
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_source_apiserver_delete.md
+++ b/docs/cmd/kn_source_apiserver_delete.md
@@ -28,8 +28,8 @@ kn source apiserver delete NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_source_apiserver_describe.md
+++ b/docs/cmd/kn_source_apiserver_describe.md
@@ -29,8 +29,8 @@ kn source apiserver describe NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_source_apiserver_list.md
+++ b/docs/cmd/kn_source_apiserver_list.md
@@ -36,8 +36,8 @@ kn source apiserver list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_source_apiserver_update.md
+++ b/docs/cmd/kn_source_apiserver_update.md
@@ -35,8 +35,8 @@ kn source apiserver update NAME --resource RESOURCE --service-account ACCOUNTNAM
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_source_binding.md
+++ b/docs/cmd/kn_source_binding.md
@@ -19,8 +19,8 @@ kn source binding [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_source_binding_create.md
+++ b/docs/cmd/kn_source_binding_create.md
@@ -31,8 +31,8 @@ kn source binding create NAME --subject SCHEDULE --sink SINK --ce-override KEY=V
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_source_binding_delete.md
+++ b/docs/cmd/kn_source_binding_delete.md
@@ -28,8 +28,8 @@ kn source binding delete NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_source_binding_describe.md
+++ b/docs/cmd/kn_source_binding_describe.md
@@ -29,8 +29,8 @@ kn source binding describe NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_source_binding_list.md
+++ b/docs/cmd/kn_source_binding_list.md
@@ -36,8 +36,8 @@ kn source binding list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_source_binding_update.md
+++ b/docs/cmd/kn_source_binding_update.md
@@ -31,8 +31,8 @@ kn source binding update NAME --subject SCHEDULE --sink SINK --ce-override OVERR
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_source_cronjob.md
+++ b/docs/cmd/kn_source_cronjob.md
@@ -19,8 +19,8 @@ kn source cronjob [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_source_cronjob_create.md
+++ b/docs/cmd/kn_source_cronjob_create.md
@@ -31,8 +31,8 @@ kn source cronjob create NAME --schedule SCHEDULE --sink SINK --data DATA [flags
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_source_cronjob_delete.md
+++ b/docs/cmd/kn_source_cronjob_delete.md
@@ -28,8 +28,8 @@ kn source cronjob delete NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_source_cronjob_describe.md
+++ b/docs/cmd/kn_source_cronjob_describe.md
@@ -29,8 +29,8 @@ kn source cronjob describe NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_source_cronjob_list.md
+++ b/docs/cmd/kn_source_cronjob_list.md
@@ -36,8 +36,8 @@ kn source cronjob list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_source_cronjob_update.md
+++ b/docs/cmd/kn_source_cronjob_update.md
@@ -31,8 +31,8 @@ kn source cronjob update NAME --schedule SCHEDULE --sink SERVICE --data DATA [fl
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_source_list-types.md
+++ b/docs/cmd/kn_source_list-types.md
@@ -35,8 +35,8 @@ kn source list-types [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_trigger.md
+++ b/docs/cmd/kn_trigger.md
@@ -19,8 +19,8 @@ kn trigger [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_trigger_create.md
+++ b/docs/cmd/kn_trigger_create.md
@@ -31,8 +31,8 @@ kn trigger create NAME --broker BROKER --filter KEY=VALUE --sink SINK [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_trigger_delete.md
+++ b/docs/cmd/kn_trigger_delete.md
@@ -28,8 +28,8 @@ kn trigger delete NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_trigger_describe.md
+++ b/docs/cmd/kn_trigger_describe.md
@@ -29,8 +29,8 @@ kn trigger describe NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_trigger_list.md
+++ b/docs/cmd/kn_trigger_list.md
@@ -36,8 +36,8 @@ kn trigger list [name] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_trigger_update.md
+++ b/docs/cmd/kn_trigger_update.md
@@ -38,8 +38,8 @@ kn trigger update NAME --filter KEY=VALUE --sink SINK [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/docs/cmd/kn_version.md
+++ b/docs/cmd/kn_version.md
@@ -19,8 +19,8 @@ kn version [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
+      --config string       kn config file (default is ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl config file (default is ~/.kube/config)
       --log-http            log http traffic
 ```
 

--- a/pkg/kn/commands/plugin/list.go
+++ b/pkg/kn/commands/plugin/list.go
@@ -42,7 +42,7 @@ func NewPluginListCommand(p *commands.KnParams) *cobra.Command {
 Available plugins are those that are:
 - executable
 - begin with "kn-"
-- Kn's plugin directory ~/.kn/plugins
+- Kn's plugin directory ` + commands.Cfg.DefaultPluginDir + `
 - Anywhere in the execution $PATH (if lookupInPath config variable is enabled)`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listPlugins(cmd, plFlags)

--- a/pkg/kn/commands/plugin/plugin.go
+++ b/pkg/kn/commands/plugin/plugin.go
@@ -40,7 +40,7 @@ Please refer to the documentation and examples for more information about how wr
 
 // AddPluginFlags plugins-dir and lookup-plugins to cmd
 func AddPluginFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&commands.Cfg.PluginsDir, "plugins-dir", "~/.kn/plugins", "kn plugins directory")
+	cmd.Flags().StringVar(&commands.Cfg.PluginsDir, "plugins-dir", commands.Cfg.DefaultPluginDir, "kn plugins directory")
 	cmd.Flags().BoolVar(commands.Cfg.LookupPlugins, "lookup-plugins", false, "look for kn plugins in $PATH")
 }
 
@@ -49,6 +49,6 @@ func BindPluginsFlagToViper(cmd *cobra.Command) {
 	viper.BindPFlag("plugins-dir", cmd.Flags().Lookup("plugins-dir"))
 	viper.BindPFlag("lookup-plugins", cmd.Flags().Lookup("lookup-plugins"))
 
-	viper.SetDefault("plugins-dir", "~/.kn/plugins")
+	viper.SetDefault("plugins-dir", commands.Cfg.DefaultPluginDir)
 	viper.SetDefault("lookup-plugins", false)
 }

--- a/pkg/kn/commands/plugin/plugin_test.go
+++ b/pkg/kn/commands/plugin/plugin_test.go
@@ -38,10 +38,10 @@ Available Commands:
 Flags:
   -h, --help                     help for plugin
       --lookup-plugins           look for kn plugins in $PATH
-      --plugins-dir string       kn plugins directory (default "~/.kn/plugins")
+      --plugins-dir string       kn plugins directory (default "~/.config/kn/plugins")
 
 Global Flags:
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
+      --config string       kn config file (default is $HOME/.config/kn/config.yaml)
       --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
 
 Use "kn plugin [command] --help" for more information about a command.`

--- a/pkg/kn/commands/testing_helper.go
+++ b/pkg/kn/commands/testing_helper.go
@@ -177,16 +177,16 @@ Eventing: Manage event subscriptions and channels. Connect up event sources.`,
 	if params.Output != nil {
 		rootCmd.SetOutput(params.Output)
 	}
-	rootCmd.PersistentFlags().StringVar(&CfgFile, "config", "", "config file (default is $HOME/.kn/config.yaml)")
+	rootCmd.PersistentFlags().StringVar(&CfgFile, "config", "", "config file (default is ~/.config/kn/config.yaml)")
 	rootCmd.PersistentFlags().StringVar(&params.KubeCfgPath, "kubeconfig", "", "kubectl config file (default is $HOME/.kube/config)")
 
-	rootCmd.Flags().StringVar(&Cfg.PluginsDir, "plugins-dir", "~/.kn/plugins", "kn plugins directory")
+	rootCmd.Flags().StringVar(&Cfg.PluginsDir, "plugins-dir", "~/.config/kn/plugins", "kn plugins directory")
 	rootCmd.Flags().BoolVar(Cfg.LookupPlugins, "lookup-plugins", false, "look for kn plugins in $PATH")
 
 	viper.BindPFlag("plugins-dir", rootCmd.Flags().Lookup("plugins-dir"))
 	viper.BindPFlag("lookup-plugins", rootCmd.Flags().Lookup("lookup-plugins"))
 
-	viper.SetDefault("plugins-dir", "~/.kn/plugins")
+	viper.SetDefault("plugins-dir", "~/.config/kn/plugins")
 	viper.SetDefault("lookup-plugins", false)
 
 	rootCmd.AddCommand(subCommand)

--- a/pkg/kn/commands/types.go
+++ b/pkg/kn/commands/types.go
@@ -40,15 +40,19 @@ var CfgFile string
 
 // Cfg is Kn's configuration values
 var Cfg Config = Config{
-	PluginsDir:    "",
-	LookupPlugins: newBoolP(false),
+	DefaultConfigDir: "~/.config/kn",
+	DefaultPluginDir: "~/.config/kn/plugins",
+	PluginsDir:       "",
+	LookupPlugins:    newBoolP(false),
 }
 
 // Config contains the variables for the Kn config
 type Config struct {
-	PluginsDir    string
-	LookupPlugins *bool
-	SinkPrefixes  []SinkPrefixConfig
+	DefaultConfigDir string
+	DefaultPluginDir string
+	PluginsDir       string
+	LookupPlugins    *bool
+	SinkPrefixes     []SinkPrefixConfig
 }
 
 // SinkPrefixConfig is the struct of sink prefix config in kn config

--- a/pkg/kn/core/root.go
+++ b/pkg/kn/core/root.go
@@ -140,8 +140,9 @@ func NewKnCommand(params ...commands.KnParams) *cobra.Command {
 	}
 
 	// Persistent flags
-	rootCmd.PersistentFlags().StringVar(&commands.CfgFile, "config", "", "kn config file (default is $HOME/.kn/config.yaml)")
-	rootCmd.PersistentFlags().StringVar(&p.KubeCfgPath, "kubeconfig", "", "kubectl config file (default is $HOME/.kube/config)")
+	rootCmd.PersistentFlags().StringVar(&commands.CfgFile, "config", "", "kn config file (default is "+
+		filepath.Join(commands.Cfg.DefaultConfigDir, "config.yaml")+")")
+	rootCmd.PersistentFlags().StringVar(&p.KubeCfgPath, "kubeconfig", "", "kubectl config file (default is ~/.kube/config)")
 	flags.AddBothBoolFlags(rootCmd.PersistentFlags(), &p.LogHTTP, "log-http", "", false, "log http traffic")
 
 	plugin.AddPluginFlags(rootCmd)

--- a/pkg/kn/core/root.go
+++ b/pkg/kn/core/root.go
@@ -19,7 +19,8 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -208,15 +209,13 @@ func initConfig() {
 		// Use config file from the flag.
 		viper.SetConfigFile(commands.CfgFile)
 	} else {
-		// Find home directory.
-		home, err := homedir.Dir()
+		configDir, err := defaultConfigDir()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%v\n", err)
-			os.Exit(1)
+			// Deprecated path warning message & continue
+			fmt.Fprintf(os.Stderr, "\n%v\n\n", err)
 		}
-
 		// Search config in home directory with name ".kn" (without extension)
-		viper.AddConfigPath(path.Join(home, ".kn"))
+		viper.AddConfigPath(configDir)
 		viper.SetConfigName("config")
 	}
 
@@ -227,6 +226,42 @@ func initConfig() {
 	if err == nil {
 		fmt.Fprintln(os.Stderr, "Using kn config file:", viper.ConfigFileUsed())
 	}
+}
+
+func defaultConfigDir() (string, error) {
+	home, err := homedir.Dir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	// Check the deprecated path first and fallback to it, add warning to error message
+	if configHome := filepath.Join(home, ".kn"); dirExists(configHome) {
+		migrationPath := filepath.Join(home, ".config", "kn")
+		if runtime.GOOS == "windows" {
+			migrationPath = filepath.Join(os.Getenv("APPDATA"), "kn")
+		}
+		return configHome, fmt.Errorf("WARNING: deprecated kn config directory detected. "+
+			"Please move your configuration to: %s", migrationPath)
+	}
+	// Respect %APPDATA% on MS Windows
+	// C:\Documents and Settings\username\Application Data
+	if runtime.GOOS == "windows" {
+		return filepath.Join(os.Getenv("APPDATA"), "kn"), nil
+	}
+	// Respect XDG_CONFIG_HOME if set
+	if xdgHome := os.Getenv("XDG_CONFIG_HOME"); xdgHome != "" {
+		return filepath.Join(xdgHome, "kn"), nil
+	}
+	// Fallback to XDF default for both Linux and macOS
+	// ~/.config/kn
+	return filepath.Join(home, ".config", "kn"), nil
+}
+
+func dirExists(path string) bool {
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		return true
+	}
+	return false
 }
 
 func initConfigFlags() error {
@@ -253,7 +288,14 @@ func initConfigFlags() error {
 }
 
 func extractKnPluginFlags(args []string) (string, bool, error) {
-	pluginsDir := "~/.kn/plugins"
+	// Deprecated default path, fallback to it when exist
+	home, _ := homedir.Dir()
+	pluginsDir := filepath.Join(home, ".kn", "plugins")
+	if !dirExists(pluginsDir) {
+		configDir, _ := defaultConfigDir()
+		pluginsDir = filepath.Join(configDir, "plugins")
+	}
+
 	lookupPluginsInPath := false
 
 	dirFlag := "--plugins-dir"

--- a/pkg/kn/core/root.go
+++ b/pkg/kn/core/root.go
@@ -252,7 +252,7 @@ func defaultConfigDir() (string, error) {
 	if xdgHome := os.Getenv("XDG_CONFIG_HOME"); xdgHome != "" {
 		return filepath.Join(xdgHome, "kn"), nil
 	}
-	// Fallback to XDF default for both Linux and macOS
+	// Fallback to XDG default for both Linux and macOS
 	// ~/.config/kn
 	return filepath.Join(home, ".config", "kn"), nil
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Before proceeding further, I'd like to ask for feedback for the following change, especially to the deprecated fallback part and plugin dir handling. 

@rhuss @navidshaikh 
Does it seem like a right direction to go?

TODO:
* Update docs about config location
* Update help/usage messages with new default location
* Add tests

Fixes #429 

## Proposed Changes

* Change default config path to: 
  * `~/.config/kn` for unix-like OS 
  * `%APPDATA%\kn` for MS Win
* Respect env variable `XDG_CONFIG_HOME`
* Check for pre-existing configuration dir on deprecated location and fallback to it. Otherwise use XDG recommended default.


<!--
Release Note:

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behaviour
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example.

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->
