### PR TITLE
Add target-utilization option for `service create` and `service update`

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,10 @@
 |===
 | | Description | PR
 
+| 🎁
+| Add concurrency-utilization option for `service create` and `service update` (`--concurrency-utilization`)
+| https://github.com/knative/client/pull/788[#788]
+
 | 🐣
 | Refactor `e2e` common code into `lib/test`
 | https://github.com/knative/client/pull/765[#765]

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -45,41 +45,42 @@ kn service create NAME --image IMAGE [flags]
 ### Options
 
 ```
-      --annotation stringArray       Service annotation to set. name=value; you may provide this flag any number of times to set multiple annotations. To unset, specify the annotation name followed by a "-" (e.g., name-).
-      --arg stringArray              Add argument to the container command. Example: --arg myArg1 --arg --myArg2 --arg myArg3=3. You can use this flag multiple times.
-      --async                        DEPRECATED: please use --no-wait instead. Create service and don't wait for it to be ready.
-      --autoscale-window string      Duration to look back for making auto-scaling decisions. The service is scaled to zero if no request was received in during that time. (eg: 10s)
-      --cluster-local                Specify that the service be private. (--no-cluster-local will make the service publicly available)
-      --cmd string                   Specify command to be used as entrypoint instead of default one. Example: --cmd /app/start or --cmd /app/start --arg myArg to pass aditional arguments.
-      --concurrency-limit int        Hard Limit of concurrent requests to be processed by a single replica.
-      --concurrency-target int       Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to --concurrency-limit when given.
-  -e, --env stringArray              Environment variable to set. NAME=value; you may provide this flag any number of times to set multiple environment variables. To unset, specify the environment variable name followed by a "-" (e.g., NAME-).
-      --env-from stringArray         Add environment variables from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret:). Example: --env-from cm:myconfigmap or --env-from secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --env-from cm:myconfigmap-.
-      --force                        Create service forcefully, replaces existing service if any.
-  -h, --help                         help for create
-      --image string                 Image to run.
-  -l, --label stringArray            Labels to set for both Service and Revision. name=value; you may provide this flag any number of times to set multiple labels. To unset, specify the label name followed by a "-" (e.g., name-).
-      --label-revision stringArray   Revision label to set. name=value; you may provide this flag any number of times to set multiple labels. To unset, specify the label name followed by a "-" (e.g., name-). This flag takes precedence over "label" flag.
-      --label-service stringArray    Service label to set. name=value; you may provide this flag any number of times to set multiple labels. To unset, specify the label name followed by a "-" (e.g., name-). This flag takes precedence over "label" flag.
-      --limits-cpu string            The limits on the requested CPU (e.g., 1000m).
-      --limits-memory string         The limits on the requested memory (e.g., 1024Mi).
-      --lock-to-digest               Keep the running image for the service constant when not explicitly specifying the image. (--no-lock-to-digest pulls the image tag afresh with each new revision) (default true)
-      --max-scale int                Maximal number of replicas.
-      --min-scale int                Minimal number of replicas.
-      --mount stringArray            Mount a ConfigMap (prefix cm: or config-map:), a Secret (prefix secret: or sc:), or an existing Volume (without any prefix) on the specified directory. Example: --mount /mydir=cm:myconfigmap, --mount /mydir=secret:mysecret, or --mount /mydir=myvolume. When a configmap or a secret is specified, a corresponding volume is automatically generated. You can use this flag multiple times. For unmounting a directory, append "-", e.g. --mount /mydir-, which also removes any auto-generated volume.
-  -n, --namespace string             Specify the namespace to operate in.
-      --no-cluster-local             Do not specify that the service be private. (--no-cluster-local will make the service publicly available) (default true)
-      --no-lock-to-digest            Do not keep the running image for the service constant when not explicitly specifying the image. (--no-lock-to-digest pulls the image tag afresh with each new revision)
-      --no-wait                      Create service and don't wait for it to be ready.
-  -p, --port int32                   The port where application listens on.
-      --pull-secret string           Image pull secret to set. An empty argument ("") clears the pull secret. The referenced secret must exist in the service's namespace.
-      --requests-cpu string          The requested CPU (e.g., 250m).
-      --requests-memory string       The requested memory (e.g., 64Mi).
-      --revision-name string         The revision name to set. Must start with the service name and a dash as a prefix. Empty revision name will result in the server generating a name for the revision. Accepts golang templates, allowing {{.Service}} for the service name, {{.Generation}} for the generation, and {{.Random [n]}} for n random consonants. (default "{{.Service}}-{{.Random 5}}-{{.Generation}}")
-      --service-account string       Service account name to set. An empty argument ("") clears the service account. The referenced service account must exist in the service's namespace.
-      --user int                     The user ID to run the container (e.g., 1001).
-      --volume stringArray           Add a volume from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret: or sc:). Example: --volume myvolume=cm:myconfigmap or --volume myvolume=secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --volume myvolume-.
-      --wait-timeout int             Seconds to wait before giving up on waiting for service to be ready. (default 600)
+      --annotation stringArray        Service annotation to set. name=value; you may provide this flag any number of times to set multiple annotations. To unset, specify the annotation name followed by a "-" (e.g., name-).
+      --arg stringArray               Add argument to the container command. Example: --arg myArg1 --arg --myArg2 --arg myArg3=3. You can use this flag multiple times.
+      --async                         DEPRECATED: please use --no-wait instead. Create service and don't wait for it to be ready.
+      --autoscale-window string       Duration to look back for making auto-scaling decisions. The service is scaled to zero if no request was received in during that time. (eg: 10s)
+      --cluster-local                 Specify that the service be private. (--no-cluster-local will make the service publicly available)
+      --cmd string                    Specify command to be used as entrypoint instead of default one. Example: --cmd /app/start or --cmd /app/start --arg myArg to pass aditional arguments.
+      --concurrency-limit int         Hard Limit of concurrent requests to be processed by a single replica.
+      --concurrency-target int        Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to --concurrency-limit when given.
+      --concurrency-utilization int   Percentage of concurrent requests utilization before scaling up. (default 70)
+  -e, --env stringArray               Environment variable to set. NAME=value; you may provide this flag any number of times to set multiple environment variables. To unset, specify the environment variable name followed by a "-" (e.g., NAME-).
+      --env-from stringArray          Add environment variables from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret:). Example: --env-from cm:myconfigmap or --env-from secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --env-from cm:myconfigmap-.
+      --force                         Create service forcefully, replaces existing service if any.
+  -h, --help                          help for create
+      --image string                  Image to run.
+  -l, --label stringArray             Labels to set for both Service and Revision. name=value; you may provide this flag any number of times to set multiple labels. To unset, specify the label name followed by a "-" (e.g., name-).
+      --label-revision stringArray    Revision label to set. name=value; you may provide this flag any number of times to set multiple labels. To unset, specify the label name followed by a "-" (e.g., name-). This flag takes precedence over "label" flag.
+      --label-service stringArray     Service label to set. name=value; you may provide this flag any number of times to set multiple labels. To unset, specify the label name followed by a "-" (e.g., name-). This flag takes precedence over "label" flag.
+      --limits-cpu string             The limits on the requested CPU (e.g., 1000m).
+      --limits-memory string          The limits on the requested memory (e.g., 1024Mi).
+      --lock-to-digest                Keep the running image for the service constant when not explicitly specifying the image. (--no-lock-to-digest pulls the image tag afresh with each new revision) (default true)
+      --max-scale int                 Maximal number of replicas.
+      --min-scale int                 Minimal number of replicas.
+      --mount stringArray             Mount a ConfigMap (prefix cm: or config-map:), a Secret (prefix secret: or sc:), or an existing Volume (without any prefix) on the specified directory. Example: --mount /mydir=cm:myconfigmap, --mount /mydir=secret:mysecret, or --mount /mydir=myvolume. When a configmap or a secret is specified, a corresponding volume is automatically generated. You can use this flag multiple times. For unmounting a directory, append "-", e.g. --mount /mydir-, which also removes any auto-generated volume.
+  -n, --namespace string              Specify the namespace to operate in.
+      --no-cluster-local              Do not specify that the service be private. (--no-cluster-local will make the service publicly available) (default true)
+      --no-lock-to-digest             Do not keep the running image for the service constant when not explicitly specifying the image. (--no-lock-to-digest pulls the image tag afresh with each new revision)
+      --no-wait                       Create service and don't wait for it to be ready.
+  -p, --port int32                    The port where application listens on.
+      --pull-secret string            Image pull secret to set. An empty argument ("") clears the pull secret. The referenced secret must exist in the service's namespace.
+      --requests-cpu string           The requested CPU (e.g., 250m).
+      --requests-memory string        The requested memory (e.g., 64Mi).
+      --revision-name string          The revision name to set. Must start with the service name and a dash as a prefix. Empty revision name will result in the server generating a name for the revision. Accepts golang templates, allowing {{.Service}} for the service name, {{.Generation}} for the generation, and {{.Random [n]}} for n random consonants. (default "{{.Service}}-{{.Random 5}}-{{.Generation}}")
+      --service-account string        Service account name to set. An empty argument ("") clears the service account. The referenced service account must exist in the service's namespace.
+      --user int                      The user ID to run the container (e.g., 1001).
+      --volume stringArray            Add a volume from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret: or sc:). Example: --volume myvolume=cm:myconfigmap or --volume myvolume=secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --volume myvolume-.
+      --wait-timeout int              Seconds to wait before giving up on waiting for service to be ready. (default 600)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -38,43 +38,44 @@ kn service update NAME [flags]
 ### Options
 
 ```
