### PR TITLE
refactor kn service export to export revisions

### DIFF
--- a/docs/cmd/kn_service_export.md
+++ b/docs/cmd/kn_service_export.md
@@ -18,10 +18,10 @@ kn service export NAME [flags]
   kn service export foo -n bar -o yaml
   # Export a service in JSON format
   kn service export foo -n bar -o json
-  # Export a service with revisions in JSON format
-  kn service export foo --with-revisions -n bar -o json
-  # Export a service with revisions in kubectl friendly format
-  kn service export foo --with-revisions --kubernetes-resources -n bar -o json
+  # Export a service with revisions
+  kn service export foo --with-revisions --mode=resources -n bar -o json
+  # Export services in kubectl friendly format, as a list kind, one service item for each revision
+  kn service export foo --with-revisions --mode=kubernetes -n bar -o json
 ```
 
 ### Options
@@ -29,7 +29,7 @@ kn service export NAME [flags]
 ```
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for export
-      --kubernetes-resources          Export all routed revisions in kubectl friendly format(experimental)
+      --mode string                   Format for exporting all routed revisions. One of kubernetes|resources (experimental)
   -n, --namespace string              Specify the namespace to operate in.
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].

--- a/docs/cmd/kn_service_export.md
+++ b/docs/cmd/kn_service_export.md
@@ -18,6 +18,10 @@ kn service export NAME [flags]
   kn service export foo -n bar -o yaml
   # Export a service in json format
   kn service export foo -n bar -o json
+  # Export a service with revisions in json format
+  kn service export foo --with-revisions -n bar -o json
+  # Export a service with revisions in kubectl friendly format
+  kn service export foo --with-revisions --kubernetes-resources -n bar -o json
 ```
 
 ### Options
@@ -25,6 +29,7 @@ kn service export NAME [flags]
 ```
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for export
+      --kubernetes-resources          Export all routed revisions in kubectl friendly format(experimental)
   -n, --namespace string              Specify the namespace to operate in.
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].

