### PR TITLE
fix(docs): Revert markdown changes for cobra's auto-docs

### DIFF
--- a/docs/cmd/kn.md
+++ b/docs/cmd/kn.md
@@ -6,8 +6,8 @@ Knative client
 
 Manage your Knative building blocks:
 
-- Serving: Manage your services and release new software to them.
-- Eventing: Manage event subscriptions and channels. Connect up event sources.
+* Serving: Manage your services and release new software to them.
+* Eventing: Manage event subscriptions and channels. Connect up event sources.
 
 ### Options
 
@@ -22,11 +22,12 @@ Manage your Knative building blocks:
 
 ### SEE ALSO
 
-- [kn completion](kn_completion.md) - Output shell completion code
-- [kn plugin](kn_plugin.md) - Plugin command group
-- [kn revision](kn_revision.md) - Revision command group
-- [kn route](kn_route.md) - Route command group
-- [kn service](kn_service.md) - Service command group
-- [kn source](kn_source.md) - Event source command group
-- [kn trigger](kn_trigger.md) - Trigger command group
-- [kn version](kn_version.md) - Prints the client version
+* [kn completion](kn_completion.md)	 - Output shell completion code
+* [kn plugin](kn_plugin.md)	 - Plugin command group
+* [kn revision](kn_revision.md)	 - Revision command group
+* [kn route](kn_route.md)	 - Route command group
+* [kn service](kn_service.md)	 - Service command group
+* [kn source](kn_source.md)	 - Event source command group
+* [kn trigger](kn_trigger.md)	 - Trigger command group
+* [kn version](kn_version.md)	 - Prints the client version
+

--- a/docs/cmd/kn_completion.md
+++ b/docs/cmd/kn_completion.md
@@ -4,13 +4,13 @@ Output shell completion code
 
 ### Synopsis
 
-This command prints shell completion code which needs to be evaluated to provide
-interactive completion
+
+This command prints shell completion code which needs to be evaluated
+to provide interactive completion
 
 Supported Shells:
-
-- bash
-- zsh
+ - bash
+ - zsh
 
 ```
 kn completion [SHELL] [flags]
@@ -43,4 +43,5 @@ kn completion [SHELL] [flags]
 
 ### SEE ALSO
 
-- [kn](kn.md) - Knative client
+* [kn](kn.md)	 - Knative client
+

--- a/docs/cmd/kn_plugin.md
+++ b/docs/cmd/kn_plugin.md
@@ -6,9 +6,8 @@ Plugin command group
 
 Provides utilities for interacting and managing with kn plugins.
 
-Plugins provide extended functionality that is not part of the core kn
-command-line distribution. Please refer to the documentation and examples for
-more information about how write your own plugins.
+Plugins provide extended functionality that is not part of the core kn command-line distribution.
+Please refer to the documentation and examples for more information about how write your own plugins.
 
 ```
 kn plugin [flags]
@@ -32,5 +31,6 @@ kn plugin [flags]
 
 ### SEE ALSO
 
-- [kn](kn.md) - Knative client
-- [kn plugin list](kn_plugin_list.md) - List plugins
+* [kn](kn.md)	 - Knative client
+* [kn plugin list](kn_plugin_list.md)	 - List plugins
+

--- a/docs/cmd/kn_plugin_list.md
+++ b/docs/cmd/kn_plugin_list.md
@@ -7,11 +7,10 @@ List plugins
 List all installed plugins.
 
 Available plugins are those that are:
-
 - executable
 - begin with "kn-"
 - Kn's plugin directory ~/.config/kn/plugins
