### PR TITLE
Correct Typo in Pull Request Template

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -33,7 +33,7 @@ PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN 
 -->
 
 <!--
-To automatically lint go code in this pull request uncomment the line belpow. You get feedback as comments on your pull request then -->
+To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->
 
 <!--
 /lint


### PR DESCRIPTION
## Description

Correcting a minor typo in the pull request template: `belpow` -> `below`
