### PR TITLE
fix(769): various issues with godoc documents

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,7 +20,7 @@
 |===
 
 | 🐣
-| Refactor `e2e` common code into `lib/test/integration`
+| Refactor `e2e` common code into `lib/test`
 | https://github.com/knative/client/pull/765[#765]
 
 ## v0.13.1 (2020-03-25)

--- a/lib/test/cli.go
+++ b/lib/test/cli.go
@@ -33,7 +33,7 @@ type Kn struct {
 	namespace string
 }
 
-// New Kn object
+// NewKn object
 func NewKn() Kn {
 	return Kn{}
 }

--- a/lib/test/integration.go
+++ b/lib/test/integration.go
@@ -44,7 +44,7 @@ type KnTest struct {
 	kn        Kn
 }
 
-// NewIntegrationTest creates a new ItegrationTest object
+// NewKnTest creates a new KnTest object
 func NewKnTest() (*KnTest, error) {
 	ns := NextNamespace()
 
@@ -68,7 +68,7 @@ func (test *KnTest) Teardown() error {
 	return DeleteNamespace(test.namespace)
 }
 
-// Teardown clean up
+// Kn object used by this KnTest
 func (test *KnTest) Kn() Kn {
 	return test.kn
 }

--- a/lib/test/result_collector.go
+++ b/lib/test/result_collector.go
@@ -49,12 +49,12 @@ type KnRunResultCollector struct {
 func NewKnRunResultCollector(t *testing.T) *KnRunResultCollector {
 	return &KnRunResultCollector{
 		results:    []KnRunResult{},
-		t:          t,
 		extraDumps: []string{},
+		t:          t,
 	}
 }
 
-// AssertError helper to assert no error on result
+// AssertNoError helper to assert no error on result
 func (c *KnRunResultCollector) AssertNoError(result KnRunResult) {
 	c.results = append(c.results, result)
 	if result.Error != nil {

--- a/test/e2e/service_options_test.go
+++ b/test/e2e/service_options_test.go
@@ -107,9 +107,9 @@ func TestServiceOptions(t *testing.T) {
 		assert.NilError(t, err)
 	}
 	serviceCreateWithOptions(t, it, r, "svc6", "--user", strconv.FormatInt(uid, 10))
-	validateUserId(t, it, r, "svc6", uid)
+	validateUserID(t, it, r, "svc6", uid)
 	serviceUpdate(t, it, r, "svc6", "--user", strconv.FormatInt(uid+1, 10))
-	validateUserId(t, it, r, "svc6", uid+1)
+	validateUserID(t, it, r, "svc6", uid+1)
 }
 
 func serviceCreateWithOptions(t *testing.T, it *test.KnTest, r *test.KnRunResultCollector, serviceName string, options ...string) {
@@ -177,7 +177,7 @@ func validateContainerField(t *testing.T, it *test.KnTest, r *test.KnRunResultCo
 	r.AssertNoError(out)
 }
 
-func validateUserId(t *testing.T, it *test.KnTest, r *test.KnRunResultCollector, serviceName string, uid int64) {
+func validateUserID(t *testing.T, it *test.KnTest, r *test.KnRunResultCollector, serviceName string, uid int64) {
 	out := it.Kn().Run("service", "describe", serviceName, "-ojson")
 	data := json.NewDecoder(strings.NewReader(out.Stdout))
 	data.UseNumber()

--- a/test/e2e/source_apiserver_test.go
+++ b/test/e2e/source_apiserver_test.go
@@ -41,7 +41,7 @@ func TestSourceApiServer(t *testing.T) {
 	it, err := test.NewKnTest()
 	assert.NilError(t, err)
 	defer func() {
-		err1 := tearDownForSourceApiServer(t, it)
+		err1 := tearDownForSourceAPIServer(t, it)
 		err2 := it.Teardown()
 		assert.NilError(t, err1)
 		assert.NilError(t, err2)
@@ -50,7 +50,7 @@ func TestSourceApiServer(t *testing.T) {
 	r := test.NewKnRunResultCollector(t)
 	defer r.DumpIfFailed()
 
-	setupForSourceApiServer(t, it)
+	setupForSourceAPIServer(t, it)
 	serviceCreate(t, it, r, "testsvc0")
 
 	t.Log("create apiserver sources with a sink to a service")
@@ -103,7 +103,7 @@ func apiServerSourceDelete(t *testing.T, it *test.KnTest, r *test.KnRunResultCol
 	assert.Check(t, util.ContainsAllIgnoreCase(out.Stdout, "apiserver", "source", sourceName, "deleted", "namespace", it.Kn().Namespace()))
 }
 
-func setupForSourceApiServer(t *testing.T, it *test.KnTest) {
+func setupForSourceAPIServer(t *testing.T, it *test.KnTest) {
 	_, err := test.NewKubectl(it.Kn().Namespace()).Run("create", "serviceaccount", testServiceAccount)
 	assert.NilError(t, err)
 
@@ -119,7 +119,7 @@ func setupForSourceApiServer(t *testing.T, it *test.KnTest) {
 	assert.NilError(t, err)
 }
 
-func tearDownForSourceApiServer(t *testing.T, it *test.KnTest) error {
+func tearDownForSourceAPIServer(t *testing.T, it *test.KnTest) error {
 	saCmd := []string{"delete", "serviceaccount", testServiceAccount}
 	_, err := test.NewKubectl(it.Kn().Namespace()).Run(saCmd...)
 	if err != nil {

--- a/test/e2e/traffic_split_test.go
+++ b/test/e2e/traffic_split_test.go
@@ -413,7 +413,7 @@ func TestTrafficSplit(t *testing.T) {
 }
 
 func verifyTargets(t *testing.T, it *test.KnTest, r *test.KnRunResultCollector, serviceName string, expectedTargets []TargetFields) {
-	out := serviceDescribeWithJsonPath(t, it, r, serviceName, targetsJsonPath)
+	out := serviceDescribeWithJSONPath(t, it, r, serviceName, targetsJsonPath)
 	assert.Check(t, out != "")
 	actualTargets, err := splitTargets(out, targetsSeparator, len(expectedTargets))
 	assert.NilError(t, err)
@@ -424,7 +424,7 @@ func verifyTargets(t *testing.T, it *test.KnTest, r *test.KnRunResultCollector, 
 	}
 }
 
-func serviceDescribeWithJsonPath(t *testing.T, it *test.KnTest, r *test.KnRunResultCollector, serviceName, jsonpath string) string {
+func serviceDescribeWithJSONPath(t *testing.T, it *test.KnTest, r *test.KnRunResultCollector, serviceName, jsonpath string) string {
 	out := it.Kn().Run("service", "describe", serviceName, "-o", jsonpath)
 	r.AssertNoError(out)
 	return out.Stdout


### PR DESCRIPTION
## Description

Fixes various godoc comments that are not conforming as well as some /lint issues that came up

## Changes

* correct signatures for some functions with with non-conforming names
* various corrections to Godoc comments for exported code in new lib/test
* fix CHANGELOG.doc for new location for common test code

## Reference

Fixes #769

/lint