### PR TITLE
Changes to SinkFlags in order to support plugin event sources

### DIFF
--- a/pkg/kn/commands/flags/sink.go
+++ b/pkg/kn/commands/flags/sink.go
@@ -18,12 +18,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 
+	corev1 "k8s.io/api/core/v1"
 	clientdynamic "knative.dev/client/pkg/dynamic"
 	"knative.dev/client/pkg/kn/commands"
 )
@@ -32,8 +34,8 @@ type SinkFlags struct {
 	sink string
 }
 
-func (i *SinkFlags) Add(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&i.sink, "sink", "s", "", "Addressable sink for events")
+func (i *SinkFlags) Add(flagset *flag.FlagSet) {
+	flagset.StringVarP(&i.sink, "sink", "s", "", "Addressable sink for events")
 }
 
 // SinkPrefixes maps prefixes used for sinks to their GroupVersionResources.
@@ -131,4 +133,18 @@ func SinkToString(sink duckv1.Destination) string {
 		return sink.URI.String()
 	}
 	return ""
+}
+
+// SinkToDuckV1Beta1 converts a Destination from duckv1 to duckv1beta1
+func SinkToDuckV1Beta1(destination *duckv1.Destination) *duckv1beta1.Destination {
+	r := destination.Ref
+	return &duckv1beta1.Destination{
+		Ref: &corev1.ObjectReference{
+			Kind:       r.Kind,
+			Namespace:  r.Namespace,
+			Name:       r.Name,
+			APIVersion: r.APIVersion,
+		},
+		URI: destination.URI,
+	}
 }

--- a/pkg/kn/commands/source/apiserver/apiserver.go
+++ b/pkg/kn/commands/source/apiserver/apiserver.go
@@ -16,10 +16,7 @@ package apiserver
 
 import (
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
-	v1 "knative.dev/pkg/apis/duck/v1"
-	"knative.dev/pkg/apis/duck/v1beta1"
 
 	clientv1alpha1 "knative.dev/eventing/pkg/client/clientset/versioned/typed/sources/v1alpha1"
 
@@ -68,17 +65,4 @@ func newAPIServerSourceClient(p *commands.KnParams, cmd *cobra.Command) (v1alpha
 	}
 
 	return v1alpha1.NewKnSourcesClient(client, namespace).APIServerSourcesClient(), nil
-}
-
-func toDuckV1Beta1(destination *v1.Destination) *v1beta1.Destination {
-	r := destination.Ref
-	return &v1beta1.Destination{
-		Ref: &corev1.ObjectReference{
-			Kind:       r.Kind,
-			Namespace:  r.Namespace,
-			Name:       r.Name,
-			APIVersion: r.APIVersion,
-		},
-		URI: destination.URI,
-	}
 }

--- a/pkg/kn/commands/source/apiserver/create.go
+++ b/pkg/kn/commands/source/apiserver/create.go
@@ -65,7 +65,7 @@ func NewAPIServerCreateCommand(p *commands.KnParams) *cobra.Command {
 			b := v1alpha1.NewAPIServerSourceBuilder(name).
 				ServiceAccount(updateFlags.ServiceAccountName).
 				Mode(updateFlags.Mode).
-				Sink(toDuckV1Beta1(objectRef))
+				Sink(flags.SinkToDuckV1Beta1(objectRef))
 
 			resources, err := updateFlags.getAPIServerResourceArray()
 			if err != nil {
@@ -90,7 +90,7 @@ func NewAPIServerCreateCommand(p *commands.KnParams) *cobra.Command {
 	}
 	commands.AddNamespaceFlags(cmd.Flags(), false)
 	updateFlags.Add(cmd)
-	sinkFlags.Add(cmd)
+	sinkFlags.Add(cmd.Flags())
 	cmd.MarkFlagRequired("resource")
 	cmd.MarkFlagRequired("sink")
 	return cmd

--- a/pkg/kn/commands/source/apiserver/update.go
+++ b/pkg/kn/commands/source/apiserver/update.go
@@ -86,7 +86,7 @@ func NewAPIServerUpdateCommand(p *commands.KnParams) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				b.Sink(toDuckV1Beta1(objectRef))
+				b.Sink(flags.SinkToDuckV1Beta1(objectRef))
 			}
 
 			err = sourcesClient.UpdateAPIServerSource(b.Build())
@@ -99,6 +99,6 @@ func NewAPIServerUpdateCommand(p *commands.KnParams) *cobra.Command {
 	}
 	commands.AddNamespaceFlags(cmd.Flags(), false)
 	apiServerUpdateFlags.Add(cmd)
-	sinkFlags.Add(cmd)
+	sinkFlags.Add(cmd.Flags())
 	return cmd
 }

