### PR TITLE
Check DeleteTimestamp before updating resource

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,6 +22,10 @@
 | Add `-a` flag as an alias for `--annotation`
 | https://github.com/knative/client/pull/782[#782]
 
+| 🐛
+| Check DeleteTimestamp before updating resource
+| https://github.com/knative/client/pull/805[#805]
+
 |===
 
 ## v0.13.2 (2020-04-15)

--- a/pkg/kn/commands/service/update_test.go
+++ b/pkg/kn/commands/service/update_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"gotest.tools/assert"
 	"gotest.tools/assert/cmp"
@@ -724,6 +725,16 @@ func TestServiceUpdateNoClusterLocalOnPrivateService(t *testing.T) {
 
 	actual = newTemplate.ObjectMeta.Labels
 	assert.DeepEqual(t, expected, actual)
+}
+
+func TestServiceUpdateDeletionTimestampNotNil(t *testing.T) {
+	original := newEmptyService()
+	original.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	_, _, _, err := fakeServiceUpdate(original, []string{
+		"service", "update", "foo", "--revision-name", "foo-v1"})
+	assert.ErrorContains(t, err, original.Name)
+	assert.ErrorContains(t, err, "deletion")
+	assert.ErrorContains(t, err, "service")
 }
 
 func newEmptyService() *servingv1.Service {

--- a/pkg/kn/commands/source/apiserver/update.go
+++ b/pkg/kn/commands/source/apiserver/update.go
@@ -63,6 +63,9 @@ func NewAPIServerUpdateCommand(p *commands.KnParams) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if source.GetDeletionTimestamp() != nil {
+				return fmt.Errorf("can't update apiserver source %s because it has been marked for deletion", name)
+			}
 
 			b := v1alpha2.NewAPIServerSourceBuilderFromExisting(source)
 			if cmd.Flags().Changed("service-account") {

--- a/pkg/kn/commands/source/binding/update.go
+++ b/pkg/kn/commands/source/binding/update.go
@@ -61,6 +61,9 @@ func NewBindingUpdateCommand(p *commands.KnParams) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if source.GetDeletionTimestamp() != nil {
+				return fmt.Errorf("can't update binding %s because it has been marked for deletion", name)
+			}
 
 			b := v1alpha12.NewSinkBindingBuilderFromExisting(source)
 			if cmd.Flags().Changed("sink") {

--- a/pkg/kn/commands/source/ping/update.go
+++ b/pkg/kn/commands/source/ping/update.go
@@ -61,6 +61,9 @@ func NewPingUpdateCommand(p *commands.KnParams) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if source.GetDeletionTimestamp() != nil {
+				return fmt.Errorf("can't update ping source %s because it has been marked for deletion", name)
+			}
 
 			b := v1alpha2.NewPingSourceBuilderFromExisting(source)
 			if cmd.Flags().Changed("schedule") {

--- a/pkg/kn/commands/trigger/update.go
+++ b/pkg/kn/commands/trigger/update.go
@@ -75,6 +75,9 @@ func NewTriggerUpdateCommand(p *commands.KnParams) *cobra.Command {
 				if err != nil {
 					return err
 				}
+				if trigger.GetDeletionTimestamp() != nil {
+					return fmt.Errorf("can't update trigger %s because it has been marked for deletion", name)
+				}
 
 				b := client_v1alpha1.NewTriggerBuilderFromExisting(trigger)
 

--- a/pkg/serving/v1/client.go
+++ b/pkg/serving/v1/client.go
@@ -237,6 +237,9 @@ func updateServiceWithRetry(cl KnServingClient, name string, updateFunc serviceU
 		if err != nil {
 			return err
 		}
+		if service.GetDeletionTimestamp() != nil {
+			return fmt.Errorf("can't update service %s because it has been marked for deletion", name)
+		}
 		updatedService, err := updateFunc(service.DeepCopy())
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes: #786 

## Description
* Check DeleteTimestamp before updating resource. Include: service, apiserver source, sink binding, ping source, trigger.

Release Note:
- 🐛 Bug fix
 Check DeleteTimestamp before updating resource.