### PR TITLE
Allow configuring output for --log-http

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,6 +21,10 @@
 | | Description | PR
 
 | 🧽
+| Allow configure destination for --log-http
+| https://github.com/knative/client/pull/683[#683]
+
+| 🧽
 | Support multiple revisions on `kn revision delete`
 | https://github.com/knative/client/pull/657[#657]
 

--- a/docs/cmd/kn.md
+++ b/docs/cmd/kn.md
@@ -12,12 +12,12 @@ Manage your Knative building blocks:
 ### Options
 
 ```
-      --config string        kn config file (default is $HOME/.kn/config.yaml)
-  -h, --help                 help for kn
-      --kubeconfig string    kubectl config file (default is $HOME/.kube/config)
-      --log-http             log http traffic
-      --lookup-plugins       look for kn plugins in $PATH
-      --plugins-dir string   kn plugins directory (default "~/.kn/plugins")
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+  -h, --help                             help for kn
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
+      --lookup-plugins                   look for kn plugins in $PATH
+      --plugins-dir string               kn plugins directory (default "~/.kn/plugins")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_completion.md
+++ b/docs/cmd/kn_completion.md
@@ -36,9 +36,9 @@ kn completion [SHELL] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_plugin.md
+++ b/docs/cmd/kn_plugin.md
@@ -24,9 +24,9 @@ kn plugin [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_plugin_list.md
+++ b/docs/cmd/kn_plugin_list.md
@@ -29,9 +29,9 @@ kn plugin list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_revision.md
+++ b/docs/cmd/kn_revision.md
@@ -19,9 +19,9 @@ kn revision [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_revision_delete.md
+++ b/docs/cmd/kn_revision_delete.md
@@ -28,9 +28,9 @@ kn revision delete NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_revision_describe.md
+++ b/docs/cmd/kn_revision_describe.md
@@ -24,9 +24,9 @@ kn revision describe NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_revision_list.md
+++ b/docs/cmd/kn_revision_list.md
@@ -43,9 +43,9 @@ kn revision list [name] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_route.md
+++ b/docs/cmd/kn_route.md
@@ -19,9 +19,9 @@ kn route [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_route_describe.md
+++ b/docs/cmd/kn_route_describe.md
@@ -24,9 +24,9 @@ kn route describe NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_route_list.md
+++ b/docs/cmd/kn_route_list.md
@@ -39,9 +39,9 @@ kn route list NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_service.md
+++ b/docs/cmd/kn_service.md
@@ -19,9 +19,9 @@ kn service [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -77,9 +77,9 @@ kn service create NAME --image IMAGE [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_service_delete.md
+++ b/docs/cmd/kn_service_delete.md
@@ -31,9 +31,9 @@ kn service delete NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_service_describe.md
+++ b/docs/cmd/kn_service_describe.md
@@ -24,9 +24,9 @@ kn service describe NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_service_list.md
+++ b/docs/cmd/kn_service_list.md
@@ -39,9 +39,9 @@ kn service list [name] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -75,9 +75,9 @@ kn service update NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source.md
+++ b/docs/cmd/kn_source.md
@@ -19,9 +19,9 @@ kn source [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_apiserver.md
+++ b/docs/cmd/kn_source_apiserver.md
@@ -19,9 +19,9 @@ kn source apiserver [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_apiserver_create.md
+++ b/docs/cmd/kn_source_apiserver_create.md
@@ -35,9 +35,9 @@ kn source apiserver create NAME --resource RESOURCE --service-account ACCOUNTNAM
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_apiserver_delete.md
+++ b/docs/cmd/kn_source_apiserver_delete.md
@@ -28,9 +28,9 @@ kn source apiserver delete NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_apiserver_describe.md
+++ b/docs/cmd/kn_source_apiserver_describe.md
@@ -29,9 +29,9 @@ kn source apiserver describe NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_apiserver_list.md
+++ b/docs/cmd/kn_source_apiserver_list.md
@@ -33,9 +33,9 @@ kn source apiserver list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_apiserver_update.md
+++ b/docs/cmd/kn_source_apiserver_update.md
@@ -35,9 +35,9 @@ kn source apiserver update NAME --resource RESOURCE --service-account ACCOUNTNAM
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_binding.md
+++ b/docs/cmd/kn_source_binding.md
@@ -19,9 +19,9 @@ kn source binding [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_binding_create.md
+++ b/docs/cmd/kn_source_binding_create.md
@@ -31,9 +31,9 @@ kn source binding create NAME --subject SCHEDULE --sink SINK --ce-override KEY=V
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_binding_delete.md
+++ b/docs/cmd/kn_source_binding_delete.md
@@ -28,9 +28,9 @@ kn source binding delete NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_binding_describe.md
+++ b/docs/cmd/kn_source_binding_describe.md
@@ -29,9 +29,9 @@ kn source binding describe NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_binding_list.md
+++ b/docs/cmd/kn_source_binding_list.md
@@ -33,9 +33,9 @@ kn source binding list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_binding_update.md
+++ b/docs/cmd/kn_source_binding_update.md
@@ -31,9 +31,9 @@ kn source binding update NAME --subject SCHEDULE --sink SINK --ce-override OVERR
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_cronjob.md
+++ b/docs/cmd/kn_source_cronjob.md
@@ -19,9 +19,9 @@ kn source cronjob [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_cronjob_create.md
+++ b/docs/cmd/kn_source_cronjob_create.md
@@ -31,9 +31,9 @@ kn source cronjob create NAME --schedule SCHEDULE --sink SINK --data DATA [flags
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_cronjob_delete.md
+++ b/docs/cmd/kn_source_cronjob_delete.md
@@ -28,9 +28,9 @@ kn source cronjob delete NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_cronjob_describe.md
+++ b/docs/cmd/kn_source_cronjob_describe.md
@@ -29,9 +29,9 @@ kn source cronjob describe NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_cronjob_list.md
+++ b/docs/cmd/kn_source_cronjob_list.md
@@ -33,9 +33,9 @@ kn source cronjob list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_cronjob_update.md
+++ b/docs/cmd/kn_source_cronjob_update.md
@@ -31,9 +31,9 @@ kn source cronjob update NAME --schedule SCHEDULE --sink SERVICE --data DATA [fl
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_list-types.md
+++ b/docs/cmd/kn_source_list-types.md
@@ -35,9 +35,9 @@ kn source list-types [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_trigger.md
+++ b/docs/cmd/kn_trigger.md
@@ -19,9 +19,9 @@ kn trigger [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_trigger_create.md
+++ b/docs/cmd/kn_trigger_create.md
@@ -31,9 +31,9 @@ kn trigger create NAME --broker BROKER --filter KEY=VALUE --sink SINK [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_trigger_delete.md
+++ b/docs/cmd/kn_trigger_delete.md
@@ -28,9 +28,9 @@ kn trigger delete NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_trigger_describe.md
+++ b/docs/cmd/kn_trigger_describe.md
@@ -29,9 +29,9 @@ kn trigger describe NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_trigger_list.md
+++ b/docs/cmd/kn_trigger_list.md
@@ -36,9 +36,9 @@ kn trigger list [name] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_trigger_update.md
+++ b/docs/cmd/kn_trigger_update.md
@@ -38,9 +38,9 @@ kn trigger update NAME --filter KEY=VALUE --sink SINK [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_version.md
+++ b/docs/cmd/kn_version.md
@@ -19,9 +19,9 @@ kn version [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       kn config file (default is $HOME/.kn/config.yaml)
-      --kubeconfig string   kubectl config file (default is $HOME/.kube/config)
-      --log-http            log http traffic
+      --config string                    kn config file (default is $HOME/.kn/config.yaml)
+      --kubeconfig string                kubectl config file (default is $HOME/.kube/config)
+      --log-http string[="__STDERR__"]   log http traffic to stderr (no argument) or a file (with argument) (default "__NO_LOG__")
 ```
 
 ### SEE ALSO