-      --annotation stringArray       Service annotation to set. name=value; you may provide this flag any number of times to set multiple annotations. To unset, specify the annotation name followed by a "-" (e.g., name-).
-      --arg stringArray              Add argument to the container command. Example: --arg myArg1 --arg --myArg2 --arg myArg3=3. You can use this flag multiple times.
-      --async                        DEPRECATED: please use --no-wait instead. Update service and don't wait for it to be ready.
-      --autoscale-window string      Duration to look back for making auto-scaling decisions. The service is scaled to zero if no request was received in during that time. (eg: 10s)
-      --cluster-local                Specify that the service be private. (--no-cluster-local will make the service publicly available)
-      --cmd string                   Specify command to be used as entrypoint instead of default one. Example: --cmd /app/start or --cmd /app/start --arg myArg to pass aditional arguments.
-      --concurrency-limit int        Hard Limit of concurrent requests to be processed by a single replica.
-      --concurrency-target int       Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to --concurrency-limit when given.
-  -e, --env stringArray              Environment variable to set. NAME=value; you may provide this flag any number of times to set multiple environment variables. To unset, specify the environment variable name followed by a "-" (e.g., NAME-).
-      --env-from stringArray         Add environment variables from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret:). Example: --env-from cm:myconfigmap or --env-from secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --env-from cm:myconfigmap-.
-  -h, --help                         help for update
-      --image string                 Image to run.
-  -l, --label stringArray            Labels to set for both Service and Revision. name=value; you may provide this flag any number of times to set multiple labels. To unset, specify the label name followed by a "-" (e.g., name-).
-      --label-revision stringArray   Revision label to set. name=value; you may provide this flag any number of times to set multiple labels. To unset, specify the label name followed by a "-" (e.g., name-). This flag takes precedence over "label" flag.
-      --label-service stringArray    Service label to set. name=value; you may provide this flag any number of times to set multiple labels. To unset, specify the label name followed by a "-" (e.g., name-). This flag takes precedence over "label" flag.
-      --limits-cpu string            The limits on the requested CPU (e.g., 1000m).
-      --limits-memory string         The limits on the requested memory (e.g., 1024Mi).
-      --lock-to-digest               Keep the running image for the service constant when not explicitly specifying the image. (--no-lock-to-digest pulls the image tag afresh with each new revision) (default true)
-      --max-scale int                Maximal number of replicas.
-      --min-scale int                Minimal number of replicas.
-      --mount stringArray            Mount a ConfigMap (prefix cm: or config-map:), a Secret (prefix secret: or sc:), or an existing Volume (without any prefix) on the specified directory. Example: --mount /mydir=cm:myconfigmap, --mount /mydir=secret:mysecret, or --mount /mydir=myvolume. When a configmap or a secret is specified, a corresponding volume is automatically generated. You can use this flag multiple times. For unmounting a directory, append "-", e.g. --mount /mydir-, which also removes any auto-generated volume.
-  -n, --namespace string             Specify the namespace to operate in.
-      --no-cluster-local             Do not specify that the service be private. (--no-cluster-local will make the service publicly available) (default true)
-      --no-lock-to-digest            Do not keep the running image for the service constant when not explicitly specifying the image. (--no-lock-to-digest pulls the image tag afresh with each new revision)
-      --no-wait                      Update service and don't wait for it to be ready.
-  -p, --port int32                   The port where application listens on.
-      --pull-secret string           Image pull secret to set. An empty argument ("") clears the pull secret. The referenced secret must exist in the service's namespace.
-      --requests-cpu string          The requested CPU (e.g., 250m).
-      --requests-memory string       The requested memory (e.g., 64Mi).
-      --revision-name string         The revision name to set. Must start with the service name and a dash as a prefix. Empty revision name will result in the server generating a name for the revision. Accepts golang templates, allowing {{.Service}} for the service name, {{.Generation}} for the generation, and {{.Random [n]}} for n random consonants. (default "{{.Service}}-{{.Random 5}}-{{.Generation}}")
-      --service-account string       Service account name to set. An empty argument ("") clears the service account. The referenced service account must exist in the service's namespace.
-      --tag strings                  Set tag (format: --tag revisionRef=tagName) where revisionRef can be a revision or '@latest' string representing latest ready revision. This flag can be specified multiple times.
-      --traffic strings              Set traffic distribution (format: --traffic revisionRef=percent) where revisionRef can be a revision or a tag or '@latest' string representing latest ready revision. This flag can be given multiple times with percent summing up to 100%.
-      --untag strings                Untag revision (format: --untag tagName). This flag can be specified multiple times.
-      --user int                     The user ID to run the container (e.g., 1001).
-      --volume stringArray           Add a volume from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret: or sc:). Example: --volume myvolume=cm:myconfigmap or --volume myvolume=secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --volume myvolume-.
-      --wait-timeout int             Seconds to wait before giving up on waiting for service to be ready. (default 600)
+      --annotation stringArray        Service annotation to set. name=value; you may provide this flag any number of times to set multiple annotations. To unset, specify the annotation name followed by a "-" (e.g., name-).
+      --arg stringArray               Add argument to the container command. Example: --arg myArg1 --arg --myArg2 --arg myArg3=3. You can use this flag multiple times.
+      --async                         DEPRECATED: please use --no-wait instead. Update service and don't wait for it to be ready.
+      --autoscale-window string       Duration to look back for making auto-scaling decisions. The service is scaled to zero if no request was received in during that time. (eg: 10s)
+      --cluster-local                 Specify that the service be private. (--no-cluster-local will make the service publicly available)
+      --cmd string                    Specify command to be used as entrypoint instead of default one. Example: --cmd /app/start or --cmd /app/start --arg myArg to pass aditional arguments.
+      --concurrency-limit int         Hard Limit of concurrent requests to be processed by a single replica.
+      --concurrency-target int        Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to --concurrency-limit when given.
+      --concurrency-utilization int   Percentage of concurrent requests utilization before scaling up. (default 70)
+  -e, --env stringArray               Environment variable to set. NAME=value; you may provide this flag any number of times to set multiple environment variables. To unset, specify the environment variable name followed by a "-" (e.g., NAME-).
+      --env-from stringArray          Add environment variables from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret:). Example: --env-from cm:myconfigmap or --env-from secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --env-from cm:myconfigmap-.
+  -h, --help                          help for update
+      --image string                  Image to run.
+  -l, --label stringArray             Labels to set for both Service and Revision. name=value; you may provide this flag any number of times to set multiple labels. To unset, specify the label name followed by a "-" (e.g., name-).
+      --label-revision stringArray    Revision label to set. name=value; you may provide this flag any number of times to set multiple labels. To unset, specify the label name followed by a "-" (e.g., name-). This flag takes precedence over "label" flag.
+      --label-service stringArray     Service label to set. name=value; you may provide this flag any number of times to set multiple labels. To unset, specify the label name followed by a "-" (e.g., name-). This flag takes precedence over "label" flag.
+      --limits-cpu string             The limits on the requested CPU (e.g., 1000m).
+      --limits-memory string          The limits on the requested memory (e.g., 1024Mi).
+      --lock-to-digest                Keep the running image for the service constant when not explicitly specifying the image. (--no-lock-to-digest pulls the image tag afresh with each new revision) (default true)
+      --max-scale int                 Maximal number of replicas.
+      --min-scale int                 Minimal number of replicas.
+      --mount stringArray             Mount a ConfigMap (prefix cm: or config-map:), a Secret (prefix secret: or sc:), or an existing Volume (without any prefix) on the specified directory. Example: --mount /mydir=cm:myconfigmap, --mount /mydir=secret:mysecret, or --mount /mydir=myvolume. When a configmap or a secret is specified, a corresponding volume is automatically generated. You can use this flag multiple times. For unmounting a directory, append "-", e.g. --mount /mydir-, which also removes any auto-generated volume.
+  -n, --namespace string              Specify the namespace to operate in.
+      --no-cluster-local              Do not specify that the service be private. (--no-cluster-local will make the service publicly available) (default true)
+      --no-lock-to-digest             Do not keep the running image for the service constant when not explicitly specifying the image. (--no-lock-to-digest pulls the image tag afresh with each new revision)
+      --no-wait                       Update service and don't wait for it to be ready.
+  -p, --port int32                    The port where application listens on.
+      --pull-secret string            Image pull secret to set. An empty argument ("") clears the pull secret. The referenced secret must exist in the service's namespace.
+      --requests-cpu string           The requested CPU (e.g., 250m).
+      --requests-memory string        The requested memory (e.g., 64Mi).
+      --revision-name string          The revision name to set. Must start with the service name and a dash as a prefix. Empty revision name will result in the server generating a name for the revision. Accepts golang templates, allowing {{.Service}} for the service name, {{.Generation}} for the generation, and {{.Random [n]}} for n random consonants. (default "{{.Service}}-{{.Random 5}}-{{.Generation}}")
+      --service-account string        Service account name to set. An empty argument ("") clears the service account. The referenced service account must exist in the service's namespace.
+      --tag strings                   Set tag (format: --tag revisionRef=tagName) where revisionRef can be a revision or '@latest' string representing latest ready revision. This flag can be specified multiple times.
+      --traffic strings               Set traffic distribution (format: --traffic revisionRef=percent) where revisionRef can be a revision or a tag or '@latest' string representing latest ready revision. This flag can be given multiple times with percent summing up to 100%.
+      --untag strings                 Untag revision (format: --untag tagName). This flag can be specified multiple times.
+      --user int                      The user ID to run the container (e.g., 1001).
+      --volume stringArray            Add a volume from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret: or sc:). Example: --volume myvolume=cm:myconfigmap or --volume myvolume=secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --volume myvolume-.
+      --wait-timeout int              Seconds to wait before giving up on waiting for service to be ready. (default 600)
 ```
 
 ### Options inherited from parent commands

--- a/pkg/kn/commands/revision/describe.go
+++ b/pkg/kn/commands/revision/describe.go
@@ -131,7 +131,8 @@ func WriteConcurrencyOptions(dw printers.PrefixWriter, revision *servingv1.Revis
 	target := clientserving.ConcurrencyTarget(&revision.ObjectMeta)
 	limit := revision.Spec.ContainerConcurrency
 	autoscaleWindow := clientserving.AutoscaleWindow(&revision.ObjectMeta)
-	if target != nil || limit != nil && *limit != 0 || autoscaleWindow != "" {
+	concurrencyUtilization := clientserving.ConcurrencyTargetUtilization(&revision.ObjectMeta)
+	if target != nil || limit != nil && *limit != 0 || autoscaleWindow != "" || concurrencyUtilization != nil {
 		section := dw.WriteAttribute("Concurrency", "")
 		if limit != nil && *limit != 0 {
 			section.WriteAttribute("Limit", strconv.FormatInt(int64(*limit), 10))
@@ -141,6 +142,9 @@ func WriteConcurrencyOptions(dw printers.PrefixWriter, revision *servingv1.Revis
 		}
 		if autoscaleWindow != "" {
 			section.WriteAttribute("Window", autoscaleWindow)
+		}
+		if concurrencyUtilization != nil {
+			section.WriteAttribute("TargetUtilization", strconv.Itoa(*concurrencyUtilization))
 		}
 	}
 

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -48,6 +48,7 @@ type ConfigurationEditFlags struct {
 	MaxScale                   int
 	ConcurrencyTarget          int
 	ConcurrencyLimit           int
+	ConcurrencyUtilization     int
 	AutoscaleWindow            string
 	Port                       int32
 	Labels                     []string
@@ -179,6 +180,10 @@ func (p *ConfigurationEditFlags) addSharedFlags(command *cobra.Command) {
 	command.Flags().IntVar(&p.ConcurrencyLimit, "concurrency-limit", 0,
 		"Hard Limit of concurrent requests to be processed by a single replica.")
 	p.markFlagMakesRevision("concurrency-limit")
+
+	command.Flags().IntVar(&p.ConcurrencyUtilization, "concurrency-utilization", 70,
+		"Percentage of concurrent requests utilization before scaling up.")
+	p.markFlagMakesRevision("concurrency-utilization")
 
 	command.Flags().Int32VarP(&p.Port, "port", "p", 0, "The port where application listens on.")
 	p.markFlagMakesRevision("port")
@@ -399,6 +404,13 @@ func (p *ConfigurationEditFlags) Apply(
 
 	if cmd.Flags().Changed("concurrency-limit") {
 		err = servinglib.UpdateConcurrencyLimit(template, int64(p.ConcurrencyLimit))
+		if err != nil {
+			return err
+		}
+	}
+
+	if cmd.Flags().Changed("concurrency-utilization") {
+		err = servinglib.UpdateConcurrencyUtilization(template, p.ConcurrencyUtilization)
 		if err != nil {
 			return err
 		}

--- a/pkg/kn/commands/service/create_test.go
+++ b/pkg/kn/commands/service/create_test.go
@@ -377,6 +377,7 @@ func TestServiceCreateMaxMinScale(t *testing.T) {
 		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
 		"--min-scale", "1", "--max-scale", "5",
 		"--concurrency-target", "10", "--concurrency-limit", "100",
+		"--concurrency-utilization", "50",
 		"--no-wait"}, false)
 
 	if err != nil {
@@ -392,6 +393,7 @@ func TestServiceCreateMaxMinScale(t *testing.T) {
 		"autoscaling.knative.dev/minScale", "1",
 		"autoscaling.knative.dev/maxScale", "5",
 		"autoscaling.knative.dev/target", "10",
+		"autoscaling.knative.dev/targetUtilizationPercentage", "50",
 	}
 
 	for i := 0; i < len(expectedAnnos); i += 2 {

--- a/pkg/kn/commands/service/update_test.go
+++ b/pkg/kn/commands/service/update_test.go
@@ -319,7 +319,7 @@ func TestServiceUpdateMaxMinScale(t *testing.T) {
 
 	action, updated, _, err := fakeServiceUpdate(original, []string{
 		"service", "update", "foo",
-		"--min-scale", "1", "--max-scale", "5", "--concurrency-target", "10", "--concurrency-limit", "100", "--no-wait"})
+		"--min-scale", "1", "--max-scale", "5", "--concurrency-target", "10", "--concurrency-limit", "100", "--concurrency-utilization", "50", "--no-wait"})
 
 	if err != nil {
 		t.Fatal(err)
@@ -337,6 +337,7 @@ func TestServiceUpdateMaxMinScale(t *testing.T) {
 		"autoscaling.knative.dev/minScale", "1",
 		"autoscaling.knative.dev/maxScale", "5",
 		"autoscaling.knative.dev/target", "10",
+		"autoscaling.knative.dev/targetUtilizationPercentage", "50",
 	}
 
 	for i := 0; i < len(expectedAnnos); i += 2 {

--- a/pkg/serving/config_changes.go
+++ b/pkg/serving/config_changes.go
@@ -198,6 +198,11 @@ func UpdateConcurrencyTarget(template *servingv1.RevisionTemplateSpec, target in
 	return UpdateRevisionTemplateAnnotation(template, autoscaling.TargetAnnotationKey, strconv.Itoa(target))
 }
 
+// UpdateConcurrencyUtilization updates container target utilization percentage annotation
+func UpdateConcurrencyUtilization(template *servingv1.RevisionTemplateSpec, target int) error {
+	return UpdateRevisionTemplateAnnotation(template, autoscaling.TargetUtilizationPercentageKey, strconv.Itoa(target))
+}
+
 // UpdateConcurrencyLimit updates container concurrency limit
 func UpdateConcurrencyLimit(template *servingv1.RevisionTemplateSpec, limit int64) error {
 	if limit < 0 {

--- a/pkg/serving/revision_template.go
+++ b/pkg/serving/revision_template.go
@@ -63,6 +63,11 @@ func ConcurrencyTarget(m *metav1.ObjectMeta) *int {
 	return ret
 }
 
+func ConcurrencyTargetUtilization(m *metav1.ObjectMeta) *int {
+	ret, _ := annotationAsInt(m, autoscaling.TargetUtilizationPercentageKey)
+	return ret
+}
+
 func AutoscaleWindow(m *metav1.ObjectMeta) string {
 	return m.Annotations[autoscaling.WindowAnnotationKey]
 }

--- a/test/e2e/service_options_test.go
+++ b/test/e2e/service_options_test.go
@@ -46,9 +46,10 @@ func TestServiceOptions(t *testing.T) {
 	t.Log("create and validate service with concurrency options")
 	defer r.DumpIfFailed()
 
-	serviceCreateWithOptions(r, "svc1", "--concurrency-limit", "250", "--concurrency-target", "300")
+	serviceCreateWithOptions(r, "svc1", "--concurrency-limit", "250", "--concurrency-target", "300", "--concurrency-utilization", "50")
 	validateServiceConcurrencyTarget(r, "svc1", "300")
 	validateServiceConcurrencyLimit(r, "svc1", "250")
+	validateServiceConcurrencyUtilization(r, "svc1", "50")
 
 	t.Log("update and validate service with concurrency limit")
 	serviceUpdate(r, "svc1", "--concurrency-limit", "300")
@@ -62,6 +63,7 @@ func TestServiceOptions(t *testing.T) {
 	t.Log("returns steady concurrency options for service")
 	validateServiceConcurrencyLimit(r, "svc1", "300")
 	validateServiceConcurrencyTarget(r, "svc1", "300")
+	validateServiceConcurrencyUtilization(r, "svc1", "50")
 
 	t.Log("delete service")
 	serviceDelete(r, "svc1")
@@ -132,6 +134,13 @@ func validateServiceConcurrencyTarget(r *test.KnRunResultCollector, serviceName,
 	jsonpath := "jsonpath={.items[0].spec.template.metadata.annotations.autoscaling\\.knative\\.dev/target}"
 	out := r.KnTest().Kn().Run("service", "list", serviceName, "-o", jsonpath)
 	assert.Equal(r.T(), out.Stdout, concurrencyTarget)
+	r.AssertNoError(out)
+}
+
+func validateServiceConcurrencyUtilization(r *test.KnRunResultCollector, serviceName, concurrencyUtilization string) {
+	jsonpath := "jsonpath={.items[0].spec.template.metadata.annotations.autoscaling\\.knative\\.dev/targetUtilizationPercentage}"
+	out := r.KnTest().Kn().Run("service", "list", serviceName, "-o", jsonpath)
+	assert.Equal(r.T(), out.Stdout, concurrencyUtilization)
 	r.AssertNoError(out)
 }
 


### PR DESCRIPTION
Fixes: #https://github.com/knative/client/issues/768

* Support setting "autoscaling.knative.dev/targetUtilizationPercentage" annotation.

Release Note:

- 🎁 New feature
Add "--target-utilization" to manage "autoscaling.knative.dev/targetUtilizationPercentage" annotation.

