### PR TITLE
Setup `./hack/update-deps.sh` so that we can auto-update CLI.

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+readonly ROOT_DIR=$(dirname $0)/..
+source ${ROOT_DIR}/vendor/knative.dev/test-infra/scripts/library.sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+cd ${ROOT_DIR}
+
+VERSION="master"
+
+# The list of dependencies that we track at HEAD and periodically
+# float forward in this repository.
+FLOATING_DEPS=(
+  "knative.dev/test-infra"
+  "knative.dev/pkg@${VERSION}"
+  "knative.dev/serving@${VERSION}"
+  "knative.dev/eventing@${VERSION}"
+  "knative.dev/eventing-contrib@${VERSION}"
+)
+
+# Parse flags to determine any we should pass to dep.
+GO_GET=0
+while [[ $# -ne 0 ]]; do
+  parameter=$1
+  case ${parameter} in
+    --upgrade) GO_GET=1 ;;
+    *) abort "unknown option ${parameter}" ;;
+  esac
+  shift
+done
+readonly GO_GET
+
+if (( GO_GET )); then
+  go get -d ${FLOATING_DEPS[@]}
+fi
+
+
+# Prune modules.
+go mod tidy
+go mod vendor


### PR DESCRIPTION
## Desciption

This script is the hook that the bots key off of to float our dependencies forward via a PR each day that lets us determine whether things have broken via Prow.  In our other repos, this generally lets us know about breaking changes across repos within 1 business day, and has proven valuable.

## Changes

Add a script to automatically float select dependencies forward via `./hack/update-deps.sh --upgrade`.

/lint
