### PR TITLE
Fix error when output is set to name

### DIFF
--- a/pkg/kn/commands/flags/listprint.go
+++ b/pkg/kn/commands/flags/listprint.go
@@ -15,11 +15,15 @@
 package flags
 
 import (
+	"io"
+
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"knative.dev/client/pkg/kn/commands"
 	hprinters "knative.dev/client/pkg/printers"
+	"knative.dev/client/pkg/util"
 )
 
 // ListFlags composes common printer flag structs
@@ -54,6 +58,24 @@ func (f *ListPrintFlags) ToPrinter() (hprinters.ResourcePrinter, error) {
 		return nil, err
 	}
 	return p, nil
+}
+
+// Print is to print an Object to a Writer
+func (f *ListPrintFlags) Print(obj runtime.Object, w io.Writer) error {
+	printer, err := f.ToPrinter()
+	if err != nil {
+		return err
+	}
+
+	if f.GenericPrintFlags.OutputFlagSpecified() {
+		unstructuredList, err := util.ToUnstructuredList(obj)
+		if err != nil {
+			return err
+		}
+		return printer.PrintObj(unstructuredList, w)
+	}
+
+	return printer.PrintObj(obj, w)
 }
 
 // AddFlags receives a *cobra.Command reference and binds

--- a/pkg/kn/commands/flags/listprint_test.go
+++ b/pkg/kn/commands/flags/listprint_test.go
@@ -48,3 +48,18 @@ func TestListPrintFlags(t *testing.T) {
 	_, ok := p.(hprinters.ResourcePrinter)
 	assert.Check(t, ok == true)
 }
+
+func TestListPrintFlagsPrint(t *testing.T) {
+	var cmd *cobra.Command
+	flags := NewListPrintFlags(func(h hprinters.PrintHandler) {})
+
+	cmd = &cobra.Command{}
+	flags.AddFlags(cmd)
+
+	pr, err := flags.ToPrinter()
+	assert.NilError(t, err)
+	assert.Assert(t, pr != nil)
+
+	err = flags.Print(nil, cmd.OutOrStdout())
+	assert.NilError(t, err)
+}

--- a/pkg/kn/commands/service/list.go
+++ b/pkg/kn/commands/service/list.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/client/pkg/kn/commands"
 	"knative.dev/client/pkg/kn/commands/flags"
 	clientservingv1 "knative.dev/client/pkg/serving/v1"
+	"knative.dev/client/pkg/util"
 )
 
 // NewServiceListCommand represents 'kn service list' command
@@ -81,11 +82,15 @@ func NewServiceListCommand(p *commands.KnParams) *cobra.Command {
 				return a.ObjectMeta.Name < b.ObjectMeta.Name
 			})
 
-			err = printer.PrintObj(serviceList, cmd.OutOrStdout())
-			if err != nil {
-				return err
+			if serviceListFlags.GenericPrintFlags.OutputFlagSpecified() {
+				unstructedList, err := util.ToUnstructuredList(serviceList)
+				if err != nil {
+					return err
+				}
+				return printer.PrintObj(unstructedList, cmd.OutOrStdout())
 			}
-			return nil
+
+			return printer.PrintObj(serviceList, cmd.OutOrStdout())
 		},
 	}
 	commands.AddNamespaceFlags(serviceListCommand.Flags(), true)

--- a/pkg/kn/commands/service/list.go
+++ b/pkg/kn/commands/service/list.go
@@ -24,7 +24,6 @@ import (
 	"knative.dev/client/pkg/kn/commands"
 	"knative.dev/client/pkg/kn/commands/flags"
 	clientservingv1 "knative.dev/client/pkg/serving/v1"
-	"knative.dev/client/pkg/util"
 )
 
 // NewServiceListCommand represents 'kn service list' command
@@ -66,11 +65,6 @@ func NewServiceListCommand(p *commands.KnParams) *cobra.Command {
 				serviceListFlags.EnsureWithNamespace()
 			}
 