--- a/pkg/kn/commands/source/binding/create.go
+++ b/pkg/kn/commands/source/binding/create.go
@@ -90,7 +90,7 @@ func NewBindingCreateCommand(p *commands.KnParams) *cobra.Command {
 	}
 	commands.AddNamespaceFlags(cmd.Flags(), false)
 	bindingFlags.addBindingFlags(cmd)
-	sinkFlags.Add(cmd)
+	sinkFlags.Add(cmd.Flags())
 	cmd.MarkFlagRequired("subject")
 	cmd.MarkFlagRequired("sink")
 

--- a/pkg/kn/commands/source/binding/update.go
+++ b/pkg/kn/commands/source/binding/update.go
@@ -95,7 +95,7 @@ func NewBindingUpdateCommand(p *commands.KnParams) *cobra.Command {
 	}
 	commands.AddNamespaceFlags(cmd.Flags(), false)
 	bindingFlags.addBindingFlags(cmd)
-	sinkFlags.Add(cmd)
+	sinkFlags.Add(cmd.Flags())
 
 	return cmd
 }

--- a/pkg/kn/commands/source/ping/create.go
+++ b/pkg/kn/commands/source/ping/create.go
@@ -77,7 +77,7 @@ func NewPingCreateCommand(p *commands.KnParams) *cobra.Command {
 	}
 	commands.AddNamespaceFlags(cmd.Flags(), false)
 	pingUpdateFlags.addPingFlags(cmd)
-	sinkFlags.Add(cmd)
+	sinkFlags.Add(cmd.Flags())
 	cmd.MarkFlagRequired("sink")
 
 	return cmd

--- a/pkg/kn/commands/source/ping/update.go
+++ b/pkg/kn/commands/source/ping/update.go
@@ -85,7 +85,7 @@ func NewPingUpdateCommand(p *commands.KnParams) *cobra.Command {
 	}
 	commands.AddNamespaceFlags(cmd.Flags(), false)
 	pingUpdateFlags.addPingFlags(cmd)
-	sinkFlags.Add(cmd)
+	sinkFlags.Add(cmd.Flags())
 
 	return cmd
 }

--- a/pkg/kn/commands/trigger/create.go
+++ b/pkg/kn/commands/trigger/create.go
@@ -108,7 +108,7 @@ func NewTriggerCreateCommand(p *commands.KnParams) *cobra.Command {
 	}
 	commands.AddNamespaceFlags(cmd.Flags(), false)
 	triggerUpdateFlags.Add(cmd)
-	sinkFlags.Add(cmd)
+	sinkFlags.Add(cmd.Flags())
 	cmd.MarkFlagRequired("sink")
 
 	return cmd

--- a/pkg/kn/commands/trigger/update.go
+++ b/pkg/kn/commands/trigger/update.go
@@ -117,7 +117,7 @@ func NewTriggerUpdateCommand(p *commands.KnParams) *cobra.Command {
 
 	commands.AddNamespaceFlags(cmd.Flags(), false)
 	triggerUpdateFlags.Add(cmd)
-	sinkFlags.Add(cmd)
+	sinkFlags.Add(cmd.Flags())
 
 	return cmd
 }


### PR DESCRIPTION
## Description

Make two changes to SinkFlags in order to support other event sources at client-contrib.

## Changes

* Add a public method SinkToDuckV1Beta1 to flags package.
* Change the parameter in SinkFlags.Add() to `flag.FlagSet`, similar as AddNamespaceFlags().