### PR TITLE
fix(docs): Fix links to knative install and relative reference

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -34,7 +34,7 @@ You must install these tools:
 
 ### Create a cluster
 
-1. [Set up a Knative](https://www.knative.dev/docs/install/), You can also set up using limited install guides like [Minikube](https://knative.dev/docs/install/knative-with-minikube/) or [Minishift](https://knative.dev/docs/install/knative-with-minishift/).
+1. [Set up Knative](https://knative.dev/docs/install/any-kubernetes-cluster)
 
 ### Checkout your fork
 

--- a/test/README.md
+++ b/test/README.md
@@ -18,9 +18,9 @@ which need [`-tags=e2e`](#running-end-to-end-tests) to be enabled._
 
 ## Running e2e tests locally
 
-To run [the e2e tests](./e2e) , you need to have a 
+To run [the e2e tests](./e2e) , you need to have a
 
-1. [Running knative environment.](./../DEVELOPMENT.md#create-a-cluster)
+1. [Running knative environment.](../docs/DEVELOPMENT.md#create-a-cluster)
 2. `kn` binary in the $PATH.
 3. Please Make sure that you are able to connect to the cluster by following the [guide here](./../docs#connecting-to-your-cluster)
 


### PR DESCRIPTION
## Desciption


## Changes
 - Setup Knative now points to https://knative.dev/docs/install/any-kubernetes-cluster/
 - Corrects the local link to docs/DEVELOPMENT.md