### PR TITLE
Remove the delete propagation flag

### DIFF
--- a/docs/cmd/kn_revision_delete.md
+++ b/docs/cmd/kn_revision_delete.md
@@ -24,7 +24,7 @@ kn revision delete NAME [flags]
       --async              DEPRECATED: please use --no-wait instead. Delete revision and don't wait for it to be deleted.
   -h, --help               help for delete
   -n, --namespace string   Specify the namespace to operate in.
-      --no-wait            Delete revision and don't wait for it to be deleted.
+      --no-wait            Delete revision and don't wait for it to be deleted. (default true)
       --wait-timeout int   Seconds to wait before giving up on waiting for revision to be deleted. (default 600)
 ```
 

--- a/docs/cmd/kn_service_delete.md
+++ b/docs/cmd/kn_service_delete.md
@@ -27,7 +27,7 @@ kn service delete NAME [flags]
       --async              DEPRECATED: please use --no-wait instead. Delete service and don't wait for it to be deleted.
   -h, --help               help for delete
   -n, --namespace string   Specify the namespace to operate in.
-      --no-wait            Delete service and don't wait for it to be deleted.
+      --no-wait            Delete service and don't wait for it to be deleted. (default true)
       --wait-timeout int   Seconds to wait before giving up on waiting for service to be deleted. (default 600)
 ```
 

--- a/pkg/kn/commands/wait_flags.go
+++ b/pkg/kn/commands/wait_flags.go
@@ -42,8 +42,15 @@ type WaitFlags struct {
 func (p *WaitFlags) AddConditionWaitFlags(command *cobra.Command, waitTimeoutDefault int, action, what, until string) {
 	waitUsage := fmt.Sprintf("%s %s and don't wait for it to be %s.", action, what, until)
 	//TODO: deprecated flag should be removed in next release
+
+	// Special-case 'delete' command so it comes back to the user immediately
+	noWaitDefault := false
+	if action == "Delete" {
+		noWaitDefault = true
+	}
+
 	command.Flags().BoolVar(&p.Async, "async", false, "DEPRECATED: please use --no-wait instead. "+waitUsage)
-	command.Flags().BoolVar(&p.NoWait, "no-wait", false, waitUsage)
+	command.Flags().BoolVar(&p.NoWait, "no-wait", noWaitDefault, waitUsage)
 
 	timeoutUsage := fmt.Sprintf("Seconds to wait before giving up on waiting for %s to be %s.", what, until)
 	command.Flags().IntVar(&p.TimeoutInSeconds, "wait-timeout", waitTimeoutDefault, timeoutUsage)

--- a/pkg/kn/commands/wait_flags_test.go
+++ b/pkg/kn/commands/wait_flags_test.go
@@ -115,3 +115,12 @@ func TestAddWaitUsageMessage(t *testing.T) {
 		t.Error("wrong until message")
 	}
 }
+
+func TestAddWaitUsageDelete(t *testing.T) {
+	flags := &WaitFlags{}
+	cmd := cobra.Command{}
+	flags.AddConditionWaitFlags(&cmd, 60, "Delete", "blub", "deleted")
+	if !strings.Contains(cmd.UsageString(), "deleted. (default true)") {
+		t.Error("Delete has wrong default value for --no-wait")
+	}
+}

--- a/pkg/serving/v1/client.go
+++ b/pkg/serving/v1/client.go
@@ -262,7 +262,7 @@ func updateServiceWithRetry(cl KnServingClient, name string, updateFunc serviceU
 // For `timeout == 0` delete is performed async without any wait.
 func (cl *knServingClient) DeleteService(serviceName string, timeout time.Duration) error {
 	if timeout == 0 {
-		return cl.deleteService(serviceName, v1.DeletePropagationBackground)
+		return cl.deleteService(serviceName)
 	}
 	waitC := make(chan error)
 	go func() {
@@ -270,17 +270,17 @@ func (cl *knServingClient) DeleteService(serviceName string, timeout time.Durati
 		err, _ := waitForEvent.Wait(serviceName, wait.Options{Timeout: &timeout}, wait.NoopMessageCallback())
 		waitC <- err
 	}()
-	err := cl.deleteService(serviceName, v1.DeletePropagationForeground)
+	err := cl.deleteService(serviceName)
 	if err != nil {
 		return err
 	}
 	return <-waitC
 }
 
-func (cl *knServingClient) deleteService(serviceName string, propagationPolicy v1.DeletionPropagation) error {
+func (cl *knServingClient) deleteService(serviceName string) error {
 	err := cl.client.Services(cl.namespace).Delete(
 		serviceName,
-		&v1.DeleteOptions{PropagationPolicy: &propagationPolicy},
+		&v1.DeleteOptions{},
 	)
 	if err != nil {
 		return clienterrors.GetError(err)

--- a/pkg/serving/v1/client.go
+++ b/pkg/serving/v1/client.go
@@ -262,7 +262,7 @@ func updateServiceWithRetry(cl KnServingClient, name string, updateFunc serviceU
 // For `timeout == 0` delete is performed async without any wait.
 func (cl *knServingClient) DeleteService(serviceName string, timeout time.Duration) error {
 	if timeout == 0 {
-		return cl.deleteService(serviceName)
+		return cl.deleteService(serviceName, v1.DeletePropagationBackground)
 	}
 	waitC := make(chan error)
 	go func() {
@@ -270,17 +270,17 @@ func (cl *knServingClient) DeleteService(serviceName string, timeout time.Durati
 		err, _ := waitForEvent.Wait(serviceName, wait.Options{Timeout: &timeout}, wait.NoopMessageCallback())
 		waitC <- err
 	}()
-	err := cl.deleteService(serviceName)
+	err := cl.deleteService(serviceName, v1.DeletePropagationForeground)
 	if err != nil {
 		return err
 	}
 	return <-waitC
 }
 
-func (cl *knServingClient) deleteService(serviceName string) error {
+func (cl *knServingClient) deleteService(serviceName string, propagationPolicy v1.DeletionPropagation) error {
 	err := cl.client.Services(cl.namespace).Delete(
 		serviceName,
-		&v1.DeleteOptions{},
+		&v1.DeleteOptions{PropagationPolicy: &propagationPolicy},
 	)
 	if err != nil {
 		return clienterrors.GetError(err)


### PR DESCRIPTION
In it's current state it now takes me about 25 seconds for the `kn delete`
to complete. Before https://github.com/knative/client/pull/682 it used to be
almost immediate. This is because we now pass in the
`DeletePropagationBackground` flag. I believe this is a mistake, not only
because of the 20+ seconds of additional time to delete things, but IMO
the CLI should talk to the server in the same way regardless of the --wait
flag. That flag should just be a CLI thing to indicate if the user wants the CLI
to wait for the server to complete but not HOW the server should do the delete.

Signed-off-by: Doug Davis <dug@us.ibm.com>

