### PR TITLE
chore(e2e): Increase e2e timeout to 45 minutes

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -41,5 +41,5 @@ initialize $@
 
 header "Running tests for Knative Serving $KNATIVE_SERVING_VERSION and Eventing $KNATIVE_EVENTING_VERSION"
 
-go_test_e2e -timeout=30m ./test/e2e || fail_test
+go_test_e2e -timeout=45m ./test/e2e || fail_test
 success


### PR DESCRIPTION
 Fixes #686

 - changed from 30m to 45m
