### PR TITLE
Improve reporting for missing kubeconfig and error connecting to the cluster

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,10 @@
 |===
 | | Description | PR
 
+| 🐛
+| Improve reporting for missing kubeconfig and error connecting to the cluster
+| https://github.com/knative/client/pull/725[#725]
+
 | 🎁
 | Add `kn source list`
 | https://github.com/knative/client/pull/666[#666]

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -22,7 +22,18 @@ import (
 func newInvalidCRD(apiGroup string) *KNError {
 	parts := strings.Split(apiGroup, ".")
 	name := parts[0]
-	msg := fmt.Sprintf("no Knative %s API found on the backend. Please verify the installation.", name)
-
+	msg := fmt.Sprintf("no Knative %s API found on the backend, please verify the installation", name)
 	return NewKNError(msg)
+}
+
+func newNoRouteToHost(errString string) error {
+	parts := strings.SplitAfter(errString, "dial tcp")
+	if len(parts) == 2 {
+		return NewKNError(fmt.Sprintf("error connecting to the cluster, please verify connection at: %s", strings.Trim(parts[1], " ")))
+	}
+	return NewKNError(fmt.Sprintf("error connecting to the cluster: %s", errString))
+}
+
+func newNoKubeConfig(errString string) error {
+	return NewKNError("no kubeconfig has been provided, please use a valid configuration to connect to the cluster")
 }

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -22,12 +22,12 @@ import (
 
 func TestNewInvalidCRD(t *testing.T) {
 	err := newInvalidCRD("serving.knative.dev")
-	assert.Error(t, err, "no Knative serving API found on the backend. Please verify the installation.")
+	assert.Error(t, err, "no Knative serving API found on the backend, please verify the installation")
 
-	err = newInvalidCRD("serving")
-	assert.Error(t, err, "no Knative serving API found on the backend. Please verify the installation.")
+	err = newInvalidCRD("eventing")
+	assert.Error(t, err, "no Knative eventing API found on the backend, please verify the installation")
 
 	err = newInvalidCRD("")
-	assert.Error(t, err, "no Knative  API found on the backend. Please verify the installation.")
+	assert.Error(t, err, "no Knative  API found on the backend, please verify the installation")
 
 }

--- a/pkg/kn/commands/types.go
+++ b/pkg/kn/commands/types.go
@@ -31,6 +31,7 @@ import (
 	"knative.dev/client/pkg/util"
 
 	clientdynamic "knative.dev/client/pkg/dynamic"
+	knerrors "knative.dev/client/pkg/errors"
 	clienteventingv1alpha1 "knative.dev/client/pkg/eventing/v1alpha1"
 	clientservingv1 "knative.dev/client/pkg/serving/v1"
 )
@@ -145,13 +146,13 @@ func (params *KnParams) RestConfig() (*rest.Config, error) {
 	if params.ClientConfig == nil {
 		params.ClientConfig, err = params.GetClientConfig()
 		if err != nil {
-			return nil, err
+			return nil, knerrors.GetError(err)
 		}
 	}
 
 	config, err := params.ClientConfig.ClientConfig()
 	if err != nil {
-		return nil, err
+		return nil, knerrors.GetError(err)
 	}
 	if params.LogHTTP {
 		// TODO: When we update to the newer version of client-go, replace with

--- a/pkg/kn/commands/types_test.go
+++ b/pkg/kn/commands/types_test.go
@@ -61,7 +61,7 @@ func TestPrepareConfig(t *testing.T) {
 	for i, tc := range []configTestCase{
 		{
 			clientcmd.NewDefaultClientConfig(clientcmdapi.Config{}, &clientcmd.ConfigOverrides{}),
-			"no configuration has been provided",
+			"no kubeconfig has been provided, please use a valid configuration to connect to the cluster",
 			false,
 		},
 		{
@@ -151,7 +151,7 @@ func TestNewSourcesClient(t *testing.T) {
 	for i, tc := range []configTestCase{
 		{
 			clientcmd.NewDefaultClientConfig(clientcmdapi.Config{}, &clientcmd.ConfigOverrides{}),
-			"no configuration has been provided",
+			"no kubeconfig has been provided, please use a valid configuration to connect to the cluster",
 			false,
 		},
 		{
@@ -202,7 +202,7 @@ func TestNewDynamicClient(t *testing.T) {
 	for i, tc := range []configTestCase{
 		{
 			clientcmd.NewDefaultClientConfig(clientcmdapi.Config{}, &clientcmd.ConfigOverrides{}),
-			"no configuration has been provided",
+			"no kubeconfig has been provided, please use a valid configuration to connect to the cluster",
 			false,
 		},
 		{


### PR DESCRIPTION
 Fixes #315

## Description
 - Improve error reporting if
    - kubeconfig file is missing or
    - there is no route to host
    - i/o timeout


/lint