-			printer, err := serviceListFlags.ToPrinter()
-			if err != nil {
-				return err
-			}
-
 			// Sort serviceList by namespace and name (in this order)
 			sort.SliceStable(serviceList.Items, func(i, j int) bool {
 				a := serviceList.Items[i]
@@ -82,15 +76,7 @@ func NewServiceListCommand(p *commands.KnParams) *cobra.Command {
 				return a.ObjectMeta.Name < b.ObjectMeta.Name
 			})
 
-			if serviceListFlags.GenericPrintFlags.OutputFlagSpecified() {
-				unstructedList, err := util.ToUnstructuredList(serviceList)
-				if err != nil {
-					return err
-				}
-				return printer.PrintObj(unstructedList, cmd.OutOrStdout())
-			}
-
-			return printer.PrintObj(serviceList, cmd.OutOrStdout())
+			return serviceListFlags.Print(serviceList, cmd.OutOrStdout())
 		},
 	}
 	commands.AddNamespaceFlags(serviceListCommand.Flags(), true)

--- a/pkg/printers/tableprinter.go
+++ b/pkg/printers/tableprinter.go
@@ -41,6 +41,10 @@ func NewTablePrinter(options PrintOptions) *HumanReadablePrinter {
 
 // PrintObj prints the obj in a human-friendly format according to the type of the obj.
 func (h *HumanReadablePrinter) PrintObj(obj runtime.Object, output io.Writer) error {
+	if obj == nil {
+		return nil
+	}
+
 	w, found := output.(*tabwriter.Writer)
 	if !found {
 		w = NewTabWriter(output)

--- a/pkg/util/unstructured.go
+++ b/pkg/util/unstructured.go
@@ -22,16 +22,18 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// ToUnstructuredList is to converts an object to unstructured.UnstructuredList.
+// If the object is not a list type, it will convert to a single item UnstructuredList.
 func ToUnstructuredList(obj runtime.Object) (*unstructured.UnstructuredList, error) {
 	unstructuredList := &unstructured.UnstructuredList{}
-	unstructuredList.SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
 	if meta.IsListType(obj) {
+		unstructuredList.SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
 		items, err := meta.ExtractList(obj)
 		if err != nil {
 			return nil, err
 		}
-		for _, obj := range items {
-			ud, err := toUnstructured(obj)
+		for _, obji := range items {
+			ud, err := toUnstructured(obji)
 			if err != nil {
 				return nil, err
 			}
@@ -39,7 +41,11 @@ func ToUnstructuredList(obj runtime.Object) (*unstructured.UnstructuredList, err
 		}
 
 	} else {
-
+		ud, err := toUnstructured(obj)
+		if err != nil {
+			return nil, err
+		}
+		unstructuredList.Items = append(unstructuredList.Items, *ud)
 	}
 	return unstructuredList, nil
 

--- a/pkg/util/unstructured.go
+++ b/pkg/util/unstructured.go
@@ -1,0 +1,58 @@
+// Copyright © 2020 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"encoding/json"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func ToUnstructuredList(obj runtime.Object) (*unstructured.UnstructuredList, error) {
+	unstructuredList := &unstructured.UnstructuredList{}
+	unstructuredList.SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
+	if meta.IsListType(obj) {
+		items, err := meta.ExtractList(obj)
+		if err != nil {
+			return nil, err
+		}
+		for _, obj := range items {
+			ud, err := toUnstructured(obj)
+			if err != nil {
+				return nil, err
+			}
+			unstructuredList.Items = append(unstructuredList.Items, *ud)
+		}
+
+	} else {
+
+	}
+	return unstructuredList, nil
+
+}
+
+func toUnstructured(obj runtime.Object) (*unstructured.Unstructured, error) {
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+	ud := &unstructured.Unstructured{}
+	if err := json.Unmarshal(b, ud); err != nil {
+		return nil, err
+	}
+	return ud, nil
+}

--- a/pkg/util/unstructured_test.go
+++ b/pkg/util/unstructured_test.go
@@ -1,0 +1,79 @@
+// Copyright © 2019 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
+)
+
+func TestToUnstructuredList(t *testing.T) {
+	serviceList := servingv1.ServiceList{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "List",
+		},
+		Items: []servingv1.Service{createService("s1"), createService("s2")},
+	}
+	expectedList := &unstructured.UnstructuredList{
+		Object: map[string]interface{}{
+			"apiVersion": string("v1"),
+			"kind":       string("List"),
+		},
+	}
+	expectedList.Items = []unstructured.Unstructured{createUnstructured("s1"), createUnstructured("s2")}
+	unstructedList, err := ToUnstructuredList(&serviceList)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, unstructedList, expectedList)
+}
+
+func createService(name string) servingv1.Service {
+	service := servingv1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "serving.knative.dev/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+	}
+	return service
+}
+
+func createUnstructured(name string) unstructured.Unstructured {
+	return unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "serving.knative.dev/v1",
+			"kind":       "Service",
+			"metadata": map[string]interface{}{
+				"namespace":         "default",
+				"name":              name,
+				"creationTimestamp": nil,
+			},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"metadata": map[string]interface{}{"creationTimestamp": nil},
+					"spec":     map[string]interface{}{"containers": nil},
+				},
+			},
+			"status": map[string]interface{}{},
+		},
+	}
+}

