### PR TITLE
Change the crontab samples in cronjob commands

### DIFF
--- a/docs/cmd/kn_source_cronjob_create.md
+++ b/docs/cmd/kn_source_cronjob_create.md
@@ -15,13 +15,13 @@ kn source cronjob create NAME --schedule SCHEDULE --sink SINK --data DATA [flags
 ```
 
   # Create a crontab scheduler 'my-cron-trigger' which fires every minute and sends 'ping' to service 'mysvc' as a cloudevent
-  kn source cronjob create my-cron-trigger --schedule "* * * * */1" --data "ping" --sink svc:mysvc
+  kn source cronjob create my-cron-trigger --schedule "* * * * *" --data "ping" --sink svc:mysvc
   
   # Create a crontab scheduler 'my-cron-trigger' with ServiceAccount name
-  kn source cronjob create my-cron-trigger1 --schedule "* * * * */1" --data "ping" --sink svc:event-display --service-account myaccount
+  kn source cronjob create my-cron-trigger --schedule "* * * * *" --data "ping" --sink svc:event-display --service-account myaccount
 
   # Create a crontab scheduler 'my-cron-trigger' with requested resources
-  kn source cronjob create my-cron-trigger1 --schedule "* * * * */1" --data "ping" --sink svc:event-display --requests-cpu 100m --requests-memory 128Mi
+  kn source cronjob create my-cron-trigger --schedule "* * * * *" --data "ping" --sink svc:event-display --requests-cpu 100m --requests-memory 128Mi
 ```
 
 ### Options
@@ -34,7 +34,7 @@ kn source cronjob create NAME --schedule SCHEDULE --sink SINK --data DATA [flags
   -n, --namespace string         Specify the namespace to operate in.
       --requests-cpu string      The requested CPU (e.g., 250m).
       --requests-memory string   The requested memory (e.g., 64Mi).
-      --schedule string          Schedule specification in crontab format (e.g. '* * * * */2' for every two minutes
+      --schedule string          Schedule specification in crontab format (e.g. '*/2 * * * *' for every two minutes
       --service-account string   Name of the service account to use to run this source
   -s, --sink string              Addressable sink for events
 ```

--- a/docs/cmd/kn_source_cronjob_update.md
+++ b/docs/cmd/kn_source_cronjob_update.md
@@ -15,7 +15,7 @@ kn source cronjob update NAME --schedule SCHEDULE --sink SERVICE --data DATA [fl
 ```
 
   # Update the schedule of a crontab source 'my-cron-trigger' to fire every minute
-  kn source cronjob update my-cron-trigger --schedule "* * * * */1"
+  kn source cronjob update my-cron-trigger --schedule "* * * * *"
 ```
 
 ### Options
@@ -28,7 +28,7 @@ kn source cronjob update NAME --schedule SCHEDULE --sink SERVICE --data DATA [fl
   -n, --namespace string         Specify the namespace to operate in.
       --requests-cpu string      The requested CPU (e.g., 250m).
       --requests-memory string   The requested memory (e.g., 64Mi).
-      --schedule string          Schedule specification in crontab format (e.g. '* * * * */2' for every two minutes
+      --schedule string          Schedule specification in crontab format (e.g. '*/2 * * * *' for every two minutes
       --service-account string   Name of the service account to use to run this source
   -s, --sink string              Addressable sink for events
 ```

--- a/pkg/kn/commands/source/cronjob/create.go
+++ b/pkg/kn/commands/source/cronjob/create.go
@@ -35,13 +35,13 @@ func NewCronJobCreateCommand(p *commands.KnParams) *cobra.Command {
 		Short: "Create a CronJob source.",
 		Example: `
   # Create a crontab scheduler 'my-cron-trigger' which fires every minute and sends 'ping' to service 'mysvc' as a cloudevent
-  kn source cronjob create my-cron-trigger --schedule "* * * * */1" --data "ping" --sink svc:mysvc
+  kn source cronjob create my-cron-trigger --schedule "* * * * *" --data "ping" --sink svc:mysvc
   
   # Create a crontab scheduler 'my-cron-trigger' with ServiceAccount name
-  kn source cronjob create my-cron-trigger1 --schedule "* * * * */1" --data "ping" --sink svc:event-display --service-account myaccount
+  kn source cronjob create my-cron-trigger --schedule "* * * * *" --data "ping" --sink svc:event-display --service-account myaccount
 
   # Create a crontab scheduler 'my-cron-trigger' with requested resources
-  kn source cronjob create my-cron-trigger1 --schedule "* * * * */1" --data "ping" --sink svc:event-display --requests-cpu 100m --requests-memory 128Mi`,
+  kn source cronjob create my-cron-trigger --schedule "* * * * *" --data "ping" --sink svc:event-display --requests-cpu 100m --requests-memory 128Mi`,
 
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {

--- a/pkg/kn/commands/source/cronjob/flags.go
+++ b/pkg/kn/commands/source/cronjob/flags.go
@@ -39,7 +39,7 @@ type cronJobUpdateFlags struct {
 }
 
 func (c *cronJobUpdateFlags) addCronJobFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&c.schedule, "schedule", "", "Schedule specification in crontab format (e.g. '* * * * */2' for every two minutes")
+	cmd.Flags().StringVar(&c.schedule, "schedule", "", "Schedule specification in crontab format (e.g. '*/2 * * * *' for every two minutes")
 	cmd.Flags().StringVarP(&c.data, "data", "d", "", "String data to send")
 	cmd.Flags().StringVar(&c.resourceRequestsCPU, "requests-cpu", "", "The requested CPU (e.g., 250m).")
 	cmd.Flags().StringVar(&c.resourceRequestsMemory, "requests-memory", "", "The requested memory (e.g., 64Mi).")

--- a/pkg/kn/commands/source/cronjob/update.go
+++ b/pkg/kn/commands/source/cronjob/update.go
@@ -35,7 +35,7 @@ func NewCronJobUpdateCommand(p *commands.KnParams) *cobra.Command {
 		Short: "Update a CronJob source.",
 		Example: `
   # Update the schedule of a crontab source 'my-cron-trigger' to fire every minute
-  kn source cronjob update my-cron-trigger --schedule "* * * * */1"`,
+  kn source cronjob update my-cron-trigger --schedule "* * * * *"`,
 
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {


### PR DESCRIPTION
## Proposed Changes

* Change the crontab string samples in the cronjob commands to avoid confusion. Refer to [crontab editor](https://crontab.guru/#*_*_*_*_*/2) to see the explanation.