--- a/docs/cmd/kn_service_export.md
+++ b/docs/cmd/kn_service_export.md
@@ -14,11 +14,11 @@ kn service export NAME [flags]
 
 ```
 
-  # Export a service in yaml format
+  # Export a service in YAML format
   kn service export foo -n bar -o yaml
-  # Export a service in json format
+  # Export a service in JSON format
   kn service export foo -n bar -o json
-  # Export a service with revisions in json format
+  # Export a service with revisions in JSON format
   kn service export foo --with-revisions -n bar -o json
   # Export a service with revisions in kubectl friendly format
   kn service export foo --with-revisions --kubernetes-resources -n bar -o json

--- a/pkg/kn/commands/service/export.go
+++ b/pkg/kn/commands/service/export.go
@@ -102,25 +102,25 @@ func exportService(cmd *cobra.Command, service *servingv1.Service, client client
 
 	if withRevisions {
 		if withKubernetesResources {
-			if svcList, err := exportServiceListWithActiveRevisions(service, client); err != nil {
+			svcList, err := exportServiceListWithActiveRevisions(service, client)
+			if err != nil {
 				return err
-			} else {
-				return printer.PrintObj(svcList, cmd.OutOrStdout())
 			}
+			return printer.PrintObj(svcList, cmd.OutOrStdout())
 		}
-		if latestSvc, revList, err := exportActiveRevisionList(service, client); err != nil {
+		latestSvc, revList, err := exportActiveRevisionList(service, client)
+		if err != nil {
 			return err
-		} else {
-			//print svc
-			if err := printer.PrintObj(latestSvc, cmd.OutOrStdout()); err != nil {
-				return err
-			}
-			// print revisionList if revisions exist
-			if len(revList.Items) > 0 {
-				return printer.PrintObj(revList, cmd.OutOrStdout())
-			}
-			return nil
 		}
+		//print svc
+		if err := printer.PrintObj(latestSvc, cmd.OutOrStdout()); err != nil {
+			return err
+		}
+		// print revisionList if revisions exist
+		if len(revList.Items) > 0 {
+			return printer.PrintObj(revList, cmd.OutOrStdout())
+		}
+		return nil
 	}
 	return printer.PrintObj(exportLatestService(service, false), cmd.OutOrStdout())
 }

--- a/pkg/kn/commands/service/export_test.go
+++ b/pkg/kn/commands/service/export_test.go
@@ -94,6 +94,7 @@ func TestServiceExportwithMultipleRevisions(t *testing.T) {
 		name: "test 2 revisions with traffic split",
 		latestSvc: getServiceWithOptions(
 			getService("foo"),
+			withAnnotations(map[string]string{"serving.knative.dev/creator": "ut", "serving.knative.dev/lastModifier": "ut"}),
 			withTrafficSplit([]string{"foo-rev-1", "foo-rev-2"}, []int{50, 50}, []string{"latest", "current"}),
 			withServiceRevisionName("foo-rev-2"),
 			withServicePodSpecOption(withContainer()),
@@ -117,6 +118,7 @@ func TestServiceExportwithMultipleRevisions(t *testing.T) {
 			withRevisions(
 				withRevisionLabels(map[string]string{apiserving.ServiceLabelKey: "foo"}),
 				withRevisionGeneration("1"),
+				withRevisionAnnotations(map[string]string{"serving.knative.dev/lastPinned": "1111132"}),
 				withRevisionName("foo-rev-1"),
 				withRevisionPodSpecOption(withContainer()),
 			),
@@ -131,6 +133,7 @@ func TestServiceExportwithMultipleRevisions(t *testing.T) {
 			withRevisions(
 				withRevisionLabels(map[string]string{apiserving.ServiceLabelKey: "foo"}),
 				withRevisionName("foo-rev-1"),
+
 				withRevisionGeneration("1"),
 				withRevisionPodSpecOption(withContainer()),
 			),

--- a/pkg/kn/commands/service/export_test.go
+++ b/pkg/kn/commands/service/export_test.go
@@ -51,11 +51,11 @@ func TestServiceExportError(t *testing.T) {
 func TestServiceExport(t *testing.T) {
 
 	svcs := []*servingv1.Service{
-		getServiceWithOptions(getService("foo"), WithServicePodSpecOption(withContainer())),
-		getServiceWithOptions(getService("foo"), WithServicePodSpecOption(withContainer(), withEnv([]v1.EnvVar{{Name: "a", Value: "mouse"}}))),
-		getServiceWithOptions(getService("foo"), withConfigurationLabels(map[string]string{"a": "mouse"}), withConfigurationAnnotations(map[string]string{"a": "mouse"}), WithServicePodSpecOption(withContainer())),
-		getServiceWithOptions(getService("foo"), withLabels(map[string]string{"a": "mouse"}), withAnnotations(map[string]string{"a": "mouse"}), WithServicePodSpecOption(withContainer())),
-		getServiceWithOptions(getService("foo"), WithServicePodSpecOption(withContainer(), withVolumeandSecrets("secretName"))),
+		getServiceWithOptions(getService("foo"), withServicePodSpecOption(withContainer())),
+		getServiceWithOptions(getService("foo"), withServicePodSpecOption(withContainer(), withEnv([]v1.EnvVar{{Name: "a", Value: "mouse"}}))),
+		getServiceWithOptions(getService("foo"), withConfigurationLabels(map[string]string{"a": "mouse"}), withConfigurationAnnotations(map[string]string{"a": "mouse"}), withServicePodSpecOption(withContainer())),
+		getServiceWithOptions(getService("foo"), withLabels(map[string]string{"a": "mouse"}), withAnnotations(map[string]string{"a": "mouse"}), withServicePodSpecOption(withContainer())),
+		getServiceWithOptions(getService("foo"), withServicePodSpecOption(withContainer(), withVolumeandSecrets("secretName"))),
 	}
 
 	for _, svc := range svcs {
@@ -96,19 +96,19 @@ func TestServiceExportwithMultipleRevisions(t *testing.T) {
 			getService("foo"),
 			withTrafficSplit([]string{"foo-rev-1", "foo-rev-2"}, []int{50, 50}, []string{"latest", "current"}),
 			withServiceRevisionName("foo-rev-2"),
-			WithServicePodSpecOption(withContainer()),
+			withServicePodSpecOption(withContainer()),
 		),
 		expectedSvcList: getServiceListWithOptions(
 			withServices(
 				getService("foo"),
 				withUnwantedFieldsStripped(),
-				WithServicePodSpecOption(withContainer()),
+				withServicePodSpecOption(withContainer()),
 				withServiceRevisionName("foo-rev-1"),
 			),
 			withServices(
 				getService("foo"),
 				withUnwantedFieldsStripped(),
-				WithServicePodSpecOption(withContainer()),
+				withServicePodSpecOption(withContainer()),
 				withServiceRevisionName("foo-rev-2"),
 				withTrafficSplit([]string{"foo-rev-1", "foo-rev-2"}, []int{50, 50}, []string{"latest", "current"}),
 			),
@@ -118,13 +118,13 @@ func TestServiceExportwithMultipleRevisions(t *testing.T) {
 				withRevisionLabels(map[string]string{apiserving.ServiceLabelKey: "foo"}),
 				withRevisionGeneration("1"),
 				withRevisionName("foo-rev-1"),
-				WithRevisionPodSpecOption(withContainer()),
+				withRevisionPodSpecOption(withContainer()),
 			),
 			withRevisions(
 				withRevisionLabels(map[string]string{apiserving.ServiceLabelKey: "foo"}),
 				withRevisionGeneration("2"),
 				withRevisionName("foo-rev-2"),
-				WithRevisionPodSpecOption(withContainer()),
+				withRevisionPodSpecOption(withContainer()),
 			),
 		),
 		expectedRevisionList: getRevisionListWithOptions(
@@ -132,7 +132,7 @@ func TestServiceExportwithMultipleRevisions(t *testing.T) {
 				withRevisionLabels(map[string]string{apiserving.ServiceLabelKey: "foo"}),
 				withRevisionName("foo-rev-1"),
 				withRevisionGeneration("1"),
-				WithRevisionPodSpecOption(withContainer()),
+				withRevisionPodSpecOption(withContainer()),
 			),
 		),
 	}, {
@@ -141,13 +141,13 @@ func TestServiceExportwithMultipleRevisions(t *testing.T) {
 			getService("foo"),
 			withTrafficSplit([]string{"foo-rev-2"}, []int{100}, []string{"latest"}),
 			withServiceRevisionName("foo-rev-2"),
-			WithServicePodSpecOption(withContainer()),
+			withServicePodSpecOption(withContainer()),
 		),
 		expectedSvcList: getServiceListWithOptions(
 			withServices(
 				getService("foo"),
 				withUnwantedFieldsStripped(),
-				WithServicePodSpecOption(withContainer()),
+				withServicePodSpecOption(withContainer()),
 				withServiceRevisionName("foo-rev-2"),
 				withTrafficSplit([]string{"foo-rev-2"}, []int{100}, []string{"latest"}),
 			),
@@ -157,13 +157,13 @@ func TestServiceExportwithMultipleRevisions(t *testing.T) {
 				withRevisionLabels(map[string]string{apiserving.ServiceLabelKey: "foo"}),
 				withRevisionGeneration("1"),
 				withRevisionName("foo-rev-1"),
-				WithRevisionPodSpecOption(withContainer()),
+				withRevisionPodSpecOption(withContainer()),
 			),
 			withRevisions(
 				withRevisionLabels(map[string]string{apiserving.ServiceLabelKey: "foo"}),
 				withRevisionGeneration("2"),
 				withRevisionName("foo-rev-2"),
-				WithRevisionPodSpecOption(withContainer()),
+				withRevisionPodSpecOption(withContainer()),
 			),
 		),
 	}, {
@@ -172,7 +172,7 @@ func TestServiceExportwithMultipleRevisions(t *testing.T) {
 			getService("foo"),
 			withTrafficSplit([]string{"foo-rev-1", "foo-rev-2", "foo-rev-3"}, []int{25, 50, 25}, []string{"", "", "latest"}),
 			withServiceRevisionName("foo-rev-3"),
-			WithServicePodSpecOption(
+			withServicePodSpecOption(
 				withContainer(),
 				withEnv([]v1.EnvVar{{Name: "a", Value: "mouse"}}),
 			),
@@ -181,7 +181,7 @@ func TestServiceExportwithMultipleRevisions(t *testing.T) {
 			withServices(
 				getService("foo"),
 				withUnwantedFieldsStripped(),
-				WithServicePodSpecOption(
+				withServicePodSpecOption(
 					withContainer(),
 					withEnv([]v1.EnvVar{{Name: "a", Value: "cat"}}),
 				),
@@ -190,7 +190,7 @@ func TestServiceExportwithMultipleRevisions(t *testing.T) {
 			withServices(
 				getService("foo"),
 				withUnwantedFieldsStripped(),
-				WithServicePodSpecOption(
+				withServicePodSpecOption(
 					withContainer(),
 					withEnv([]v1.EnvVar{{Name: "a", Value: "dog"}}),
 				),
@@ -199,7 +199,7 @@ func TestServiceExportwithMultipleRevisions(t *testing.T) {
 			withServices(
 				getService("foo"),
 				withUnwantedFieldsStripped(),
-				WithServicePodSpecOption(
+				withServicePodSpecOption(
 					withContainer(),
 					withEnv([]v1.EnvVar{{Name: "a", Value: "mouse"}}),
 				),
@@ -212,7 +212,7 @@ func TestServiceExportwithMultipleRevisions(t *testing.T) {
 				withRevisionLabels(map[string]string{apiserving.ServiceLabelKey: "foo"}),
 				withRevisionGeneration("1"),
 				withRevisionName("foo-rev-1"),
-				WithRevisionPodSpecOption(
+				withRevisionPodSpecOption(
 					withContainer(),
 					withEnv([]v1.EnvVar{{Name: "a", Value: "cat"}}),
 				),
@@ -221,7 +221,7 @@ func TestServiceExportwithMultipleRevisions(t *testing.T) {
 				withRevisionLabels(map[string]string{apiserving.ServiceLabelKey: "foo"}),
 				withRevisionGeneration("2"),
 				withRevisionName("foo-rev-2"),
-				WithRevisionPodSpecOption(
+				withRevisionPodSpecOption(
 					withContainer(),
 					withEnv([]v1.EnvVar{{Name: "a", Value: "dog"}}),
 				),
@@ -230,7 +230,7 @@ func TestServiceExportwithMultipleRevisions(t *testing.T) {
 				withRevisionLabels(map[string]string{apiserving.ServiceLabelKey: "foo"}),
 				withRevisionGeneration("3"),
 				withRevisionName("foo-rev-3"),
-				WithRevisionPodSpecOption(
+				withRevisionPodSpecOption(
 					withContainer(),
 					withEnv([]v1.EnvVar{{Name: "a", Value: "mouse"}}),
 				),
@@ -241,7 +241,7 @@ func TestServiceExportwithMultipleRevisions(t *testing.T) {
 				withRevisionLabels(map[string]string{apiserving.ServiceLabelKey: "foo"}),
 				withRevisionName("foo-rev-1"),
 				withRevisionGeneration("1"),
-				WithRevisionPodSpecOption(
+				withRevisionPodSpecOption(
 					withContainer(),
 					withEnv([]v1.EnvVar{{Name: "a", Value: "cat"}}),
 				),
@@ -250,7 +250,7 @@ func TestServiceExportwithMultipleRevisions(t *testing.T) {
 				withRevisionLabels(map[string]string{apiserving.ServiceLabelKey: "foo"}),
 				withRevisionName("foo-rev-2"),
 				withRevisionGeneration("2"),
-				WithRevisionPodSpecOption(
+				withRevisionPodSpecOption(
 					withContainer(),
 					withEnv([]v1.EnvVar{{Name: "a", Value: "dog"}}),
 				),
@@ -431,7 +431,7 @@ func withTrafficSplit(revisions []string, percentages []int, tags []string) expe
 		}
 	}
 }
-func WithServicePodSpecOption(options ...podSpecOption) expectedServiceOption {
+func withServicePodSpecOption(options ...podSpecOption) expectedServiceOption {
 	return func(svc *servingv1.Service) {
 		svc.Spec.Template.Spec.PodSpec = getPodSpecWithOptions(options...)
 	}
@@ -469,7 +469,7 @@ func withRevisionAnnotations(Annotations map[string]string) expectedRevisionOpti
 		rev.ObjectMeta.Annotations = Annotations
 	}
 }
-func WithRevisionPodSpecOption(options ...podSpecOption) expectedRevisionOption {
+func withRevisionPodSpecOption(options ...podSpecOption) expectedRevisionOption {
 	return func(rev *servingv1.Revision) {
 		rev.Spec.PodSpec = getPodSpecWithOptions(options...)
 	}

--- a/pkg/kn/commands/service/export_test.go
+++ b/pkg/kn/commands/service/export_test.go
@@ -16,15 +16,13 @@ package service
 
 import (
 	"encoding/json"
-	"fmt"
-	"strconv"
+	"strings"
 	"testing"
 
 	"gotest.tools/assert"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	servinglib "knative.dev/client/pkg/serving"
 	knclient "knative.dev/client/pkg/serving/v1"
 	"knative.dev/client/pkg/util/mock"
 	"knative.dev/pkg/ptr"
@@ -35,94 +33,9 @@ import (
 
 type expectedServiceOption func(*servingv1.Service)
 type expectedRevisionOption func(*servingv1.Revision)
-
-func TestServiceExport(t *testing.T) {
-
-	svcs := []*servingv1.Service{
-		getServiceWithOptions(getService("foo"), withContainer()),
-		getServiceWithOptions(getService("foo"), withContainer(), withEnv([]v1.EnvVar{{Name: "a", Value: "mouse"}})),
-		getServiceWithOptions(getService("foo"), withContainer(), withLabels(map[string]string{"a": "mouse", "b": "cookie", "empty": ""})),
-		getServiceWithOptions(getService("foo"), withContainer(), withEnvFrom([]string{"cm-name"})),
-		getServiceWithOptions(getService("foo"), withContainer(), withVolumeandSecrets("volName", "secretName")),
-	}
-
-	for _, svc := range svcs {
-		callServiceExportTest(t, svc)
-	}
-}
-
-func callServiceExportTest(t *testing.T, expectedService *servingv1.Service) {
-	// New mock client
-	client := knclient.NewMockKnServiceClient(t)
-	// Recording:
-	r := client.Recorder()
-	r.GetService(expectedService.ObjectMeta.Name, expectedService, nil)
-
-	output, err := executeServiceCommand(client, "export", expectedService.ObjectMeta.Name, "-o", "yaml")
-	assert.NilError(t, err)
-
-	actSvc := servingv1.Service{}
-	err = yaml.Unmarshal([]byte(output), &actSvc)
-	assert.NilError(t, err)
-	stripExpectedSvcVariables(expectedService)
-	assert.DeepEqual(t, expectedService, &actSvc)
-	// Validate that all recorded API methods have been called
-	r.Validate()
-}
-
-func TestServiceExportwithMultipleRevisions(t *testing.T) {
-	//case 1 - 2 revisions with traffic split
-	expSvc1 := getServiceWithOptions(getService("foo"), withContainer(), withServiceRevisionName("foo-rev-1"))
-	stripExpectedSvcVariables(expSvc1)
-	expSvc2 := getServiceWithOptions(getService("foo"), withContainer(), withTrafficSplit([]string{"foo-rev-1", "foo-rev-2"}, []int{50, 50}, []string{"latest", "current"}), withServiceRevisionName("foo-rev-2"))
-	stripExpectedSvcVariables(expSvc2)
-	latestSvc := getServiceWithOptions(getService("foo"), withContainer(), withTrafficSplit([]string{"foo-rev-1", "foo-rev-2"}, []int{50, 50}, []string{"latest", "current"}))
-
-	expSvcList := servingv1.ServiceList{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "List",
-		},
-		Items: []servingv1.Service{*expSvc1, *expSvc2},
-	}
-
-	multiRevs := getRevisionList("rev", "foo")
-
-	callServiceExportHistoryTest(t, latestSvc, multiRevs, &expSvcList)
-
-	// case 2 - same revisions no traffic split
-	expSvc2 = getServiceWithOptions(getService("foo"), withContainer(), withServiceRevisionName("foo-rev-2"))
-	stripExpectedSvcVariables(expSvc2)
-	expSvcList = servingv1.ServiceList{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "List",
-		},
-		Items: []servingv1.Service{*expSvc2},
-	}
-	latestSvc = getServiceWithOptions(getService("foo"), withContainer(), withTrafficSplit([]string{"foo-rev-2"}, []int{100}, []string{"latest"}))
-	callServiceExportHistoryTest(t, latestSvc, multiRevs, &expSvcList)
-}
-
-func callServiceExportHistoryTest(t *testing.T, latestSvc *servingv1.Service, revs *servingv1.RevisionList, expSvcList *servingv1.ServiceList) {
-	// New mock client
-	client := knclient.NewMockKnServiceClient(t)
-	// Recording:
-	r := client.Recorder()
-
-	r.GetService(latestSvc.ObjectMeta.Name, latestSvc, nil)
-	r.ListRevisions(mock.Any(), revs, nil)
-
-	output, err := executeServiceCommand(client, "export", latestSvc.ObjectMeta.Name, "--with-revisions", "-o", "json")
-	assert.NilError(t, err)
-
-	actSvcList := servingv1.ServiceList{}
-	err = json.Unmarshal([]byte(output), &actSvcList)
-	assert.NilError(t, err)
-	assert.DeepEqual(t, expSvcList, &actSvcList)
-	// Validate that all recorded API methods have been called
-	r.Validate()
-}
+type expectedServiceListOption func(*servingv1.ServiceList)
+type expectedRevisionListOption func(*servingv1.RevisionList)
+type podSpecOption func(*v1.PodSpec)
 
 func TestServiceExportError(t *testing.T) {
 	// New mock client
@@ -135,62 +48,320 @@ func TestServiceExportError(t *testing.T) {
 	assert.Error(t, err, "'kn service export' requires output format")
 }
 
-func getRevisionList(revision string, service string) *servingv1.RevisionList {
-	rev1 := getRevisionWithOptions(
-		service,
-		withRevisionGeneration("1"),
-		withRevisionName(fmt.Sprintf("%s-%s-%d", service, revision, 1)),
-	)
+func TestServiceExport(t *testing.T) {
 
-	rev2 := getRevisionWithOptions(
-		service,
-		withRevisionGeneration("2"),
-		withRevisionName(fmt.Sprintf("%s-%s-%d", service, revision, 2)),
-	)
+	svcs := []*servingv1.Service{
+		getServiceWithOptions(getService("foo"), WithServicePodSpecOption(withContainer())),
+		getServiceWithOptions(getService("foo"), WithServicePodSpecOption(withContainer(), withEnv([]v1.EnvVar{{Name: "a", Value: "mouse"}}))),
+		getServiceWithOptions(getService("foo"), withConfigurationLabels(map[string]string{"a": "mouse"}), withConfigurationAnnotations(map[string]string{"a": "mouse"}), WithServicePodSpecOption(withContainer())),
+		getServiceWithOptions(getService("foo"), withLabels(map[string]string{"a": "mouse"}), withAnnotations(map[string]string{"a": "mouse"}), WithServicePodSpecOption(withContainer())),
+		getServiceWithOptions(getService("foo"), WithServicePodSpecOption(withContainer(), withVolumeandSecrets("secretName"))),
+	}
 
-	return &servingv1.RevisionList{
+	for _, svc := range svcs {
+		exportServiceTest(t, svc)
+	}
+}
+
+func exportServiceTest(t *testing.T, expectedService *servingv1.Service) {
+	// New mock client
+	client := knclient.NewMockKnServiceClient(t)
+	// Recording:
+	r := client.Recorder()
+	r.GetService(expectedService.ObjectMeta.Name, expectedService, nil)
+
+	output, err := executeServiceCommand(client, "export", expectedService.ObjectMeta.Name, "-o", "yaml")
+	assert.NilError(t, err)
+
+	actSvc := servingv1.Service{}
+	err = yaml.Unmarshal([]byte(output), &actSvc)
+	assert.NilError(t, err)
+
+	stripUnwantedFields(expectedService)
+	assert.DeepEqual(t, expectedService, &actSvc)
+	// Validate that all recorded API methods have been called
+	r.Validate()
+}
+
+func TestServiceExportwithMultipleRevisions(t *testing.T) {
+	for _, tc := range []struct {
+		name                 string
+		latestSvc            *servingv1.Service
+		expectedSvcList      *servingv1.ServiceList
+		revisionList         *servingv1.RevisionList
+		expectedRevisionList *servingv1.RevisionList
+	}{{
+		name: "test 2 revisions with traffic split",
+		latestSvc: getServiceWithOptions(
+			getService("foo"),
+			withTrafficSplit([]string{"foo-rev-1", "foo-rev-2"}, []int{50, 50}, []string{"latest", "current"}),
+			withServiceRevisionName("foo-rev-2"),
+			WithServicePodSpecOption(withContainer()),
+		),
+		expectedSvcList: getServiceListWithOptions(
+			withServices(
+				getService("foo"),
+				withUnwantedFieldsStripped(),
+				WithServicePodSpecOption(withContainer()),
+				withServiceRevisionName("foo-rev-1"),
+			),
+			withServices(
+				getService("foo"),
+				withUnwantedFieldsStripped(),
+				WithServicePodSpecOption(withContainer()),
+				withServiceRevisionName("foo-rev-2"),
+				withTrafficSplit([]string{"foo-rev-1", "foo-rev-2"}, []int{50, 50}, []string{"latest", "current"}),
+			),
+		),
+		revisionList: getRevisionListWithOptions(
+			withRevisions(
+				withRevisionLabels(map[string]string{apiserving.ServiceLabelKey: "foo"}),
+				withRevisionGeneration("1"),
+				withRevisionName("foo-rev-1"),
+				WithRevisionPodSpecOption(withContainer()),
+			),
+			withRevisions(
+				withRevisionLabels(map[string]string{apiserving.ServiceLabelKey: "foo"}),
+				withRevisionGeneration("2"),
+				withRevisionName("foo-rev-2"),
+				WithRevisionPodSpecOption(withContainer()),
+			),
+		),
+		expectedRevisionList: getRevisionListWithOptions(
+			withRevisions(
+				withRevisionLabels(map[string]string{apiserving.ServiceLabelKey: "foo"}),
+				withRevisionName("foo-rev-1"),
+				withRevisionGeneration("1"),
+				WithRevisionPodSpecOption(withContainer()),
+			),
+		),
+	}, {
+		name: "test 2 revisions no traffic split",
+		latestSvc: getServiceWithOptions(
+			getService("foo"),
+			withTrafficSplit([]string{"foo-rev-2"}, []int{100}, []string{"latest"}),
+			withServiceRevisionName("foo-rev-2"),
+			WithServicePodSpecOption(withContainer()),
+		),
+		expectedSvcList: getServiceListWithOptions(
+			withServices(
+				getService("foo"),
+				withUnwantedFieldsStripped(),
+				WithServicePodSpecOption(withContainer()),
+				withServiceRevisionName("foo-rev-2"),
+				withTrafficSplit([]string{"foo-rev-2"}, []int{100}, []string{"latest"}),
+			),
+		),
+		revisionList: getRevisionListWithOptions(
+			withRevisions(
+				withRevisionLabels(map[string]string{apiserving.ServiceLabelKey: "foo"}),
+				withRevisionGeneration("1"),
+				withRevisionName("foo-rev-1"),
+				WithRevisionPodSpecOption(withContainer()),
+			),
+			withRevisions(
+				withRevisionLabels(map[string]string{apiserving.ServiceLabelKey: "foo"}),
+				withRevisionGeneration("2"),
+				withRevisionName("foo-rev-2"),
+				WithRevisionPodSpecOption(withContainer()),
+			),
+		),
+	}, {
+		name: "test 3 active revisions with traffic split",
+		latestSvc: getServiceWithOptions(
+			getService("foo"),
+			withTrafficSplit([]string{"foo-rev-1", "foo-rev-2", "foo-rev-3"}, []int{25, 50, 25}, []string{"", "", "latest"}),
+			withServiceRevisionName("foo-rev-3"),
+			WithServicePodSpecOption(
+				withContainer(),
+				withEnv([]v1.EnvVar{{Name: "a", Value: "mouse"}}),
+			),
+		),
+		expectedSvcList: getServiceListWithOptions(
+			withServices(
+				getService("foo"),
+				withUnwantedFieldsStripped(),
+				WithServicePodSpecOption(
+					withContainer(),
+					withEnv([]v1.EnvVar{{Name: "a", Value: "cat"}}),
+				),
+				withServiceRevisionName("foo-rev-1"),
+			),
+			withServices(
+				getService("foo"),
+				withUnwantedFieldsStripped(),
+				WithServicePodSpecOption(
+					withContainer(),
+					withEnv([]v1.EnvVar{{Name: "a", Value: "dog"}}),
+				),
+				withServiceRevisionName("foo-rev-2"),
+			),
+			withServices(
+				getService("foo"),
+				withUnwantedFieldsStripped(),
+				WithServicePodSpecOption(
+					withContainer(),
+					withEnv([]v1.EnvVar{{Name: "a", Value: "mouse"}}),
+				),
+				withServiceRevisionName("foo-rev-3"),
+				withTrafficSplit([]string{"foo-rev-1", "foo-rev-2", "foo-rev-3"}, []int{25, 50, 25}, []string{"", "", "latest"}),
+			),
+		),
+		revisionList: getRevisionListWithOptions(
+			withRevisions(
+				withRevisionLabels(map[string]string{apiserving.ServiceLabelKey: "foo"}),
+				withRevisionGeneration("1"),
+				withRevisionName("foo-rev-1"),
+				WithRevisionPodSpecOption(
+					withContainer(),
+					withEnv([]v1.EnvVar{{Name: "a", Value: "cat"}}),
+				),
+			),
+			withRevisions(
+				withRevisionLabels(map[string]string{apiserving.ServiceLabelKey: "foo"}),
+				withRevisionGeneration("2"),
+				withRevisionName("foo-rev-2"),
+				WithRevisionPodSpecOption(
+					withContainer(),
+					withEnv([]v1.EnvVar{{Name: "a", Value: "dog"}}),
+				),
+			),
+			withRevisions(
+				withRevisionLabels(map[string]string{apiserving.ServiceLabelKey: "foo"}),
+				withRevisionGeneration("3"),
+				withRevisionName("foo-rev-3"),
+				WithRevisionPodSpecOption(
+					withContainer(),
+					withEnv([]v1.EnvVar{{Name: "a", Value: "mouse"}}),
+				),
+			),
+		),
+		expectedRevisionList: getRevisionListWithOptions(
+			withRevisions(
+				withRevisionLabels(map[string]string{apiserving.ServiceLabelKey: "foo"}),
+				withRevisionName("foo-rev-1"),
+				withRevisionGeneration("1"),
+				WithRevisionPodSpecOption(
+					withContainer(),
+					withEnv([]v1.EnvVar{{Name: "a", Value: "cat"}}),
+				),
+			),
+			withRevisions(
+				withRevisionLabels(map[string]string{apiserving.ServiceLabelKey: "foo"}),
+				withRevisionName("foo-rev-2"),
+				withRevisionGeneration("2"),
+				WithRevisionPodSpecOption(
+					withContainer(),
+					withEnv([]v1.EnvVar{{Name: "a", Value: "dog"}}),
+				),
+			),
+		),
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			exportWithRevisionsforKubernetesTest(t, tc.latestSvc, tc.revisionList, tc.expectedSvcList)
+			exportWithRevisionsTest(t, tc.latestSvc, tc.revisionList, tc.expectedRevisionList)
+		})
+	}
+}
+
+func exportWithRevisionsforKubernetesTest(t *testing.T, latestSvc *servingv1.Service, revs *servingv1.RevisionList, expSvcList *servingv1.ServiceList) {
+	// New mock client
+	client := knclient.NewMockKnServiceClient(t)
+	// Recording:
+	r := client.Recorder()
+
+	r.GetService(latestSvc.ObjectMeta.Name, latestSvc, nil)
+	r.ListRevisions(mock.Any(), revs, nil)
+
+	output, err := executeServiceCommand(client, "export", latestSvc.ObjectMeta.Name, "--with-revisions", "--kubernetes-resources", "-o", "json")
+	assert.NilError(t, err)
+
+	actSvcList := servingv1.ServiceList{}
+	err = json.Unmarshal([]byte(output), &actSvcList)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, expSvcList, &actSvcList)
+	// Validate that all recorded API methods have been called
+	r.Validate()
+}
+
+func exportWithRevisionsTest(t *testing.T, latestSvc *servingv1.Service, revs *servingv1.RevisionList, expRevList *servingv1.RevisionList) {
+	// New mock client
+	client := knclient.NewMockKnServiceClient(t)
+	// Recording:
+	r := client.Recorder()
+
+	r.GetService(latestSvc.ObjectMeta.Name, latestSvc, nil)
+	r.ListRevisions(mock.Any(), revs, nil)
+
+	output, err := executeServiceCommand(client, "export", latestSvc.ObjectMeta.Name, "--with-revisions", "-o", "json")
+	assert.NilError(t, err)
+
+	stripUnwantedFields(latestSvc)
+	expOut := strings.Builder{}
+	expSvcJSON, err := json.MarshalIndent(latestSvc, "", "    ")
+	assert.NilError(t, err)
+	expOut.Write(expSvcJSON)
+	expOut.WriteString("\n")
+
+	if expRevList != nil {
+		expRevsJSON, err := json.MarshalIndent(expRevList, "", "    ")
+		assert.NilError(t, err)
+		expOut.Write(expRevsJSON)
+		expOut.WriteString("\n")
+	}
+
+	assert.Equal(t, expOut.String(), output)
+	// Validate that all recorded API methods have been called
+	r.Validate()
+}
+
+func stripUnwantedFields(svc *servingv1.Service) {
+	svc.ObjectMeta.Namespace = ""
+	svc.Spec.Template.Spec.Containers[0].Resources = v1.ResourceRequirements{}
+	svc.Status = servingv1.ServiceStatus{}
+	svc.ObjectMeta.CreationTimestamp = metav1.Time{}
+}
+
+func getServiceListWithOptions(options ...expectedServiceListOption) *servingv1.ServiceList {
+	list := &servingv1.ServiceList{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "List",
 		},
-		Items: []servingv1.Revision{rev1, rev2},
 	}
-}
 
-func stripExpectedSvcVariables(expectedsvc *servingv1.Service) {
-	expectedsvc.ObjectMeta.Namespace = ""
-	expectedsvc.Spec.Template.Spec.Containers[0].Resources = v1.ResourceRequirements{}
-	expectedsvc.Status = servingv1.ServiceStatus{}
-	expectedsvc.ObjectMeta.Annotations = nil
-	expectedsvc.ObjectMeta.CreationTimestamp = metav1.Time{}
-}
-
-func getRevisionWithOptions(service string, options ...expectedRevisionOption) servingv1.Revision {
-	rev := servingv1.Revision{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Revision",
-			APIVersion: "serving.knative.dev/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Labels: map[string]string{
-				apiserving.ServiceLabelKey: service,
-			},
-		},
-		Spec: servingv1.RevisionSpec{
-			PodSpec: v1.PodSpec{
-				Containers: []v1.Container{
-					{
-						Image: "gcr.io/foo/bar:baz",
-					},
-				},
-			},
-		},
-	}
 	for _, fn := range options {
-		fn(&rev)
+		fn(list)
 	}
-	return rev
+
+	return list
+}
+
+func withServices(svc *servingv1.Service, options ...expectedServiceOption) expectedServiceListOption {
+	return func(list *servingv1.ServiceList) {
+		list.Items = append(list.Items, *(getServiceWithOptions(svc, options...)))
+	}
+}
+
+func getRevisionListWithOptions(options ...expectedRevisionListOption) *servingv1.RevisionList {
+	list := &servingv1.RevisionList{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "List",
+		},
+	}
+
+	for _, fn := range options {
+		fn(list)
+	}
+
+	return list
+}
+
+func withRevisions(options ...expectedRevisionOption) expectedRevisionListOption {
+	return func(list *servingv1.RevisionList) {
+		list.Items = append(list.Items, getRevisionWithOptions(options...))
+	}
 }
 
 func getServiceWithOptions(svc *servingv1.Service, options ...expectedServiceOption) *servingv1.Service {
@@ -205,87 +376,39 @@ func getServiceWithOptions(svc *servingv1.Service, options ...expectedServiceOpt
 
 	return svc
 }
-
 func withLabels(labels map[string]string) expectedServiceOption {
+	return func(svc *servingv1.Service) {
+		svc.ObjectMeta.Labels = labels
+	}
+}
+func withConfigurationLabels(labels map[string]string) expectedServiceOption {
 	return func(svc *servingv1.Service) {
 		svc.Spec.ConfigurationSpec.Template.ObjectMeta.Labels = labels
 	}
 }
-
-func withEnvFrom(cmNames []string) expectedServiceOption {
+func withAnnotations(Annotations map[string]string) expectedServiceOption {
 	return func(svc *servingv1.Service) {
-		var list []v1.EnvFromSource
-		for _, cmName := range cmNames {
-			list = append(list, v1.EnvFromSource{
-				ConfigMapRef: &v1.ConfigMapEnvSource{
-					LocalObjectReference: v1.LocalObjectReference{
-						Name: cmName,
-					},
-				},
-			})
-		}
-		svc.Spec.ConfigurationSpec.Template.Spec.PodSpec.Containers[0].EnvFrom = list
+		svc.ObjectMeta.Annotations = Annotations
 	}
 }
-
-func withEnv(env []v1.EnvVar) expectedServiceOption {
+func withConfigurationAnnotations(Annotations map[string]string) expectedServiceOption {
 	return func(svc *servingv1.Service) {
-		svc.Spec.ConfigurationSpec.Template.Spec.PodSpec.Containers[0].Env = env
+		svc.Spec.ConfigurationSpec.Template.ObjectMeta.Annotations = Annotations
 	}
 }
-
-func withContainer() expectedServiceOption {
-	return func(svc *servingv1.Service) {
-		svc.Spec.ConfigurationSpec.Template.Spec.Containers[0].Image = "gcr.io/foo/bar:baz"
-		svc.Spec.ConfigurationSpec.Template.Annotations = map[string]string{servinglib.UserImageAnnotationKey: "gcr.io/foo/bar:baz"}
-
-	}
-}
-
-func withVolumeandSecrets(volName string, secretName string) expectedServiceOption {
-	return func(svc *servingv1.Service) {
-		template := &svc.Spec.Template
-		template.Spec.Volumes = []v1.Volume{
-			{
-				Name: volName,
-				VolumeSource: v1.VolumeSource{
-					Secret: &v1.SecretVolumeSource{
-						SecretName: secretName,
-					},
-				},
-			},
-		}
-
-		template.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{
-			{
-				Name:      volName,
-				MountPath: "/mount/path",
-				ReadOnly:  true,
-			},
-		}
-	}
-}
-
-func withRevisionGeneration(gen string) expectedRevisionOption {
-	return func(rev *servingv1.Revision) {
-		i, _ := strconv.Atoi(gen)
-		rev.ObjectMeta.Generation = int64(i)
-		rev.ObjectMeta.Labels[apiserving.ConfigurationGenerationLabelKey] = gen
-	}
-}
-
-func withRevisionName(name string) expectedRevisionOption {
-	return func(rev *servingv1.Revision) {
-		rev.ObjectMeta.Name = name
-	}
-}
-
 func withServiceRevisionName(name string) expectedServiceOption {
 	return func(svc *servingv1.Service) {
 		svc.Spec.ConfigurationSpec.Template.ObjectMeta.Name = name
 	}
 }
-
+func withUnwantedFieldsStripped() expectedServiceOption {
+	return func(svc *servingv1.Service) {
+		svc.ObjectMeta.Namespace = ""
+		svc.Spec.Template.Spec.Containers[0].Resources = v1.ResourceRequirements{}
+		svc.Status = servingv1.ServiceStatus{}
+		svc.ObjectMeta.CreationTimestamp = metav1.Time{}
+	}
+}
 func withTrafficSplit(revisions []string, percentages []int, tags []string) expectedServiceOption {
 	return func(svc *servingv1.Service) {
 		var trafficTargets []servingv1.TrafficTarget
@@ -305,6 +428,89 @@ func withTrafficSplit(revisions []string, percentages []int, tags []string) expe
 		}
 		svc.Spec.RouteSpec = servingv1.RouteSpec{
 			Traffic: trafficTargets,
+		}
+	}
+}
+func WithServicePodSpecOption(options ...podSpecOption) expectedServiceOption {
+	return func(svc *servingv1.Service) {
+		svc.Spec.Template.Spec.PodSpec = getPodSpecWithOptions(options...)
+	}
+}
+
+func getRevisionWithOptions(options ...expectedRevisionOption) servingv1.Revision {
+	rev := servingv1.Revision{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Revision",
+			APIVersion: "serving.knative.dev/v1",
+		},
+	}
+	for _, fn := range options {
+		fn(&rev)
+	}
+	return rev
+}
+func withRevisionGeneration(gen string) expectedRevisionOption {
+	return func(rev *servingv1.Revision) {
+		rev.ObjectMeta.Labels[apiserving.ConfigurationGenerationLabelKey] = gen
+	}
+}
+func withRevisionName(name string) expectedRevisionOption {
+	return func(rev *servingv1.Revision) {
+		rev.ObjectMeta.Name = name
+	}
+}
+func withRevisionLabels(labels map[string]string) expectedRevisionOption {
+	return func(rev *servingv1.Revision) {
+		rev.ObjectMeta.Labels = labels
+	}
+}
+func withRevisionAnnotations(Annotations map[string]string) expectedRevisionOption {
+	return func(rev *servingv1.Revision) {
+		rev.ObjectMeta.Annotations = Annotations
+	}
+}
+func WithRevisionPodSpecOption(options ...podSpecOption) expectedRevisionOption {
+	return func(rev *servingv1.Revision) {
+		rev.Spec.PodSpec = getPodSpecWithOptions(options...)
+	}
+}
+
+func getPodSpecWithOptions(options ...podSpecOption) v1.PodSpec {
+	spec := v1.PodSpec{}
+	for _, fn := range options {
+		fn(&spec)
+	}
+	return spec
+}
+
+func withEnv(env []v1.EnvVar) podSpecOption {
+	return func(spec *v1.PodSpec) {
+		spec.Containers[0].Env = env
+	}
+}
+func withContainer() podSpecOption {
+	return func(spec *v1.PodSpec) {
+		spec.Containers = append(spec.Containers, v1.Container{Image: "gcr.io/foo/bar:baz"})
+	}
+}
+func withVolumeandSecrets(secretName string) podSpecOption {
+	return func(spec *v1.PodSpec) {
+		spec.Volumes = []v1.Volume{
+			{
+				Name: secretName,
+				VolumeSource: v1.VolumeSource{
+					Secret: &v1.SecretVolumeSource{
+						SecretName: secretName,
+					},
+				},
+			},
+		}
+		spec.Containers[0].VolumeMounts = []v1.VolumeMount{
+			{
+				Name:      secretName,
+				MountPath: "/mount/path",
+				ReadOnly:  true,
+			},
 		}
 	}
 }

--- a/pkg/kn/commands/service/export_test.go
+++ b/pkg/kn/commands/service/export_test.go
@@ -38,7 +38,6 @@ type expectedRevisionListOption func(*servingv1.RevisionList)
 type podSpecOption func(*v1.PodSpec)
 
 func TestServiceExportError(t *testing.T) {
-	// New mock client
 	client := knclient.NewMockKnServiceClient(t)
 
 	expectedService := getService("foo")
@@ -64,9 +63,7 @@ func TestServiceExport(t *testing.T) {
 }
 
 func exportServiceTest(t *testing.T, expectedService *servingv1.Service) {
-	// New mock client
 	client := knclient.NewMockKnServiceClient(t)
-	// Recording:
 	r := client.Recorder()
 	r.GetService(expectedService.ObjectMeta.Name, expectedService, nil)
 
@@ -268,9 +265,7 @@ func TestServiceExportwithMultipleRevisions(t *testing.T) {
 }
 
 func exportWithRevisionsforKubernetesTest(t *testing.T, latestSvc *servingv1.Service, revs *servingv1.RevisionList, expSvcList *servingv1.ServiceList) {
-	// New mock client
 	client := knclient.NewMockKnServiceClient(t)
-	// Recording:
 	r := client.Recorder()
 
 	r.GetService(latestSvc.ObjectMeta.Name, latestSvc, nil)
@@ -288,9 +283,7 @@ func exportWithRevisionsforKubernetesTest(t *testing.T, latestSvc *servingv1.Ser
 }
 
 func exportWithRevisionsTest(t *testing.T, latestSvc *servingv1.Service, revs *servingv1.RevisionList, expRevList *servingv1.RevisionList) {
-	// New mock client
 	client := knclient.NewMockKnServiceClient(t)
-	// Recording:
 	r := client.Recorder()
 
 	r.GetService(latestSvc.ObjectMeta.Name, latestSvc, nil)

--- a/pkg/kn/commands/service/export_test.go
+++ b/pkg/kn/commands/service/export_test.go
@@ -92,7 +92,7 @@ func TestServiceExportwithMultipleRevisions(t *testing.T) {
 		latestSvc: getServiceWithOptions(
 			getService("foo"),
 			withAnnotations(map[string]string{"serving.knative.dev/creator": "ut", "serving.knative.dev/lastModifier": "ut"}),
-			withTrafficSplit([]string{"foo-rev-1", "foo-rev-2"}, []int{50, 50}, []bool{false, true}),
+			withTrafficSplit([]string{"foo-rev-1", ""}, []int{50, 50}, []bool{false, true}),
 			withServicePodSpecOption(withContainer()),
 		),
 		expectedSvcList: getServiceListWithOptions(
@@ -106,7 +106,7 @@ func TestServiceExportwithMultipleRevisions(t *testing.T) {
 				getService("foo"),
 				withUnwantedFieldsStripped(),
 				withServicePodSpecOption(withContainer()),
-				withTrafficSplit([]string{"foo-rev-1", "foo-rev-2"}, []int{50, 50}, []bool{false, true}),
+				withTrafficSplit([]string{"foo-rev-1", ""}, []int{50, 50}, []bool{false, true}),
 			),
 		),
 		revisionList: getRevisionListWithOptions(
@@ -136,7 +136,7 @@ func TestServiceExportwithMultipleRevisions(t *testing.T) {
 		name: "test 2 revisions no traffic split",
 		latestSvc: getServiceWithOptions(
 			getService("foo"),
-			withTrafficSplit([]string{"foo-rev-2"}, []int{100}, []bool{true}),
+			withTrafficSplit([]string{""}, []int{100}, []bool{true}),
 			withServicePodSpecOption(withContainer()),
 		),
 		expectedSvcList: getServiceListWithOptions(
@@ -144,7 +144,7 @@ func TestServiceExportwithMultipleRevisions(t *testing.T) {
 				getService("foo"),
 				withUnwantedFieldsStripped(),
 				withServicePodSpecOption(withContainer()),
-				withTrafficSplit([]string{"foo-rev-2"}, []int{100}, []bool{true}),
+				withTrafficSplit([]string{""}, []int{100}, []bool{true}),
 			),
 		),
 		revisionList: getRevisionListWithOptions(

--- a/test/e2e/service_export_import_apply_test.go
+++ b/test/e2e/service_export_import_apply_test.go
@@ -85,7 +85,7 @@ func TestServiceExport(t *testing.T) {
 				withEnv([]corev1.EnvVar{{Name: "a", Value: "mouse"}}),
 			),
 		),
-	), "--with-revisions", "--kubernetes-resources", "-o", "yaml")
+	), "--with-revisions", "--mode", "kubernetes", "-o", "yaml")
 
 	t.Log("export service-revision2 with revisions-only")
 	serviceExportWithRevisionList(r, "hello", getServiceWithOptions(
@@ -96,7 +96,7 @@ func TestServiceExport(t *testing.T) {
 			withContainer(),
 			withEnv([]corev1.EnvVar{{Name: "a", Value: "mouse"}}),
 		),
-	), getRevisionListWithOptions(), "--with-revisions", "-o", "yaml")
+	), getRevisionListWithOptions(), "--with-revisions", "--mode", "resources", "-o", "yaml")
 
 	t.Log("update service with tag and split traffic")
 	serviceUpdateWithOptions(r, "hello", "--tag", "hello-rev1=candidate", "--traffic", "candidate=2%,@latest=98%")
@@ -119,7 +119,7 @@ func TestServiceExport(t *testing.T) {
 				withEnv([]corev1.EnvVar{{Name: "a", Value: "mouse"}}),
 			),
 		),
-	), "--with-revisions", "--kubernetes-resources", "-o", "yaml")
+	), "--with-revisions", "--mode", "kubernetes", "-o", "yaml")
 
 	t.Log("export service-revision2 after tagging with revisions-only")
 	serviceExportWithRevisionList(r, "hello", getServiceWithOptions(
@@ -149,7 +149,7 @@ func TestServiceExport(t *testing.T) {
 				withContainer(),
 			),
 		),
-	), "--with-revisions", "-o", "yaml")
+	), "--with-revisions", "--mode", "resources", "-o", "yaml")
 
 	t.Log("update service - untag, add env variable, traffic split and system revision name")
 	serviceUpdateWithOptions(r, "hello", "--untag", "candidate")
@@ -181,7 +181,7 @@ func TestServiceExport(t *testing.T) {
 				withEnv([]corev1.EnvVar{{Name: "a", Value: "mouse"}, {Name: "b", Value: "cat"}}),
 			),
 		),
-	), "--with-revisions", "--kubernetes-resources", "-o", "yaml")
+	), "--with-revisions", "--mode", "kubernetes", "-o", "yaml")
 
 	t.Log("export service-revision3 with revisions-only")
 	serviceExportWithRevisionList(r, "hello", getServiceWithOptions(
@@ -229,7 +229,7 @@ func TestServiceExport(t *testing.T) {
 				withEnv([]corev1.EnvVar{{Name: "a", Value: "mouse"}}),
 			),
 		),
-	), "--with-revisions", "-o", "yaml")
+	), "--with-revisions", "--mode", "resources", "-o", "yaml")
 
 	t.Log("send all traffic to revision 2")
 	serviceUpdateWithOptions(r, "hello", "--traffic", "hello-rev2=100")
@@ -253,7 +253,7 @@ func TestServiceExport(t *testing.T) {
 				withEnv([]corev1.EnvVar{{Name: "a", Value: "mouse"}, {Name: "b", Value: "cat"}}),
 			),
 		),
-	), "--with-revisions", "--kubernetes-resources", "-o", "yaml")
+	), "--with-revisions", "--mode", "kubernetes", "-o", "yaml")
 
 	t.Log("export revisions-only - all traffic to revision 2")
 	serviceExportWithRevisionList(r, "hello", getServiceWithOptions(
@@ -283,7 +283,7 @@ func TestServiceExport(t *testing.T) {
 				withEnv([]corev1.EnvVar{{Name: "a", Value: "mouse"}}),
 			),
 		),
-	), "--with-revisions", "-o", "yaml")
+	), "--with-revisions", "--mode", "resources", "-o", "yaml")
 }
 
 // Private methods

--- a/test/e2e/service_export_import_apply_test.go
+++ b/test/e2e/service_export_import_apply_test.go
@@ -61,7 +61,7 @@ func TestServiceExportImportApply(t *testing.T) {
 		withServiceRevisionName("hello-rev1"),
 		withConfigurationAnnotations(),
 		withAnnotations(),
-		WithServicePodSpecOption(withContainer()),
+		withServicePodSpecOption(withContainer()),
 	), "-o", "json")
 
 	t.Log("update service - add env variable")
@@ -70,7 +70,7 @@ func TestServiceExportImportApply(t *testing.T) {
 		withServiceName("hello"),
 		withServiceRevisionName("hello-rev2"),
 		withAnnotations(),
-		WithServicePodSpecOption(
+		withServicePodSpecOption(
 			withContainer(),
 			withEnv([]corev1.EnvVar{{Name: "a", Value: "mouse"}}),
 		),
@@ -82,7 +82,7 @@ func TestServiceExportImportApply(t *testing.T) {
 			withServiceRevisionName("hello-rev2"),
 			withAnnotations(),
 			withTrafficSplit([]string{"latest"}, []int{100}, []string{""}),
-			WithServicePodSpecOption(
+			withServicePodSpecOption(
 				withContainer(),
 				withEnv([]corev1.EnvVar{{Name: "a", Value: "mouse"}}),
 			),
@@ -94,7 +94,7 @@ func TestServiceExportImportApply(t *testing.T) {
 		withServiceRevisionName("hello-rev2"),
 		withAnnotations(),
 		withTrafficSplit([]string{"latest"}, []int{100}, []string{""}),
-		WithServicePodSpecOption(
+		withServicePodSpecOption(
 			withContainer(),
 			withEnv([]corev1.EnvVar{{Name: "a", Value: "mouse"}}),
 		),
@@ -108,7 +108,7 @@ func TestServiceExportImportApply(t *testing.T) {
 			withServiceName("hello"),
 			withServiceRevisionName("hello-rev1"),
 			withAnnotations(),
-			WithServicePodSpecOption(
+			withServicePodSpecOption(
 				withContainer(),
 			),
 		),
@@ -117,7 +117,7 @@ func TestServiceExportImportApply(t *testing.T) {
 			withServiceRevisionName("hello-rev2"),
 			withAnnotations(),
 			withTrafficSplit([]string{"latest", "hello-rev1"}, []int{98, 2}, []string{"", "candidate"}),
-			WithServicePodSpecOption(
+			withServicePodSpecOption(
 				withContainer(),
 				withEnv([]corev1.EnvVar{{Name: "a", Value: "mouse"}}),
 			),
@@ -129,7 +129,7 @@ func TestServiceExportImportApply(t *testing.T) {
 		withServiceRevisionName("hello-rev2"),
 		withAnnotations(),
 		withTrafficSplit([]string{"latest", "hello-rev1"}, []int{98, 2}, []string{"", "candidate"}),
-		WithServicePodSpecOption(
+		withServicePodSpecOption(
 			withContainer(),
 			withEnv([]corev1.EnvVar{{Name: "a", Value: "mouse"}}),
 		),
@@ -148,7 +148,7 @@ func TestServiceExportImportApply(t *testing.T) {
 					"serving.knative.dev/route":                   "hello",
 					"serving.knative.dev/service":                 "hello",
 				}),
-			WithRevisionPodSpecOption(
+			withRevisionPodSpecOption(
 				withContainer(),
 			),
 		),
@@ -162,7 +162,7 @@ func TestServiceExportImportApply(t *testing.T) {
 			withServiceName("hello"),
 			withServiceRevisionName("hello-rev1"),
 			withAnnotations(),
-			WithServicePodSpecOption(
+			withServicePodSpecOption(
 				withContainer(),
 			),
 		),
@@ -170,7 +170,7 @@ func TestServiceExportImportApply(t *testing.T) {
 			withServiceName("hello"),
 			withServiceRevisionName("hello-rev2"),
 			withAnnotations(),
-			WithServicePodSpecOption(
+			withServicePodSpecOption(
 				withContainer(),
 				withEnv([]corev1.EnvVar{{Name: "a", Value: "mouse"}}),
 			),
@@ -180,7 +180,7 @@ func TestServiceExportImportApply(t *testing.T) {
 			withServiceRevisionName("hello-rev3"),
 			withAnnotations(),
 			withTrafficSplit([]string{"hello-rev1", "hello-rev2", "hello-rev3"}, []int{30, 30, 40}, []string{"", "", ""}),
-			WithServicePodSpecOption(
+			withServicePodSpecOption(
 				withContainer(),
 				withEnv([]corev1.EnvVar{{Name: "a", Value: "mouse"}, {Name: "b", Value: "cat"}}),
 			),
@@ -192,7 +192,7 @@ func TestServiceExportImportApply(t *testing.T) {
 		withServiceRevisionName("hello-rev3"),
 		withAnnotations(),
 		withTrafficSplit([]string{"hello-rev1", "hello-rev2", "hello-rev3"}, []int{30, 30, 40}, []string{"", "", ""}),
-		WithServicePodSpecOption(
+		withServicePodSpecOption(
 			withContainer(),
 			withEnv([]corev1.EnvVar{{Name: "a", Value: "mouse"}, {Name: "b", Value: "cat"}}),
 		),
@@ -211,7 +211,7 @@ func TestServiceExportImportApply(t *testing.T) {
 					"serving.knative.dev/route":                   "hello",
 					"serving.knative.dev/service":                 "hello",
 				}),
-			WithRevisionPodSpecOption(
+			withRevisionPodSpecOption(
 				withContainer(),
 			),
 		),
@@ -228,7 +228,7 @@ func TestServiceExportImportApply(t *testing.T) {
 					"serving.knative.dev/route":                   "hello",
 					"serving.knative.dev/service":                 "hello",
 				}),
-			WithRevisionPodSpecOption(
+			withRevisionPodSpecOption(
 				withContainer(),
 				withEnv([]corev1.EnvVar{{Name: "a", Value: "mouse"}}),
 			),
@@ -243,7 +243,7 @@ func TestServiceExportImportApply(t *testing.T) {
 			withServiceName("hello"),
 			withServiceRevisionName("hello-rev2"),
 			withAnnotations(),
-			WithServicePodSpecOption(
+			withServicePodSpecOption(
 				withContainer(),
 				withEnv([]corev1.EnvVar{{Name: "a", Value: "mouse"}}),
 			),
@@ -253,7 +253,7 @@ func TestServiceExportImportApply(t *testing.T) {
 			withServiceRevisionName("hello-rev3"),
 			withAnnotations(),
 			withTrafficSplit([]string{"hello-rev2"}, []int{100}, []string{""}),
-			WithServicePodSpecOption(
+			withServicePodSpecOption(
 				withContainer(),
 				withEnv([]corev1.EnvVar{{Name: "a", Value: "mouse"}, {Name: "b", Value: "cat"}}),
 			),
@@ -265,7 +265,7 @@ func TestServiceExportImportApply(t *testing.T) {
 		withServiceRevisionName("hello-rev3"),
 		withAnnotations(),
 		withTrafficSplit([]string{"hello-rev2"}, []int{100}, []string{""}),
-		WithServicePodSpecOption(
+		withServicePodSpecOption(
 			withContainer(),
 			withEnv([]corev1.EnvVar{{Name: "a", Value: "mouse"}, {Name: "b", Value: "cat"}}),
 		),
@@ -283,7 +283,7 @@ func TestServiceExportImportApply(t *testing.T) {
 					"serving.knative.dev/route":                   "hello",
 					"serving.knative.dev/service":                 "hello",
 				}),
-			WithRevisionPodSpecOption(
+			withRevisionPodSpecOption(
 				withContainer(),
 				withEnv([]corev1.EnvVar{{Name: "a", Value: "mouse"}}),
 			),
@@ -470,7 +470,7 @@ func withTrafficSplit(revisions []string, percentages []int, tags []string) expe
 		}
 	}
 }
-func WithServicePodSpecOption(options ...podSpecOption) expectedServiceOption {
+func withServicePodSpecOption(options ...podSpecOption) expectedServiceOption {
 	return func(svc *servingv1.Service) {
 		svc.Spec.Template.Spec.PodSpec = getPodSpecWithOptions(options...)
 	}
@@ -504,7 +504,7 @@ func withRevisionAnnotations(Annotations map[string]string) expectedRevisionOpti
 		rev.ObjectMeta.Annotations = Annotations
 	}
 }
-func WithRevisionPodSpecOption(options ...podSpecOption) expectedRevisionOption {
+func withRevisionPodSpecOption(options ...podSpecOption) expectedRevisionOption {
 	return func(rev *servingv1.Revision) {
 		rev.Spec.PodSpec = getPodSpecWithOptions(options...)
 	}

--- a/test/e2e/service_export_import_apply_test.go
+++ b/test/e2e/service_export_import_apply_test.go
@@ -309,7 +309,6 @@ func validateExportedService(t *testing.T, it *test.KnTest, out string, expServi
 	actSvc := servingv1.Service{}
 	err := json.Unmarshal([]byte(out), &actSvc)
 	assert.NilError(t, err)
-	stripGeneratedFieldsfromService(&actSvc)
 	assert.DeepEqual(t, &expService, &actSvc)
 }
 
@@ -317,7 +316,6 @@ func validateExportedServiceList(t *testing.T, it *test.KnTest, out string, expS
 	actSvcList := servingv1.ServiceList{}
 	err := yaml.Unmarshal([]byte(out), &actSvcList)
 	assert.NilError(t, err)
-	stripGeneratedFieldsfromServiceList(&actSvcList)
 	assert.DeepEqual(t, &expServiceList, &actSvcList)
 }
 
@@ -327,7 +325,6 @@ func validateExportedServiceandRevisionList(t *testing.T, it *test.KnTest, out s
 	actSvc := servingv1.Service{}
 	err := yaml.Unmarshal([]byte(outArray[0]), &actSvc)
 	assert.NilError(t, err)
-	stripGeneratedFieldsfromService(&actSvc)
 	assert.DeepEqual(t, &expService, &actSvc)
 
 	if len(outArray) > 1 {
@@ -338,7 +335,6 @@ func validateExportedServiceandRevisionList(t *testing.T, it *test.KnTest, out s
 		actRevList := servingv1.RevisionList{}
 		err := yaml.Unmarshal([]byte(revListBuilder.String()), &actRevList)
 		assert.NilError(t, err)
-		stripGeneratedFieldsfromRevisionList(&actRevList)
 		assert.DeepEqual(t, &actRevList, &actRevList)
 	} else if len(expRevisionList.Items) > 0 {
 		t.Errorf("expecting a revision list and got no list")
@@ -399,7 +395,6 @@ func getServiceWithOptions(options ...expectedServiceOption) servingv1.Service {
 	}
 	svc.Spec.Template.Spec.ContainerConcurrency = ptr.Int64(int64(0))
 	svc.Spec.Template.Spec.TimeoutSeconds = ptr.Int64(int64(300))
-	svc.ObjectMeta.Annotations = map[string]string{}
 
 	return svc
 }
@@ -519,24 +514,4 @@ func withContainer() podSpecOption {
 			},
 		}
 	}
-}
-
-func stripGeneratedFieldsfromRevisionList(list *servingv1.RevisionList) {
-	for _, revision := range list.Items {
-		delete(revision.ObjectMeta.Annotations, "serving.knative.dev/lastPinned")
-		if len(revision.ObjectMeta.Annotations) == 0 {
-			revision.ObjectMeta.Annotations = nil
-		}
-	}
-}
-
-func stripGeneratedFieldsfromServiceList(list *servingv1.ServiceList) {
-	for _, service := range list.Items {
-		stripGeneratedFieldsfromService(&service)
-	}
-}
-
-func stripGeneratedFieldsfromService(svc *servingv1.Service) {
-	delete(svc.ObjectMeta.Annotations, "serving.knative.dev/creator")
-	delete(svc.ObjectMeta.Annotations, "serving.knative.dev/lastModifier")
 }


### PR DESCRIPTION
## Description
Changes made to export revisions directly with kn service export.
https://github.com/knative/client/issues/728#issuecomment-603928462 - This was the approach followed
<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages --> 
* --with-revisions option will export service and revision list
* --with-revisions --kubernetes-resources will export a service list (kubectl friendly)
* add annotations to export

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #728 

<!--
Please add an entrty to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line belpow. You get feedback as comments on your pull request then -->

<!--
/lint
-->
