### PR TITLE
fixes(#814) allow plugins to extend the 'source' command group

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -26,6 +26,10 @@
 | Check DeleteTimestamp before updating resource
 | https://github.com/knative/client/pull/805[#805]
 
+| 🎁
+| Allow plugins to extend fixed list of command groups, currently `source`
+| https://github.com/knative/client/pull/818[#818]
+
 |===
 
 ## v0.13.2 (2020-04-15)

--- a/pkg/kn/commands/plugin/list_test.go
+++ b/pkg/kn/commands/plugin/list_test.go
@@ -71,7 +71,6 @@ func (ctx *testContext) createTestPluginWithPath(pluginName string, fileMode os.
 }
 
 func TestPluginList(t *testing.T) {
-
 	setup := func(t *testing.T) *testContext {
 		knParams := &commands.KnParams{}
 		pluginCmd := NewPluginCommand(knParams)
@@ -159,7 +158,6 @@ func TestPluginList(t *testing.T) {
 				})
 
 				t.Run("with plugins with same name", func(t *testing.T) {
-
 					t.Run("warns user about second (in $PATH) plugin shadowing first", func(t *testing.T) {
 						ctx := setup(t)
 						defer ctx.cleanup()
@@ -201,6 +199,24 @@ func TestPluginList(t *testing.T) {
 						assert.ErrorContains(t, err, "overwrite", "built-in")
 						assert.Assert(t, util.ContainsAll(ctx.output(), "ERROR", "overwrite", "built-in"))
 					})
+
+					t.Run("allows plugin under the `source` command group", func(t *testing.T) {
+						ctx := setup(t)
+						defer ctx.cleanup()
+
+						sourceCmd := &cobra.Command{
+							Use: "source",
+						}
+						ctx.rootCmd.AddCommand(sourceCmd)
+						defer ctx.rootCmd.RemoveCommand(sourceCmd)
+
+						err := ctx.createTestPlugin("kn-source-fake", FileModeExecutable, true)
+						assert.NilError(t, err)
+
+						err = ctx.execute("plugin", "list", "--lookup-plugins=true")
+						assert.NilError(t, err)
+					})
+
 				})
 			})
 		})

--- a/pkg/kn/commands/plugin/plugin.go
+++ b/pkg/kn/commands/plugin/plugin.go
@@ -52,3 +52,20 @@ func BindPluginsFlagToViper(cmd *cobra.Command) {
 	viper.SetDefault("plugins-dir", commands.Cfg.DefaultPluginDir)
 	viper.SetDefault("lookup-plugins", false)
 }
+
+// AllowedExtensibleCommandGroups the list of command groups that can be
+// extended with plugins, e.g., a plugin named `kn-source-kafka` for Kafka
+// event sources is allowed. This is defined as a fixed [...]string since
+// cannot defined Golang []string constants
+var AllowedExtensibleCommandGroups = [...]string{"source"}
+
+// InAllowedExtensibleCommandGroups checks that the name is in the list of allowed
+// extensible command groups
+func InAllowedExtensibleCommandGroups(name string) bool {
+	for _, groupName := range AllowedExtensibleCommandGroups {
+		if name == groupName {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/kn/commands/plugin/plugin_test.go
+++ b/pkg/kn/commands/plugin/plugin_test.go
@@ -72,3 +72,13 @@ func TestNewPluginCommand(t *testing.T) {
 		assert.Assert(t, pluginCmd.Args == nil)
 	})
 }
+
+func TestInAllowedExtensibleCommandGroups(t *testing.T) {
+	isExtensibleCommand := InAllowedExtensibleCommandGroups("fake")
+	assert.Assert(t, isExtensibleCommand == false)
+
+	for _, name := range AllowedExtensibleCommandGroups {
+		isExtensibleCommand = InAllowedExtensibleCommandGroups(name)
+		assert.Assert(t, isExtensibleCommand == true)
+	}
+}

--- a/pkg/kn/commands/plugin/verifier.go
+++ b/pkg/kn/commands/plugin/verifier.go
@@ -33,23 +33,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// AllowedExtensibleCommandGroups the list of command groups that can be
-// extended with plugins, e.g., a plugin named `kn-source-kafka` for Kafka
-// event sources is allowed. This is defined as a fixed [...]string since
-// cannot defined Golang []string constants
-var AllowedExtensibleCommandGroups = [...]string{"source"}
-
-// InAllowedExtensibleCommandGroups checks that the name is in the list of allowed
-// extensible command groups
-func InAllowedExtensibleCommandGroups(name string) bool {
-	for _, groupName := range AllowedExtensibleCommandGroups {
-		if name == groupName {
-			return true
-		}
-	}
-	return false
-}
-
 // pluginVerifier verifies that existing kn commands are not overridden
 type pluginVerifier struct {
 	root        *cobra.Command

--- a/pkg/kn/commands/plugin/verifier_test.go
+++ b/pkg/kn/commands/plugin/verifier_test.go
@@ -143,6 +143,20 @@ func TestPluginVerifier(t *testing.T) {
 				assert.Assert(t, util.ContainsAll(eaw.errors[0], "overwrite", "kn-plugin"))
 			})
 		})