-- Anywhere in the execution \$PATH (if lookupInPath config variable is enabled)
+- Anywhere in the execution $PATH (if lookupInPath config variable is enabled)
 
 ```
 kn plugin list [flags]
@@ -37,4 +36,5 @@ kn plugin list [flags]
 
 ### SEE ALSO
 
-- [kn plugin](kn_plugin.md) - Plugin command group
+* [kn plugin](kn_plugin.md)	 - Plugin command group
+

--- a/docs/cmd/kn_revision.md
+++ b/docs/cmd/kn_revision.md
@@ -26,7 +26,8 @@ kn revision [flags]
 
 ### SEE ALSO
 
-- [kn](kn.md) - Knative client
-- [kn revision delete](kn_revision_delete.md) - Delete a revision.
-- [kn revision describe](kn_revision_describe.md) - Show details of a revision
-- [kn revision list](kn_revision_list.md) - List available revisions.
+* [kn](kn.md)	 - Knative client
+* [kn revision delete](kn_revision_delete.md)	 - Delete a revision.
+* [kn revision describe](kn_revision_describe.md)	 - Show details of a revision
+* [kn revision list](kn_revision_list.md)	 - List available revisions.
+

--- a/docs/cmd/kn_revision_delete.md
+++ b/docs/cmd/kn_revision_delete.md
@@ -38,4 +38,5 @@ kn revision delete NAME [flags]
 
 ### SEE ALSO
 
-- [kn revision](kn_revision.md) - Revision command group
+* [kn revision](kn_revision.md)	 - Revision command group
+

--- a/docs/cmd/kn_revision_describe.md
+++ b/docs/cmd/kn_revision_describe.md
@@ -31,4 +31,5 @@ kn revision describe NAME [flags]
 
 ### SEE ALSO
 
-- [kn revision](kn_revision.md) - Revision command group
+* [kn revision](kn_revision.md)	 - Revision command group
+

--- a/docs/cmd/kn_revision_list.md
+++ b/docs/cmd/kn_revision_list.md
@@ -50,4 +50,5 @@ kn revision list [name] [flags]
 
 ### SEE ALSO
 
-- [kn revision](kn_revision.md) - Revision command group
+* [kn revision](kn_revision.md)	 - Revision command group
+

--- a/docs/cmd/kn_route.md
+++ b/docs/cmd/kn_route.md
@@ -26,6 +26,7 @@ kn route [flags]
 
 ### SEE ALSO
 
-- [kn](kn.md) - Knative client
-- [kn route describe](kn_route_describe.md) - Show details of a route
-- [kn route list](kn_route_list.md) - List available routes.
+* [kn](kn.md)	 - Knative client
+* [kn route describe](kn_route_describe.md)	 - Show details of a route
+* [kn route list](kn_route_list.md)	 - List available routes.
+

--- a/docs/cmd/kn_route_describe.md
+++ b/docs/cmd/kn_route_describe.md
@@ -31,4 +31,5 @@ kn route describe NAME [flags]
 
 ### SEE ALSO
 
-- [kn route](kn_route.md) - Route command group
+* [kn route](kn_route.md)	 - Route command group
+

--- a/docs/cmd/kn_route_list.md
+++ b/docs/cmd/kn_route_list.md
@@ -46,4 +46,5 @@ kn route list NAME [flags]
 
 ### SEE ALSO
 
-- [kn route](kn_route.md) - Route command group
+* [kn route](kn_route.md)	 - Route command group
+

--- a/docs/cmd/kn_service.md
+++ b/docs/cmd/kn_service.md
@@ -26,9 +26,10 @@ kn service [flags]
 
 ### SEE ALSO
 
-- [kn](kn.md) - Knative client
-- [kn service create](kn_service_create.md) - Create a service.
-- [kn service delete](kn_service_delete.md) - Delete a service.
-- [kn service describe](kn_service_describe.md) - Show details of a service
-- [kn service list](kn_service_list.md) - List available services.
-- [kn service update](kn_service_update.md) - Update a service.
+* [kn](kn.md)	 - Knative client
+* [kn service create](kn_service_create.md)	 - Create a service.
+* [kn service delete](kn_service_delete.md)	 - Delete a service.
+* [kn service describe](kn_service_describe.md)	 - Show details of a service
+* [kn service list](kn_service_list.md)	 - List available services.
+* [kn service update](kn_service_update.md)	 - Update a service.
+

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -85,4 +85,5 @@ kn service create NAME --image IMAGE [flags]
 
 ### SEE ALSO
 
-- [kn service](kn_service.md) - Service command group
+* [kn service](kn_service.md)	 - Service command group
+

--- a/docs/cmd/kn_service_delete.md
+++ b/docs/cmd/kn_service_delete.md
@@ -41,4 +41,5 @@ kn service delete NAME [flags]
 
 ### SEE ALSO
 
-- [kn service](kn_service.md) - Service command group
+* [kn service](kn_service.md)	 - Service command group
+

--- a/docs/cmd/kn_service_describe.md
+++ b/docs/cmd/kn_service_describe.md
@@ -31,4 +31,5 @@ kn service describe NAME [flags]
 
 ### SEE ALSO
 
-- [kn service](kn_service.md) - Service command group
+* [kn service](kn_service.md)	 - Service command group
+

--- a/docs/cmd/kn_service_list.md
+++ b/docs/cmd/kn_service_list.md
@@ -46,4 +46,5 @@ kn service list [name] [flags]
 
 ### SEE ALSO
 
-- [kn service](kn_service.md) - Service command group
+* [kn service](kn_service.md)	 - Service command group
+

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -83,4 +83,5 @@ kn service update NAME [flags]
 
 ### SEE ALSO
 
-- [kn service](kn_service.md) - Service command group
+* [kn service](kn_service.md)	 - Service command group
+

--- a/docs/cmd/kn_source.md
+++ b/docs/cmd/kn_source.md
@@ -26,9 +26,9 @@ kn source [flags]
 
 ### SEE ALSO
 
-- [kn](kn.md) - Knative client
-- [kn source apiserver](kn_source_apiserver.md) - Kubernetes API Server Event
-  Source command group
-- [kn source binding](kn_source_binding.md) - Sink binding command group
-- [kn source list-types](kn_source_list-types.md) - List available source types
-- [kn source ping](kn_source_ping.md) - Ping source command group
+* [kn](kn.md)	 - Knative client
+* [kn source apiserver](kn_source_apiserver.md)	 - Kubernetes API Server Event Source command group
+* [kn source binding](kn_source_binding.md)	 - Sink binding command group
+* [kn source list-types](kn_source_list-types.md)	 - List available source types
+* [kn source ping](kn_source_ping.md)	 - Ping source command group
+

--- a/docs/cmd/kn_source_apiserver.md
+++ b/docs/cmd/kn_source_apiserver.md
@@ -26,14 +26,10 @@ kn source apiserver [flags]
 
 ### SEE ALSO
 
-- [kn source](kn_source.md) - Event source command group
-- [kn source apiserver create](kn_source_apiserver_create.md) - Create an
-  ApiServer source.
-- [kn source apiserver delete](kn_source_apiserver_delete.md) - Delete an
-  ApiServer source.
-- [kn source apiserver describe](kn_source_apiserver_describe.md) - Show details
-  of an ApiServer source
-- [kn source apiserver list](kn_source_apiserver_list.md) - List ApiServer
-  sources.
-- [kn source apiserver update](kn_source_apiserver_update.md) - Update an
-  ApiServer source.
+* [kn source](kn_source.md)	 - Event source command group
+* [kn source apiserver create](kn_source_apiserver_create.md)	 - Create an ApiServer source.
+* [kn source apiserver delete](kn_source_apiserver_delete.md)	 - Delete an ApiServer source.
+* [kn source apiserver describe](kn_source_apiserver_describe.md)	 - Show details of an ApiServer source
+* [kn source apiserver list](kn_source_apiserver_list.md)	 - List ApiServer sources.
+* [kn source apiserver update](kn_source_apiserver_update.md)	 - Update an ApiServer source.
+

--- a/docs/cmd/kn_source_apiserver_create.md
+++ b/docs/cmd/kn_source_apiserver_create.md
@@ -42,5 +42,5 @@ kn source apiserver create NAME --resource RESOURCE --service-account ACCOUNTNAM
 
 ### SEE ALSO
 
-- [kn source apiserver](kn_source_apiserver.md) - Kubernetes API Server Event
-  Source command group
+* [kn source apiserver](kn_source_apiserver.md)	 - Kubernetes API Server Event Source command group
+

--- a/docs/cmd/kn_source_apiserver_delete.md
+++ b/docs/cmd/kn_source_apiserver_delete.md
@@ -35,5 +35,5 @@ kn source apiserver delete NAME [flags]
 
 ### SEE ALSO
 
-- [kn source apiserver](kn_source_apiserver.md) - Kubernetes API Server Event
-  Source command group
+* [kn source apiserver](kn_source_apiserver.md)	 - Kubernetes API Server Event Source command group
+

--- a/docs/cmd/kn_source_apiserver_describe.md
+++ b/docs/cmd/kn_source_apiserver_describe.md
@@ -36,5 +36,5 @@ kn source apiserver describe NAME [flags]
 
 ### SEE ALSO
 
-- [kn source apiserver](kn_source_apiserver.md) - Kubernetes API Server Event
-  Source command group
+* [kn source apiserver](kn_source_apiserver.md)	 - Kubernetes API Server Event Source command group
+

--- a/docs/cmd/kn_source_apiserver_list.md
+++ b/docs/cmd/kn_source_apiserver_list.md
@@ -43,5 +43,5 @@ kn source apiserver list [flags]
 
 ### SEE ALSO
 
-- [kn source apiserver](kn_source_apiserver.md) - Kubernetes API Server Event
-  Source command group
+* [kn source apiserver](kn_source_apiserver.md)	 - Kubernetes API Server Event Source command group
+

--- a/docs/cmd/kn_source_apiserver_update.md
+++ b/docs/cmd/kn_source_apiserver_update.md
@@ -42,5 +42,5 @@ kn source apiserver update NAME --resource RESOURCE --service-account ACCOUNTNAM
 
 ### SEE ALSO
 
-- [kn source apiserver](kn_source_apiserver.md) - Kubernetes API Server Event
-  Source command group
+* [kn source apiserver](kn_source_apiserver.md)	 - Kubernetes API Server Event Source command group
+

--- a/docs/cmd/kn_source_binding.md
+++ b/docs/cmd/kn_source_binding.md
@@ -26,13 +26,10 @@ kn source binding [flags]
 
 ### SEE ALSO
 
-- [kn source](kn_source.md) - Event source command group
-- [kn source binding create](kn_source_binding_create.md) - Create a sink
-  binding.
-- [kn source binding delete](kn_source_binding_delete.md) - Delete a sink
-  binding.
-- [kn source binding describe](kn_source_binding_describe.md) - Show details of
-  a sink binding
-- [kn source binding list](kn_source_binding_list.md) - List sink bindings.
-- [kn source binding update](kn_source_binding_update.md) - Update a sink
-  binding.
+* [kn source](kn_source.md)	 - Event source command group
+* [kn source binding create](kn_source_binding_create.md)	 - Create a sink binding.
+* [kn source binding delete](kn_source_binding_delete.md)	 - Delete a sink binding.
+* [kn source binding describe](kn_source_binding_describe.md)	 - Show details of a sink binding
+* [kn source binding list](kn_source_binding_list.md)	 - List sink bindings.
+* [kn source binding update](kn_source_binding_update.md)	 - Update a sink binding.
+

--- a/docs/cmd/kn_source_binding_create.md
+++ b/docs/cmd/kn_source_binding_create.md
@@ -38,4 +38,5 @@ kn source binding create NAME --subject SCHEDULE --sink SINK --ce-override KEY=V
 
 ### SEE ALSO
 
-- [kn source binding](kn_source_binding.md) - Sink binding command group
+* [kn source binding](kn_source_binding.md)	 - Sink binding command group
+

--- a/docs/cmd/kn_source_binding_delete.md
+++ b/docs/cmd/kn_source_binding_delete.md
@@ -35,4 +35,5 @@ kn source binding delete NAME [flags]
 
 ### SEE ALSO
 
-- [kn source binding](kn_source_binding.md) - Sink binding command group
+* [kn source binding](kn_source_binding.md)	 - Sink binding command group
+

--- a/docs/cmd/kn_source_binding_describe.md
+++ b/docs/cmd/kn_source_binding_describe.md
@@ -36,4 +36,5 @@ kn source binding describe NAME [flags]
 
 ### SEE ALSO
 
-- [kn source binding](kn_source_binding.md) - Sink binding command group
+* [kn source binding](kn_source_binding.md)	 - Sink binding command group
+

--- a/docs/cmd/kn_source_binding_list.md
+++ b/docs/cmd/kn_source_binding_list.md
@@ -43,4 +43,5 @@ kn source binding list [flags]
 
 ### SEE ALSO
 
-- [kn source binding](kn_source_binding.md) - Sink binding command group
+* [kn source binding](kn_source_binding.md)	 - Sink binding command group
+

--- a/docs/cmd/kn_source_binding_update.md
+++ b/docs/cmd/kn_source_binding_update.md
@@ -14,7 +14,7 @@ kn source binding update NAME --subject SCHEDULE --sink SINK --ce-override OVERR
 
 ```
 
