### PR TITLE
Fix resource listing with -oname flag

### DIFF
--- a/pkg/kn/commands/revision/list.go
+++ b/pkg/kn/commands/revision/list.go
@@ -103,12 +103,7 @@ func NewRevisionListCommand(p *commands.KnParams) *cobra.Command {
 			sortRevisions(revisionList)
 
 			// Print out infos via printer framework
-			printer, err := revisionListFlags.ToPrinter()
-			if err != nil {
-				return err
-			}
-
-			return printer.PrintObj(revisionList, cmd.OutOrStdout())
+			return revisionListFlags.Print(revisionList, cmd.OutOrStdout())
 		},
 	}
 	commands.AddNamespaceFlags(revisionListCommand.Flags(), true)

--- a/pkg/kn/commands/route/list.go
+++ b/pkg/kn/commands/route/list.go
@@ -69,11 +69,7 @@ func NewRouteListCommand(p *commands.KnParams) *cobra.Command {
 				fmt.Fprintf(cmd.OutOrStdout(), "No routes found.\n")
 				return nil
 			}
-			printer, err := routeListFlags.ToPrinter()
-			if err != nil {
-				return err
-			}
-			err = printer.PrintObj(routeList, cmd.OutOrStdout())
+			err = routeListFlags.Print(routeList, cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}

--- a/pkg/kn/commands/source/apiserver/list.go
+++ b/pkg/kn/commands/source/apiserver/list.go
@@ -59,12 +59,7 @@ func NewAPIServerListCommand(p *commands.KnParams) *cobra.Command {
 				listFlags.EnsureWithNamespace()
 			}
 
-			printer, err := listFlags.ToPrinter()
-			if err != nil {
-				return nil
-			}
-
-			err = printer.PrintObj(sourceList, cmd.OutOrStdout())
+			err = listFlags.Print(sourceList, cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}

--- a/pkg/kn/commands/source/binding/list.go
+++ b/pkg/kn/commands/source/binding/list.go
@@ -58,12 +58,7 @@ func NewBindingListCommand(p *commands.KnParams) *cobra.Command {
 				listFlags.EnsureWithNamespace()
 			}
 
-			printer, err := listFlags.ToPrinter()
-			if err != nil {
-				return nil
-			}
-
-			err = printer.PrintObj(sourceList, cmd.OutOrStdout())
+			err = listFlags.Print(sourceList, cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}

--- a/pkg/kn/commands/source/ping/list.go
+++ b/pkg/kn/commands/source/ping/list.go
@@ -59,12 +59,7 @@ func NewPingListCommand(p *commands.KnParams) *cobra.Command {
 				listFlags.EnsureWithNamespace()
 			}
 
-			printer, err := listFlags.ToPrinter()
-			if err != nil {
-				return nil
-			}
-
-			err = printer.PrintObj(sourceList, cmd.OutOrStdout())
+			err = listFlags.Print(sourceList, cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}

--- a/pkg/kn/commands/trigger/list.go
+++ b/pkg/kn/commands/trigger/list.go
@@ -59,12 +59,7 @@ func NewTriggerListCommand(p *commands.KnParams) *cobra.Command {
 				triggerListFlags.EnsureWithNamespace()
 			}
 
-			printer, err := triggerListFlags.ToPrinter()
-			if err != nil {
-				return err
-			}
-
-			err = printer.PrintObj(triggerList, cmd.OutOrStdout())
+			err = triggerListFlags.Print(triggerList, cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}

--- a/test/e2e/ping_test.go
+++ b/test/e2e/ping_test.go
@@ -43,6 +43,7 @@ func TestSourcePing(t *testing.T) {
 	t.Log("create Ping sources with a sink to a service")
 
 	pingSourceCreate(r, "testpingsource0", "* * * * */1", "ping", "svc:testsvc0")
+	pingSourceListOutputName(r, "testpingsource0")
 
 	t.Log("delete Ping sources")
 	pingSourceDelete(r, "testpingsource0")
@@ -76,7 +77,12 @@ func pingSourceDelete(r *test.KnRunResultCollector, sourceName string) {
 	out := r.KnTest().Kn().Run("source", "ping", "delete", sourceName)
 	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "ping", "source", sourceName, "deleted", "namespace", r.KnTest().Kn().Namespace()))
 	r.AssertNoError(out)
+}
 
