### PR TITLE
feat(version): Add JSON/YAML output formats for version command

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,10 @@
 |===
 | | Description | PR
 
+| 🎁
+| Add JSON/YAML output format for version command
+| https://github.com/knative/client/pull/709[#709]
+
 | 🐣
 | Replaced `kn source cron` with `kn source ping`. `--schedule` is not mandatory anymore and defaults to "* * * * *" (every minute)
 | https://github.com/knative/client/issues/564[#564]

--- a/docs/cmd/kn_version.md
+++ b/docs/cmd/kn_version.md
@@ -13,7 +13,8 @@ kn version [flags]
 ### Options
 
 ```
-  -h, --help   help for version
+  -h, --help            help for version
+  -o, --output string   Output format. One of: json|yaml.
 ```
 
 ### Options inherited from parent commands

--- a/pkg/kn/commands/version/version.go
+++ b/pkg/kn/commands/version/version.go
@@ -15,11 +15,13 @@
 package version
 
 import (
+	"encoding/json"
 	"fmt"
 
-	"knative.dev/client/pkg/kn/commands"
-
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+
+	"knative.dev/client/pkg/kn/commands"
 )
 
 var Version string
@@ -38,12 +40,22 @@ var apiVersions = map[string][]string{
 	},
 }
 
+type knVersion struct {
+	Version       string
+	BuildDate     string
+	GitRevision   string
+	SupportedAPIs map[string][]string
+}
+
 // NewVersionCommand implements 'kn version' command
 func NewVersionCommand(p *commands.KnParams) *cobra.Command {
 	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "Prints the client version",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().Changed("output") {
+				return printVersionMachineReadable(cmd)
+			}
 			out := cmd.OutOrStdout()
 			fmt.Fprintf(out, "Version:      %s\n", Version)
 			fmt.Fprintf(out, "Build Date:   %s\n", BuildDate)
@@ -57,7 +69,37 @@ func NewVersionCommand(p *commands.KnParams) *cobra.Command {
 			for _, api := range apiVersions["eventing"] {
 				fmt.Fprintf(out, "  - %s\n", api)
 			}
+			return nil
 		},
 	}
+	versionCmd.Flags().StringP(
+		"output",
+		"o",
+		"",
+		"Output format. One of: json|yaml.",
+	)
 	return versionCmd
+}
+
+func printVersionMachineReadable(cmd *cobra.Command) error {
+	out := cmd.OutOrStdout()
+	v := knVersion{Version, BuildDate, GitRevision, apiVersions}
+	format := cmd.Flag("output").Value.String()
+	switch format {
+	case "JSON", "json":
+		b, err := json.MarshalIndent(v, "", "\t")
+		if err != nil {
+			return err
+		}
+		fmt.Fprint(out, string(b))
+	case "YAML", "yaml":
+		b, err := yaml.Marshal(v)
+		if err != nil {
+			return err
+		}
+		fmt.Fprint(out, string(b))
+	default:
+		return fmt.Errorf("Invalid value for output flag, choose one among 'json' or 'yaml'.")
+	}
+	return nil
 }

--- a/pkg/kn/commands/version/version_test.go
+++ b/pkg/kn/commands/version/version_test.go
@@ -31,12 +31,10 @@ var versionOutputTemplate = `Version:      {{.Version}}
 Build Date:   {{.BuildDate}}
 Git Revision: {{.GitRevision}}
 Supported APIs:
-* Serving
-  - {{ index .SupportedAPIs.serving 0}}
-* Eventing
-  - {{ index .SupportedAPIs.eventing 0}}
-  - {{ index .SupportedAPIs.eventing 1}}
-  - {{ index .SupportedAPIs.eventing 2}}
+* Serving{{range $apis := .SupportedAPIs.serving }}
+  - {{$apis}}{{end}}
+* Eventing{{range $apis := .SupportedAPIs.eventing }}
+  - {{$apis}}{{end}}
 `
 
 const (


### PR DESCRIPTION
Fixes #513

## Description:
Add -o flag to `kn version` command and support JSON/YAML formats.

## Changes
Examples:
```
➜  client git:(pr/kn-version-json) kn version -ojson
{
	"Version": "v20200309-local-1cbb94e2-dirty",
	"BuildDate": "2020-03-09 13:35:39",
	"GitRevision": "1cbb94e2",
	"SupportedAPIs": {
		"eventing": [
			"sources.eventing.knative.dev/v1alpha1 (knative-eventing v0.13.1)",
			"sources.eventing.knative.dev/v1alpha2 (knative-eventing v0.13.1)",
			"eventing.knative.dev/v1alpha1 (knative-eventing v0.13.1)"
		],
		"serving": [
			"serving.knative.dev/v1 (knative-serving v0.13.0)"
		]
	}
}
```
and
```
➜  client git:(pr/kn-version-json) kn version -oyaml
BuildDate: "2020-03-09 13:35:39"
GitRevision: 1cbb94e2
SupportedAPIs:
  eventing:
  - sources.eventing.knative.dev/v1alpha1 (knative-eventing v0.13.1)
  - sources.eventing.knative.dev/v1alpha2 (knative-eventing v0.13.1)
  - eventing.knative.dev/v1alpha1 (knative-eventing v0.13.1)
  serving:
  - serving.knative.dev/v1 (knative-serving v0.13.0)
Version: v20200309-local-1cbb94e2-dirty
```
/lint