-  # Update the subject of a sink binding 'my-binding' to a new cronjob with label selector 'app=ping'
+  # Update the subject of a sink binding 'my-binding' to a new cronjob with label selector 'app=ping'  
   kn source binding update my-binding --subject cronjob:batch/v1beta1:app=ping"
 ```
 
@@ -38,4 +38,5 @@ kn source binding update NAME --subject SCHEDULE --sink SINK --ce-override OVERR
 
 ### SEE ALSO
 
-- [kn source binding](kn_source_binding.md) - Sink binding command group
+* [kn source binding](kn_source_binding.md)	 - Sink binding command group
+

--- a/docs/cmd/kn_source_list-types.md
+++ b/docs/cmd/kn_source_list-types.md
@@ -42,4 +42,5 @@ kn source list-types [flags]
 
 ### SEE ALSO
 
-- [kn source](kn_source.md) - Event source command group
+* [kn source](kn_source.md)	 - Event source command group
+

--- a/docs/cmd/kn_source_ping.md
+++ b/docs/cmd/kn_source_ping.md
@@ -26,10 +26,10 @@ kn source ping [flags]
 
 ### SEE ALSO
 
-- [kn source](kn_source.md) - Event source command group
-- [kn source ping create](kn_source_ping_create.md) - Create a Ping source.
-- [kn source ping delete](kn_source_ping_delete.md) - Delete a Ping source.
-- [kn source ping describe](kn_source_ping_describe.md) - Show details of a Ping
-  source
-- [kn source ping list](kn_source_ping_list.md) - List Ping sources.
-- [kn source ping update](kn_source_ping_update.md) - Update a Ping source.
+* [kn source](kn_source.md)	 - Event source command group
+* [kn source ping create](kn_source_ping_create.md)	 - Create a Ping source.
+* [kn source ping delete](kn_source_ping_delete.md)	 - Delete a Ping source.
+* [kn source ping describe](kn_source_ping_describe.md)	 - Show details of a Ping source
+* [kn source ping list](kn_source_ping_list.md)	 - List Ping sources.
+* [kn source ping update](kn_source_ping_update.md)	 - Update a Ping source.
+

--- a/docs/cmd/kn_source_ping_create.md
+++ b/docs/cmd/kn_source_ping_create.md
@@ -38,4 +38,5 @@ kn source ping create NAME --schedule SCHEDULE --sink SINK --data DATA [flags]
 
 ### SEE ALSO
 
-- [kn source ping](kn_source_ping.md) - Ping source command group
+* [kn source ping](kn_source_ping.md)	 - Ping source command group
+

--- a/docs/cmd/kn_source_ping_delete.md
+++ b/docs/cmd/kn_source_ping_delete.md
@@ -35,4 +35,5 @@ kn source ping delete NAME [flags]
 
 ### SEE ALSO
 
-- [kn source ping](kn_source_ping.md) - Ping source command group
+* [kn source ping](kn_source_ping.md)	 - Ping source command group
+

--- a/docs/cmd/kn_source_ping_describe.md
+++ b/docs/cmd/kn_source_ping_describe.md
@@ -36,4 +36,5 @@ kn source ping describe NAME [flags]
 
 ### SEE ALSO
 
-- [kn source ping](kn_source_ping.md) - Ping source command group
+* [kn source ping](kn_source_ping.md)	 - Ping source command group
+

--- a/docs/cmd/kn_source_ping_list.md
+++ b/docs/cmd/kn_source_ping_list.md
@@ -43,4 +43,5 @@ kn source ping list [flags]
 
 ### SEE ALSO
 
-- [kn source ping](kn_source_ping.md) - Ping source command group
+* [kn source ping](kn_source_ping.md)	 - Ping source command group
+

--- a/docs/cmd/kn_source_ping_update.md
+++ b/docs/cmd/kn_source_ping_update.md
@@ -38,4 +38,5 @@ kn source ping update NAME --schedule SCHEDULE --sink SERVICE --data DATA [flags
 
 ### SEE ALSO
 
-- [kn source ping](kn_source_ping.md) - Ping source command group
+* [kn source ping](kn_source_ping.md)	 - Ping source command group
+

--- a/docs/cmd/kn_trigger.md
+++ b/docs/cmd/kn_trigger.md
@@ -26,9 +26,10 @@ kn trigger [flags]
 
 ### SEE ALSO
 
-- [kn](kn.md) - Knative client
-- [kn trigger create](kn_trigger_create.md) - Create a trigger
-- [kn trigger delete](kn_trigger_delete.md) - Delete a trigger.
-- [kn trigger describe](kn_trigger_describe.md) - Show details of a trigger
-- [kn trigger list](kn_trigger_list.md) - List available triggers.
-- [kn trigger update](kn_trigger_update.md) - Update a trigger
+* [kn](kn.md)	 - Knative client
+* [kn trigger create](kn_trigger_create.md)	 - Create a trigger
+* [kn trigger delete](kn_trigger_delete.md)	 - Delete a trigger.
+* [kn trigger describe](kn_trigger_describe.md)	 - Show details of a trigger
+* [kn trigger list](kn_trigger_list.md)	 - List available triggers.
+* [kn trigger update](kn_trigger_update.md)	 - Update a trigger
+

--- a/docs/cmd/kn_trigger_create.md
+++ b/docs/cmd/kn_trigger_create.md
@@ -38,4 +38,5 @@ kn trigger create NAME --broker BROKER --filter KEY=VALUE --sink SINK [flags]
 
 ### SEE ALSO
 
-- [kn trigger](kn_trigger.md) - Trigger command group
+* [kn trigger](kn_trigger.md)	 - Trigger command group
+

--- a/docs/cmd/kn_trigger_delete.md
+++ b/docs/cmd/kn_trigger_delete.md
@@ -35,4 +35,5 @@ kn trigger delete NAME [flags]
 
 ### SEE ALSO
 
-- [kn trigger](kn_trigger.md) - Trigger command group
+* [kn trigger](kn_trigger.md)	 - Trigger command group
+

--- a/docs/cmd/kn_trigger_describe.md
+++ b/docs/cmd/kn_trigger_describe.md
@@ -36,4 +36,5 @@ kn trigger describe NAME [flags]
 
 ### SEE ALSO
 
-- [kn trigger](kn_trigger.md) - Trigger command group
+* [kn trigger](kn_trigger.md)	 - Trigger command group
+

--- a/docs/cmd/kn_trigger_list.md
+++ b/docs/cmd/kn_trigger_list.md
@@ -43,4 +43,5 @@ kn trigger list [name] [flags]
 
 ### SEE ALSO
 
-- [kn trigger](kn_trigger.md) - Trigger command group
+* [kn trigger](kn_trigger.md)	 - Trigger command group
+

--- a/docs/cmd/kn_trigger_update.md
+++ b/docs/cmd/kn_trigger_update.md
@@ -17,12 +17,12 @@ kn trigger update NAME --filter KEY=VALUE --sink SINK [flags]
   # Update the filter which key is 'type' to value 'knative.dev.bar' in a trigger 'mytrigger'
   kn trigger update mytrigger --filter type=knative.dev.bar
 
-  # Remove the filter which key is 'type' from a trigger 'mytrigger'
+  # Remove the filter which key is 'type' from a trigger 'mytrigger' 
   kn trigger update mytrigger --filter type-
 
   # Update the sink of a trigger 'mytrigger' to 'svc:new-service'
   kn trigger update mytrigger --sink svc:new-service
-
+  
 ```
 
 ### Options
@@ -45,4 +45,5 @@ kn trigger update NAME --filter KEY=VALUE --sink SINK [flags]
 
 ### SEE ALSO
 
-- [kn trigger](kn_trigger.md) - Trigger command group
+* [kn trigger](kn_trigger.md)	 - Trigger command group
+

--- a/docs/cmd/kn_version.md
+++ b/docs/cmd/kn_version.md
@@ -26,4 +26,5 @@ kn version [flags]
 
 ### SEE ALSO
 
-- [kn](kn.md) - Knative client
+* [kn](kn.md)	 - Knative client
+


### PR DESCRIPTION
 Revert sub-set of changes from https://github.com/knative/client/pull/710 which
 are auto-generated by cobra for cmd docs. (run `./hack/build.sh` on current HEAD)

/cc @mattmoor if we can update the format markdown command for client meanwhile
```
prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github | grep -v docs/cmd/)
```