--- a/pkg/kn/commands/types_test.go
+++ b/pkg/kn/commands/types_test.go
@@ -29,7 +29,7 @@ import (
 type configTestCase struct {
 	clientConfig      clientcmd.ClientConfig
 	expectedErrString string
-	logHttp           bool
+	logHttp           string
 }
 
 var BASIC_KUBECONFIG = `apiVersion: v1
@@ -62,17 +62,17 @@ func TestPrepareConfig(t *testing.T) {
 		{
 			clientcmd.NewDefaultClientConfig(clientcmdapi.Config{}, &clientcmd.ConfigOverrides{}),
 			"no configuration has been provided",
-			false,
+			"__EMTPY__",
 		},
 		{
 			basic,
 			"",
-			false,
+			"__NO_LOG__",
 		},
 		{ // Test that the cast to wrap the http client in a logger works
 			basic,
 			"",
-			true,
+			"",
 		},
 	} {
 		p := &KnParams{
@@ -152,17 +152,17 @@ func TestNewSourcesClient(t *testing.T) {
 		{
 			clientcmd.NewDefaultClientConfig(clientcmdapi.Config{}, &clientcmd.ConfigOverrides{}),
 			"no configuration has been provided",
-			false,
+			"__NO_LOG__",
 		},
 		{
 			basic,
 			"",
-			false,
+			"__NO_LOG__",
 		},
 		{ // Test that the cast to wrap the http client in a logger works
 			basic,
 			"",
-			true,
+			"",
 		},
 	} {
 		p := &KnParams{
@@ -203,17 +203,17 @@ func TestNewDynamicClient(t *testing.T) {
 		{
 			clientcmd.NewDefaultClientConfig(clientcmdapi.Config{}, &clientcmd.ConfigOverrides{}),
 			"no configuration has been provided",
-			false,
+			"__NO_LOG__",
 		},
 		{
 			basic,
 			"",
-			false,
+			"__NO_LOG__",
 		},
 		{ // Test that the cast to wrap the http client in a logger works
 			basic,
 			"",
-			true,
+			"",
 		},
 	} {
 		p := &KnParams{

--- a/pkg/kn/core/root.go
+++ b/pkg/kn/core/root.go
@@ -137,7 +137,8 @@ func NewKnCommand(params ...commands.KnParams) *cobra.Command {
 	// Persistent flags
 	rootCmd.PersistentFlags().StringVar(&commands.CfgFile, "config", "", "kn config file (default is $HOME/.kn/config.yaml)")
 	rootCmd.PersistentFlags().StringVar(&p.KubeCfgPath, "kubeconfig", "", "kubectl config file (default is $HOME/.kube/config)")
-	flags.AddBothBoolFlags(rootCmd.PersistentFlags(), &p.LogHTTP, "log-http", "", false, "log http traffic")
+	rootCmd.PersistentFlags().StringVar(&p.LogHTTP, "log-http", "__NO_LOG__", "log http traffic to stderr (no argument) or a file (with argument)")
+	rootCmd.PersistentFlags().Lookup("log-http").NoOptDefVal = "__STDERR__"
 
 	plugin.AddPluginFlags(rootCmd)
 	plugin.BindPluginsFlagToViper(rootCmd)


### PR DESCRIPTION
Change log-http from boolean to string, if no argument is given write log to stderr, otherwise treat argument as file to write to.

/lint

Fixes #390 

## Proposed Changes

* Change behavior of --log-http: if set without argument, write the http log to stderr, if an argument is set, treat it as a file path to where the logs are written