+
+		t.Run("when kn plugin in path overwrites 'source' command (which is allowed)", func(t *testing.T) {
+			setup(t)
+			defer cleanup(t)
+			var overwritingPluginPath = CreateTestPlugin(t, "kn-source-test", KnTestPluginScript, FileModeExecutable)
+			defer DeleteTestPlugin(t, overwritingPluginPath)
+
+			t.Run("runs successfully", func(t *testing.T) {
+				eaw := errorsAndWarnings{}
+				eaw = verifier.verify(eaw, overwritingPluginPath)
+				assert.Assert(t, len(eaw.errors) == 0)
+				assert.Assert(t, len(eaw.warnings) == 0)
+			})
+		})
 	})
 }
 

--- a/pkg/kn/commands/plugin/verifier_test.go
+++ b/pkg/kn/commands/plugin/verifier_test.go
@@ -32,16 +32,6 @@ import (
 	"gotest.tools/assert"
 )
 
-func TestInAllowedExtensibleCommandGroups(t *testing.T) {
-	isExtensibleCommand := InAllowedExtensibleCommandGroups("fake")
-	assert.Assert(t, isExtensibleCommand == false)
-
-	for _, name := range AllowedExtensibleCommandGroups {
-		isExtensibleCommand = InAllowedExtensibleCommandGroups(name)
-		assert.Assert(t, isExtensibleCommand == true)
-	}
-}
-
 func TestPluginVerifier(t *testing.T) {
 	var (
 		pluginPath string

--- a/pkg/kn/commands/plugin/verifier_test.go
+++ b/pkg/kn/commands/plugin/verifier_test.go
@@ -32,8 +32,17 @@ import (
 	"gotest.tools/assert"
 )
 
-func TestPluginVerifier(t *testing.T) {
+func TestInAllowedExtensibleCommandGroups(t *testing.T) {
+	isExtensibleCommand := InAllowedExtensibleCommandGroups("fake")
+	assert.Assert(t, isExtensibleCommand == false)
 
+	for _, name := range AllowedExtensibleCommandGroups {
+		isExtensibleCommand = InAllowedExtensibleCommandGroups(name)
+		assert.Assert(t, isExtensibleCommand == true)
+	}
+}
+
+func TestPluginVerifier(t *testing.T) {
 	var (
 		pluginPath string
 		rootCmd    *cobra.Command

--- a/pkg/kn/core/root.go
+++ b/pkg/kn/core/root.go
@@ -43,12 +43,6 @@ import (
 	"knative.dev/client/pkg/kn/flags"
 )
 
-// AllowedExtensibleCommandGroups the list of command groups that can be
-// extended with plugins, e.g., a plugin named `kn-source-kafka` for Kafka
-// event sources is allowed. This is defined as a fixed [...]string since
-// cannot defined Golang []string constants
-var AllowedExtensibleCommandGroups = [...]string{"source"}
-
 // NewDefaultKnCommand creates the default `kn` command with a default plugin handler
 func NewDefaultKnCommand() *cobra.Command {
 	rootCmd := NewKnCommand()
@@ -87,7 +81,7 @@ func NewDefaultKnCommandWithArgs(rootCmd *cobra.Command,
 		// only look for suitable extension executables if
 		// the specified command does not already exist
 		foundCmd, innerArgs, err := rootCmd.Find(cmdPathPieces)
-		if err != nil || inAllowedExtensibleCommandGroups(foundCmd.Name()) {
+		if err != nil || plugin.InAllowedExtensibleCommandGroups(foundCmd.Name()) {
 			err := plugin.HandlePluginCommand(pluginHandler, cmdPathPieces)
 			if err != nil {
 				fmt.Fprintf(rootCmd.OutOrStderr(), "Error: unknown command '%s' \nRun 'kn --help' for usage.\n", args[1])
@@ -378,13 +372,4 @@ func showSubcommands(cmd *cobra.Command, args []string, innerArg string) string 
 		strs = append(strs, subcmd.Name())
 	}
 	return fmt.Sprintf("Error: unknown subcommand '%s' for '%s'. Available subcommands: %s\nRun 'kn --help' for usage.\n", innerArg, getCommands(args, innerArg), strings.Join(strs, ", "))
-}
-
-func inAllowedExtensibleCommandGroups(name string) bool {
-	for _, groupName := range AllowedExtensibleCommandGroups {
-		if name == groupName {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
## Description

In rare cases (e.g., `source`) an existing command group should be extensible via plugins. This PR addresses that. Source should be extensible since many of the eventing sources will be supported via plugins.

## Changes

* introduce a list of command group that can be extended (currently only source)
* check if plugin main group is in that list and execute, otherwise fail
* add e2e test for both plugin that is allowed and not allowed to extend existing group

## Reference

Fixes #814

/lint