### PR TITLE
Add -a flag as alias for --annotation

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -34,6 +34,10 @@
 | Correct error message when updating service
 | https://github.com/knative/client/pull/778[#778]
 
+| 🎁
+| Add `-a` flag as an alias for `--annotation`
+| https://github.com/knative/client/pull/782[#782]
+
 |===
 
 ## v0.13.1 (2020-03-25)

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -45,7 +45,7 @@ kn service create NAME --image IMAGE [flags]
 ### Options
 
 ```
-      --annotation stringArray        Service annotation to set. name=value; you may provide this flag any number of times to set multiple annotations. To unset, specify the annotation name followed by a "-" (e.g., name-).
+  -a, --annotation stringArray        Service annotation to set. name=value; you may provide this flag any number of times to set multiple annotations. To unset, specify the annotation name followed by a "-" (e.g., name-).
       --arg stringArray               Add argument to the container command. Example: --arg myArg1 --arg --myArg2 --arg myArg3=3. You can use this flag multiple times.
       --async                         DEPRECATED: please use --no-wait instead. Create service and don't wait for it to be ready.
       --autoscale-window string       Duration to look back for making auto-scaling decisions. The service is scaled to zero if no request was received in during that time. (eg: 10s)

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -38,7 +38,7 @@ kn service update NAME [flags]
 ### Options
 
 ```
-      --annotation stringArray        Service annotation to set. name=value; you may provide this flag any number of times to set multiple annotations. To unset, specify the annotation name followed by a "-" (e.g., name-).
+  -a, --annotation stringArray        Service annotation to set. name=value; you may provide this flag any number of times to set multiple annotations. To unset, specify the annotation name followed by a "-" (e.g., name-).
       --arg stringArray               Add argument to the container command. Example: --arg myArg1 --arg --myArg2 --arg myArg3=3. You can use this flag multiple times.
       --async                         DEPRECATED: please use --no-wait instead. Update service and don't wait for it to be ready.
       --autoscale-window string       Duration to look back for making auto-scaling decisions. The service is scaled to zero if no request was received in during that time. (eg: 10s)

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -225,7 +225,7 @@ func (p *ConfigurationEditFlags) addSharedFlags(command *cobra.Command) {
 		"Service account name to set. An empty argument (\"\") clears the service account. The referenced service account must exist in the service's namespace.")
 	p.markFlagMakesRevision("service-account")
 
-	command.Flags().StringArrayVar(&p.Annotations, "annotation", []string{},
+	command.Flags().StringArrayVarP(&p.Annotations, "annotation", "a", []string{},
 		"Service annotation to set. name=value; you may provide this flag "+
 			"any number of times to set multiple annotations. "+
 			"To unset, specify the annotation name followed by a \"-\" (e.g., name-).")

--- a/test/e2e/service_options_test.go
+++ b/test/e2e/service_options_test.go
@@ -87,6 +87,13 @@ func TestServiceOptions(t *testing.T) {
 	validateServiceAnnotations(r, "svc3", map[string]string{"alpha": "direwolf", "brave": ""})
 	serviceDelete(r, "svc3")
 
+	t.Log("create, update and validate service with annotations but -a")
+	serviceCreateWithOptions(r, "svc3a", "-a", "alpha=wolf", "-a", "brave=horse")
+	validateServiceAnnotations(r, "svc3a", map[string]string{"alpha": "wolf", "brave": "horse"})
+	serviceUpdate(r, "svc3a", "-a", "alpha=direwolf", "-a", "brave-")
+	validateServiceAnnotations(r, "svc3a", map[string]string{"alpha": "direwolf", "brave": ""})
+	serviceDelete(r, "svc3a")
+
 	t.Log("create, update and validate service with autoscale window option")
 	serviceCreateWithOptions(r, "svc4", "--autoscale-window", "1m")
 	validateAutoscaleWindow(r, "svc4", "1m")


### PR DESCRIPTION
I find that I'm using annotations more and more and since `-a`
wasn't being used I decided we should save people from typing too much

Signed-off-by: Doug Davis <dug@us.ibm.com>

## Changes

* add support for `-a` as an alias for `--annotation`

/lint