### PR TITLE
e2e: Foreground delete for revisions and services in e2e

### DIFF
--- a/test/e2e/basic_workflow_test.go
+++ b/test/e2e/basic_workflow_test.go
@@ -131,7 +131,7 @@ func serviceUpdate(r *test.KnRunResultCollector, serviceName string, args ...str
 }
 
 func serviceDelete(r *test.KnRunResultCollector, serviceName string) {
-	out := r.KnTest().Kn().Run("service", "delete", serviceName)
+	out := r.KnTest().Kn().Run("service", "delete", "--no-wait=false", serviceName)
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAll(out.Stdout, "Service", serviceName, "successfully deleted in namespace", r.KnTest().Kn().Namespace()))
 }

--- a/test/e2e/basic_workflow_test.go
+++ b/test/e2e/basic_workflow_test.go
@@ -131,7 +131,7 @@ func serviceUpdate(r *test.KnRunResultCollector, serviceName string, args ...str
 }
 
 func serviceDelete(r *test.KnRunResultCollector, serviceName string) {
-	out := r.KnTest().Kn().Run("service", "delete", "--no-wait=false", serviceName)
+	out := r.KnTest().Kn().Run("service", "delete", "--wait", serviceName)
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAll(out.Stdout, "Service", serviceName, "successfully deleted in namespace", r.KnTest().Kn().Namespace()))
 }

--- a/test/e2e/revision_test.go
+++ b/test/e2e/revision_test.go
@@ -98,7 +98,7 @@ func revisionListWithService(r *test.KnRunResultCollector, serviceNames ...strin
 }
 
 func revisionDelete(r *test.KnRunResultCollector, revName string) {
-	out := r.KnTest().Kn().Run("revision", "delete", "--no-wait=false", revName)
+	out := r.KnTest().Kn().Run("revision", "delete", "--wait", revName)
 	assert.Check(r.T(), util.ContainsAll(out.Stdout, "Revision", revName, "deleted", "namespace", r.KnTest().Kn().Namespace()))
 	r.AssertNoError(out)
 }

--- a/test/e2e/revision_test.go
+++ b/test/e2e/revision_test.go
@@ -98,7 +98,7 @@ func revisionListWithService(r *test.KnRunResultCollector, serviceNames ...strin
 }
 
 func revisionDelete(r *test.KnRunResultCollector, revName string) {
-	out := r.KnTest().Kn().Run("revision", "delete", revName)
+	out := r.KnTest().Kn().Run("revision", "delete", "--no-wait=false", revName)
 	assert.Check(r.T(), util.ContainsAll(out.Stdout, "Revision", revName, "deleted", "namespace", r.KnTest().Kn().Namespace()))
 	r.AssertNoError(out)
 }


### PR DESCRIPTION
## Description
Since the default behavior is background deletion, add `--no-wait=false` to service/revision delete operations in e2e to avoid any race conditions and flakes

## Changes
- Add `--no-wait=false` for service/revision delete operations in e2e.

/lint