+func pingSourceListOutputName(r *test.KnRunResultCollector, pingSource string) {
+	out := r.KnTest().Kn().Run("source", "ping", "list", "--output", "name")
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAll(out.Stdout, pingSource))
 }
 
 func pingSourceCreateMissingSink(r *test.KnRunResultCollector, sourceName string, schedule string, data string, sink string) {

--- a/test/e2e/revision_test.go
+++ b/test/e2e/revision_test.go
@@ -45,6 +45,7 @@ func TestRevision(t *testing.T) {
 
 	t.Log("describe revision from hello service with print flags")
 	revName := findRevision(r, "hello")
+	revisionListOutputName(r, revName)
 	revisionDescribeWithPrintFlags(r, revName)
 
 	t.Log("update hello service and increase revision count to 2")
@@ -68,6 +69,12 @@ func TestRevision(t *testing.T) {
 
 	t.Log("delete hello service and return no error")
 	serviceDelete(r, "hello")
+}
+
+func revisionListOutputName(r *test.KnRunResultCollector, revisionName string) {
+	out := r.KnTest().Kn().Run("revision", "list", "--output", "name")
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAll(out.Stdout, revisionName, "revision.serving.knative.dev"))
 }
 
 func revisionListWithService(r *test.KnRunResultCollector, serviceNames ...string) {

--- a/test/e2e/route_test.go
+++ b/test/e2e/route_test.go
@@ -48,6 +48,9 @@ func TestRoute(t *testing.T) {
 	t.Log("return a list of routes associated with hello service")
 	routeListWithArgument(r, "hello")
 
+	t.Log("return a list of routes associated with hello service with -oname flag")
+	routeListOutputName(r, "hello")
+
 	t.Log("return a list of routes associated with hello service with print flags")
 	routeListWithPrintFlags(r, "hello")
 
@@ -67,6 +70,12 @@ func routeList(r *test.KnRunResultCollector) {
 	expectedHeaders := []string{"NAME", "URL", "READY"}
 	assert.Check(r.T(), util.ContainsAll(out.Stdout, expectedHeaders...))
 	r.AssertNoError(out)
+}
+
+func routeListOutputName(r *test.KnRunResultCollector, routeName string) {
+	out := r.KnTest().Kn().Run("route", "list", "--output", "name")
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAll(out.Stdout, routeName, "route.serving.knative.dev"))
 }
 
 func routeListWithArgument(r *test.KnRunResultCollector, routeName string) {

--- a/test/e2e/source_apiserver_test.go
+++ b/test/e2e/source_apiserver_test.go
@@ -56,6 +56,7 @@ func TestSourceApiServer(t *testing.T) {
 	t.Log("create apiserver sources with a sink to a service")
 	apiServerSourceCreate(r, "testapisource0", "Event:v1:true", "testsa", "svc:testsvc0")
 	apiServerSourceCreate(r, "testapisource1", "Event:v1", "testsa", "svc:testsvc0")
+	apiServerSourceListOutputName(r, "testapisource0", "testapisource1")
 
 	t.Log("list sources")
 	output := sourceList(r)
@@ -89,6 +90,12 @@ func apiServerSourceCreate(r *test.KnRunResultCollector, sourceName string, reso
 	out := r.KnTest().Kn().Run("source", "apiserver", "create", sourceName, "--resource", resources, "--service-account", sa, "--sink", sink)
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "apiserver", "source", sourceName, "created", "namespace", r.KnTest().Kn().Namespace()))
+}
+
+func apiServerSourceListOutputName(r *test.KnRunResultCollector, apiserverSources ...string) {
+	out := r.KnTest().Kn().Run("source", "apiserver", "list", "--output", "name")
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAll(out.Stdout, apiserverSources...))
 }
 
 func apiServerSourceCreateMissingSink(r *test.KnRunResultCollector, sourceName string, resources string, sa string, sink string) {

--- a/test/e2e/source_binding_test.go
+++ b/test/e2e/source_binding_test.go
@@ -41,6 +41,7 @@ func TestSourceBinding(t *testing.T) {
 
 	t.Log("create source binding")
 	sourceBindingCreate(r, "my-binding0", "Deployment:apps/v1:myapp", "svc:testsvc0")
+	sourceBindingListOutputName(r, "my-binding0")
 
 	t.Log("delete source binding")
 	sourceBindingDelete(r, "my-binding0")
@@ -71,4 +72,10 @@ func sourceBindingUpdate(r *test.KnRunResultCollector, bindingName string, subje
 	out := r.KnTest().Kn().Run("source", "binding", "update", bindingName, "--subject", subject, "--sink", sink)
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAll(out.Stdout, bindingName, "updated", "namespace", r.KnTest().Kn().Namespace()))
+}
+
+func sourceBindingListOutputName(r *test.KnRunResultCollector, bindingName string) {
+	out := r.KnTest().Kn().Run("source", "binding", "list", "--output", "name")
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAll(out.Stdout, bindingName))
 }

--- a/test/e2e/trigger_test.go
+++ b/test/e2e/trigger_test.go
@@ -51,6 +51,7 @@ func TestBrokerTrigger(t *testing.T) {
 	triggerCreate(r, "trigger1", "sinksvc0", []string{"a=b"})
 	triggerCreate(r, "trigger2", "sinksvc1", []string{"type=knative.dev.bar", "source=ping"})
 	verifyTriggerList(r, "trigger1", "trigger2")
+	verifyTriggerListOutputName(r, "trigger1", "trigger2")
 	triggerDelete(r, "trigger1")
 	triggerDelete(r, "trigger2")
 
@@ -137,6 +138,12 @@ func triggerUpdate(r *test.KnRunResultCollector, name string, filter string, sin
 
 func verifyTriggerList(r *test.KnRunResultCollector, triggers ...string) {
 	out := r.KnTest().Kn().Run("trigger", "list")
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, triggers...))
+}
+
+func verifyTriggerListOutputName(r *test.KnRunResultCollector, triggers ...string) {
+	out := r.KnTest().Kn().Run("trigger", "list", "--output", "name")
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, triggers...))
 }


### PR DESCRIPTION
## Description

Follow up PR #775  to fix other resources `list -oname` issue.

## Changes

* Fix errors of resource list command to support -oname flag

## Reference

Fixes #798 