--- a/pkg/util/unstructured_test.go
+++ b/pkg/util/unstructured_test.go
@@ -41,6 +41,13 @@ func TestToUnstructuredList(t *testing.T) {
 	unstructedList, err := ToUnstructuredList(&serviceList)
 	assert.NilError(t, err)
 	assert.DeepEqual(t, unstructedList, expectedList)
+
+	service1 := createService("s3")
+	expectedList = &unstructured.UnstructuredList{}
+	expectedList.Items = []unstructured.Unstructured{createUnstructured("s3")}
+	unstructedList, err = ToUnstructuredList(&service1)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, unstructedList, expectedList)
 }
 
 func createService(name string) servingv1.Service {

--- a/test/e2e/basic_workflow_test.go
+++ b/test/e2e/basic_workflow_test.go
@@ -48,6 +48,9 @@ func TestBasicWorkflow(t *testing.T) {
 	serviceList(r, "hello")
 	serviceDescribe(r, "hello")
 
+	t.Log("return list --output name about hello service")
+	serviceListOutput(t, it, r, "hello")
+
 	t.Log("update hello service's configuration and return no error")
 	serviceUpdate(r, "hello", "--env", "TARGET=kn", "--port", "8888")
 
@@ -111,6 +114,12 @@ func serviceDescribe(r *test.KnRunResultCollector, serviceName string) {
 	assert.Assert(r.T(), util.ContainsAll(out.Stdout, serviceName, r.KnTest().Kn().Namespace(), test.KnDefaultTestImage))
 	assert.Assert(r.T(), util.ContainsAll(out.Stdout, "Conditions", "ConfigurationsReady", "Ready", "RoutesReady"))
 	assert.Assert(r.T(), util.ContainsAll(out.Stdout, "Name", "Namespace", "URL", "Age", "Revisions"))
+}
+
+func serviceListOutput(r *test.KnRunResultCollector, r *test.KnRunResultCollector, serviceName string) {
+	out := r.KnTest().Kn().Run("service", "list", serviceName, "--output", "name")
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAll(out.Stdout, serviceName, "service.serving.knative.dev"))
 }
 
 func serviceUpdate(r *test.KnRunResultCollector, serviceName string, args ...string) {

--- a/test/e2e/basic_workflow_test.go
+++ b/test/e2e/basic_workflow_test.go
@@ -49,7 +49,7 @@ func TestBasicWorkflow(t *testing.T) {
 	serviceDescribe(r, "hello")
 
 	t.Log("return list --output name about hello service")
-	serviceListOutput(t, it, r, "hello")
+	serviceListOutput(r, "hello")
 
 	t.Log("update hello service's configuration and return no error")
 	serviceUpdate(r, "hello", "--env", "TARGET=kn", "--port", "8888")
@@ -116,7 +116,7 @@ func serviceDescribe(r *test.KnRunResultCollector, serviceName string) {
 	assert.Assert(r.T(), util.ContainsAll(out.Stdout, "Name", "Namespace", "URL", "Age", "Revisions"))
 }
 
-func serviceListOutput(r *test.KnRunResultCollector, r *test.KnRunResultCollector, serviceName string) {
+func serviceListOutput(r *test.KnRunResultCollector, serviceName string) {
 	out := r.KnTest().Kn().Run("service", "list", serviceName, "--output", "name")
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAll(out.Stdout, serviceName, "service.serving.knative.dev"))


### PR DESCRIPTION
## Describe

Fix the error when calling `kn service list -o name`. Because the default name printer only supports `unstructured.UnstructuredList`, we have to convert `servingv1.ServiceList` to `unstructured.UnstructuredList` when output flag is set.

## Changes

* Convert servingv1.ServiceList to unstructured.UnstructuredList when output flag is set in `kn service list -o name`

## Reference

Fixes #754 