### PR TITLE
fix typo in source list-types examples

### DIFF
--- a/docs/cmd/kn_revision_list.md
+++ b/docs/cmd/kn_revision_list.md
@@ -22,7 +22,7 @@ kn revision list [name] [flags]
 
   # List all revisions in JSON output format
   kn revision list -o json
-  
+
   # List revision 'web'
   kn revision list web
 ```

--- a/docs/cmd/kn_route_list.md
+++ b/docs/cmd/kn_route_list.md
@@ -20,7 +20,7 @@ kn route list NAME [flags]
   # List route 'web' in namespace 'dev'
   kn route list web -n dev
 
-  # List all routes in yaml format
+  # List all routes in YAML format
   kn route list -o yaml
 ```
 

--- a/docs/cmd/kn_source_apiserver_list.md
+++ b/docs/cmd/kn_source_apiserver_list.md
@@ -14,6 +14,9 @@ kn source apiserver list [flags]
 
 ```
 
+  # List all ApiServer sources
+  kn source apiserver list
+
   # List all ApiServer sources in YAML format
   kn source apiserver list -o yaml
 ```

--- a/docs/cmd/kn_source_binding_list.md
+++ b/docs/cmd/kn_source_binding_list.md
@@ -14,7 +14,10 @@ kn source binding list [flags]
 
 ```
 
-  # List all sink binding in YAML format
+  # List all sink binidngs
+  kn source binding list
+
+  # List all sink bindings in YAML format
   kn source binding list -o yaml
 ```
 

--- a/docs/cmd/kn_source_cronjob_list.md
+++ b/docs/cmd/kn_source_cronjob_list.md
@@ -14,6 +14,9 @@ kn source cronjob list [flags]
 
 ```
 
+  # List all CronJob sources
+  kn source cronjob list
+
   # List all CronJob sources in YAML format
   kn source cronjob list -o yaml
 ```

--- a/docs/cmd/kn_source_list-types.md
+++ b/docs/cmd/kn_source_list-types.md
@@ -17,7 +17,7 @@ kn source list-types [flags]
   # List available eventing source types
   kn source list-types
 
-  # List available eventing source types in JSON format
+  # List available eventing source types in YAML format
   kn source list-types -o yaml
 ```
 

--- a/pkg/kn/commands/revision/list.go
+++ b/pkg/kn/commands/revision/list.go
@@ -50,7 +50,7 @@ func NewRevisionListCommand(p *commands.KnParams) *cobra.Command {
 
   # List all revisions in JSON output format
   kn revision list -o json
-  
+
   # List revision 'web'
   kn revision list web`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/kn/commands/route/list.go
+++ b/pkg/kn/commands/route/list.go
@@ -40,7 +40,7 @@ func NewRouteListCommand(p *commands.KnParams) *cobra.Command {
   # List route 'web' in namespace 'dev'
   kn route list web -n dev
 
-  # List all routes in yaml format
+  # List all routes in YAML format
   kn route list -o yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 

--- a/pkg/kn/commands/source/apiserver/list.go
+++ b/pkg/kn/commands/source/apiserver/list.go
@@ -30,6 +30,9 @@ func NewAPIServerListCommand(p *commands.KnParams) *cobra.Command {
 		Use:   "list",
 		Short: "List ApiServer sources.",
 		Example: `
+  # List all ApiServer sources
+  kn source apiserver list
+
   # List all ApiServer sources in YAML format
   kn source apiserver list -o yaml`,
 

--- a/pkg/kn/commands/source/binding/list.go
+++ b/pkg/kn/commands/source/binding/list.go
@@ -30,7 +30,10 @@ func NewBindingListCommand(p *commands.KnParams) *cobra.Command {
 		Use:   "list",
 		Short: "List sink bindings.",
 		Example: `
-  # List all sink binding in YAML format
+  # List all sink binidngs
+  kn source binding list
+
+  # List all sink bindings in YAML format
   kn source binding list -o yaml`,
 
 		RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/pkg/kn/commands/source/cronjob/list.go
+++ b/pkg/kn/commands/source/cronjob/list.go
@@ -30,6 +30,9 @@ func NewCronJobListCommand(p *commands.KnParams) *cobra.Command {
 		Use:   "list",
 		Short: "List CronJob sources.",
 		Example: `
+  # List all CronJob sources
+  kn source cronjob list
+
   # List all CronJob sources in YAML format
   kn source cronjob list -o yaml`,
 

--- a/pkg/kn/commands/source/list_types.go
+++ b/pkg/kn/commands/source/list_types.go
@@ -32,7 +32,7 @@ func NewListTypesCommand(p *commands.KnParams) *cobra.Command {
   # List available eventing source types
   kn source list-types
 
-  # List available eventing source types in JSON format
+  # List available eventing source types in YAML format
   kn source list-types -o yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, err := p.GetNamespace(cmd)


### PR DESCRIPTION
Update other list command examples as well.
