### PR TITLE
fix(e2e): Refactor e2e utils and resource actions

### DIFF
--- a/lib/test/revision.go
+++ b/lib/test/revision.go
@@ -23,6 +23,7 @@ import (
 	"knative.dev/client/pkg/util"
 )
 
+// RevisionListForService list revisions of given service and verifies if their status is True
 func RevisionListForService(r *KnRunResultCollector, serviceName string) {
 	out := r.KnTest().Kn().Run("revision", "list", "-s", serviceName)
 	r.AssertNoError(out)
@@ -35,6 +36,7 @@ func RevisionListForService(r *KnRunResultCollector, serviceName string) {
 	}
 }
 
+// RevisionDescribe verifies revision describe output for given service's revision
 func RevisionDescribe(r *KnRunResultCollector, serviceName string) {
 	revName := FindRevision(r, serviceName)
 
@@ -43,12 +45,14 @@ func RevisionDescribe(r *KnRunResultCollector, serviceName string) {
 	assert.Check(r.T(), util.ContainsAll(out.Stdout, revName, r.KnTest().Kn().Namespace(), serviceName, "++ Ready", "TARGET=kn"))
 }
 
+// RevisionDelete verifies deleting given revision in sync mode
 func RevisionDelete(r *KnRunResultCollector, revName string) {
 	out := r.KnTest().Kn().Run("revision", "delete", "--wait", revName)
 	assert.Check(r.T(), util.ContainsAll(out.Stdout, "Revision", revName, "deleted", "namespace", r.KnTest().Kn().Namespace()))
 	r.AssertNoError(out)
 }
 
+// RevisionMultipleDelete verifies deleting multiple revisions
 func RevisionMultipleDelete(r *KnRunResultCollector, existRevision1, existRevision2, nonexistRevision string) {
 	out := r.KnTest().Kn().Run("revision", "list")
 	r.AssertNoError(out)
@@ -63,6 +67,7 @@ func RevisionMultipleDelete(r *KnRunResultCollector, existRevision1, existRevisi
 	assert.Check(r.T(), util.ContainsAll(out.Stdout, "revisions.serving.knative.dev", nonexistRevision, "not found"), "Failed to get 'not found' error")
 }
 
+// RevisionDescribeWithPrintFlags verifies describing given revision using print flag '--output=name'
 func RevisionDescribeWithPrintFlags(r *KnRunResultCollector, revName string) {
 	out := r.KnTest().Kn().Run("revision", "describe", revName, "-o=name")
 	r.AssertNoError(out)
@@ -70,6 +75,7 @@ func RevisionDescribeWithPrintFlags(r *KnRunResultCollector, revName string) {
 	assert.Equal(r.T(), strings.TrimSpace(out.Stdout), expectedName)
 }
 
+// FindRevision returns a revision name (at index 0) for given service
 func FindRevision(r *KnRunResultCollector, serviceName string) string {
 	out := r.KnTest().Kn().Run("revision", "list", "-s", serviceName, "-o=jsonpath={.items[0].metadata.name}")
 	r.AssertNoError(out)
@@ -79,6 +85,7 @@ func FindRevision(r *KnRunResultCollector, serviceName string) string {
 	return out.Stdout
 }
 
+// FindRevisionByGeneration returns a revision name for given revision at given generation number
 func FindRevisionByGeneration(r *KnRunResultCollector, serviceName string, generation int) string {
 	maxGen := FindConfigurationGeneration(r, serviceName)
 	out := r.KnTest().Kn().Run("revision", "list", "-s", serviceName,
@@ -90,6 +97,7 @@ func FindRevisionByGeneration(r *KnRunResultCollector, serviceName string, gener
 	return out.Stdout
 }
 
+// FindConfigurationGeneration returns the configuration generation number of given service
 func FindConfigurationGeneration(r *KnRunResultCollector, serviceName string) int {
 	out := r.KnTest().Kn().Run("revision", "list", "-s", serviceName, "-o=jsonpath={.items[0].metadata.labels.serving\\.knative\\.dev/configurationGeneration}")
 	r.AssertNoError(out)
@@ -104,12 +112,14 @@ func FindConfigurationGeneration(r *KnRunResultCollector, serviceName string) in
 	return confGen
 }
 
+// RevisionListOutputName verifies listing given revision using print flag '--output name'
 func RevisionListOutputName(r *KnRunResultCollector, revisionName string) {
 	out := r.KnTest().Kn().Run("revision", "list", "--output", "name")
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAll(out.Stdout, revisionName, "revision.serving.knative.dev"))
 }
 
+// RevisionListWithService verifies listing revisions per service from each given service names
 func RevisionListWithService(r *KnRunResultCollector, serviceNames ...string) {
 	for _, svcName := range serviceNames {
 		confGen := FindConfigurationGeneration(r, svcName)

--- a/lib/test/revision.go
+++ b/lib/test/revision.go
@@ -1,0 +1,131 @@
+// Copyright 2020 The Knative Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"gotest.tools/assert"
+	"knative.dev/client/pkg/util"
+)
+
+func RevisionListForService(r *KnRunResultCollector, serviceName string) {
+	out := r.KnTest().Kn().Run("revision", "list", "-s", serviceName)
+	r.AssertNoError(out)
+	outputLines := strings.Split(out.Stdout, "\n")
+	// Ignore the last line because it is an empty string caused by splitting a line break
+	// at the end of the output string
+	for _, line := range outputLines[1 : len(outputLines)-1] {
+		// The last item is the revision status, which should be ready
+		assert.Check(r.T(), util.ContainsAll(line, " "+serviceName+" ", "True"))
+	}
+}
+
+func RevisionDescribe(r *KnRunResultCollector, serviceName string) {
+	revName := FindRevision(r, serviceName)
+
+	out := r.KnTest().Kn().Run("revision", "describe", revName)
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAll(out.Stdout, revName, r.KnTest().Kn().Namespace(), serviceName, "++ Ready", "TARGET=kn"))
+}
+
+func RevisionDelete(r *KnRunResultCollector, revName string) {
+	out := r.KnTest().Kn().Run("revision", "delete", "--wait", revName)
+	assert.Check(r.T(), util.ContainsAll(out.Stdout, "Revision", revName, "deleted", "namespace", r.KnTest().Kn().Namespace()))
+	r.AssertNoError(out)
+}
+
+func RevisionMultipleDelete(r *KnRunResultCollector, existRevision1, existRevision2, nonexistRevision string) {
+	out := r.KnTest().Kn().Run("revision", "list")
+	r.AssertNoError(out)
+	assert.Check(r.T(), strings.Contains(out.Stdout, existRevision1), "Required revision1 does not exist")
+	assert.Check(r.T(), strings.Contains(out.Stdout, existRevision2), "Required revision2 does not exist")
+
+	out = r.KnTest().Kn().Run("revision", "delete", existRevision1, existRevision2, nonexistRevision)
+	r.AssertNoError(out)
+
+	assert.Check(r.T(), util.ContainsAll(out.Stdout, "Revision", existRevision1, "deleted", "namespace", r.KnTest().Kn().Namespace()), "Failed to get 'deleted' first revision message")
+	assert.Check(r.T(), util.ContainsAll(out.Stdout, "Revision", existRevision2, "deleted", "namespace", r.KnTest().Kn().Namespace()), "Failed to get 'deleted' second revision message")
+	assert.Check(r.T(), util.ContainsAll(out.Stdout, "revisions.serving.knative.dev", nonexistRevision, "not found"), "Failed to get 'not found' error")
+}
+
+func RevisionDescribeWithPrintFlags(r *KnRunResultCollector, revName string) {
+	out := r.KnTest().Kn().Run("revision", "describe", revName, "-o=name")
+	r.AssertNoError(out)
+	expectedName := fmt.Sprintf("revision.serving.knative.dev/%s", revName)
+	assert.Equal(r.T(), strings.TrimSpace(out.Stdout), expectedName)
+}
+
+func FindRevision(r *KnRunResultCollector, serviceName string) string {
+	out := r.KnTest().Kn().Run("revision", "list", "-s", serviceName, "-o=jsonpath={.items[0].metadata.name}")
+	r.AssertNoError(out)
+	if strings.Contains(out.Stdout, "No resources") {
+		r.T().Errorf("Could not find revision name.")
+	}
+	return out.Stdout
+}
+
+func FindRevisionByGeneration(r *KnRunResultCollector, serviceName string, generation int) string {
+	maxGen := FindConfigurationGeneration(r, serviceName)
+	out := r.KnTest().Kn().Run("revision", "list", "-s", serviceName,
+		fmt.Sprintf("-o=jsonpath={.items[%d].metadata.name}", maxGen-generation))
+	r.AssertNoError(out)
+	if strings.Contains(out.Stdout, "No resources found.") {
+		r.T().Errorf("Could not find revision name.")
+	}
+	return out.Stdout
+}
+
+func FindConfigurationGeneration(r *KnRunResultCollector, serviceName string) int {
+	out := r.KnTest().Kn().Run("revision", "list", "-s", serviceName, "-o=jsonpath={.items[0].metadata.labels.serving\\.knative\\.dev/configurationGeneration}")
+	r.AssertNoError(out)
+	if out.Stdout == "" {
+		r.T().Errorf("Could not find configuration generation.")
+	}
+	confGen, err := strconv.Atoi(out.Stdout)
+	if err != nil {
+		r.T().Errorf("Invalid type of configuration generation: %s", err)
+	}
+
+	return confGen
+}
+
+func RevisionListOutputName(r *KnRunResultCollector, revisionName string) {
+	out := r.KnTest().Kn().Run("revision", "list", "--output", "name")
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAll(out.Stdout, revisionName, "revision.serving.knative.dev"))
+}
+
+func RevisionListWithService(r *KnRunResultCollector, serviceNames ...string) {
+	for _, svcName := range serviceNames {
+		confGen := FindConfigurationGeneration(r, svcName)
+		out := r.KnTest().Kn().Run("revision", "list", "-s", svcName)
+		r.AssertNoError(out)
+
+		outputLines := strings.Split(out.Stdout, "\n")
+		// Ignore the last line because it is an empty string caused by splitting a line break
+		// at the end of the output string
+		for _, line := range outputLines[1 : len(outputLines)-1] {
+			revName := FindRevisionByGeneration(r, svcName, confGen)
+			assert.Check(r.T(), util.ContainsAll(line, revName, svcName, strconv.Itoa(confGen)))
+			confGen--
+		}
+		if r.T().Failed() {
+			r.AddDump("service", svcName, r.KnTest().Kn().Namespace())
+		}
+	}
+}

--- a/lib/test/service.go
+++ b/lib/test/service.go
@@ -1,0 +1,26 @@
+// Copyright 2020 The Knative Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"gotest.tools/assert"
+	"knative.dev/client/pkg/util"
+)
+
+func ServiceCreate(r *KnRunResultCollector, serviceName string) {
+	out := r.KnTest().Kn().Run("service", "create", serviceName, "--image", KnDefaultTestImage)
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "service", serviceName, "creating", "namespace", r.KnTest().Kn().Namespace(), "ready"))
+}

--- a/lib/test/service.go
+++ b/lib/test/service.go
@@ -24,3 +24,57 @@ func ServiceCreate(r *KnRunResultCollector, serviceName string) {
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "service", serviceName, "creating", "namespace", r.KnTest().Kn().Namespace(), "ready"))
 }
+
+func ServiceListEmpty(r *KnRunResultCollector) {
+	out := r.KnTest().Kn().Run("service", "list")
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAll(out.Stdout, "No services found."))
+}
+
+func ServiceList(r *KnRunResultCollector, serviceName string) {
+	out := r.KnTest().Kn().Run("service", "list", serviceName)
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAll(out.Stdout, serviceName))
+}
+
+func ServiceDescribe(r *KnRunResultCollector, serviceName string) {
+	out := r.KnTest().Kn().Run("service", "describe", serviceName)
+	r.AssertNoError(out)
+	assert.Assert(r.T(), util.ContainsAll(out.Stdout, serviceName, r.KnTest().Kn().Namespace(), KnDefaultTestImage))
+	assert.Assert(r.T(), util.ContainsAll(out.Stdout, "Conditions", "ConfigurationsReady", "Ready", "RoutesReady"))
+	assert.Assert(r.T(), util.ContainsAll(out.Stdout, "Name", "Namespace", "URL", "Age", "Revisions"))
+}
+
+func ServiceListOutput(r *KnRunResultCollector, serviceName string) {
+	out := r.KnTest().Kn().Run("service", "list", serviceName, "--output", "name")
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAll(out.Stdout, serviceName, "service.serving.knative.dev"))
+}
+
+func ServiceUpdate(r *KnRunResultCollector, serviceName string, args ...string) {
+	fullArgs := append([]string{}, "service", "update", serviceName)
+	fullArgs = append(fullArgs, args...)
+	out := r.KnTest().Kn().Run(fullArgs...)
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "updating", "service", serviceName, "ready"))
+}
+
+func ServiceDelete(r *KnRunResultCollector, serviceName string) {
+	out := r.KnTest().Kn().Run("service", "delete", "--wait", serviceName)
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAll(out.Stdout, "Service", serviceName, "successfully deleted in namespace", r.KnTest().Kn().Namespace()))
+}
+
+func ServiceDescribeWithJSONPath(r *KnRunResultCollector, serviceName, jsonpath string) string {
+	out := r.KnTest().Kn().Run("service", "describe", serviceName, "-o", jsonpath)
+	r.AssertNoError(out)
+	return out.Stdout
+}
+
+func ServiceUpdateWithOptions(r *KnRunResultCollector, serviceName string, options ...string) {
+	command := []string{"service", "update", serviceName}
+	command = append(command, options...)
+	out := r.KnTest().Kn().Run(command...)
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "Service", serviceName, "updating", "namespace", r.KnTest().Kn().Namespace()))
+}

--- a/lib/test/service.go
+++ b/lib/test/service.go
@@ -19,24 +19,28 @@ import (
 	"knative.dev/client/pkg/util"
 )
 
+// ServiceCreate verifies given service creation in sync mode and also verifies output
 func ServiceCreate(r *KnRunResultCollector, serviceName string) {
 	out := r.KnTest().Kn().Run("service", "create", serviceName, "--image", KnDefaultTestImage)
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "service", serviceName, "creating", "namespace", r.KnTest().Kn().Namespace(), "ready"))
 }
 
+// ServiceListEmpty verifies that there are no services present
 func ServiceListEmpty(r *KnRunResultCollector) {
 	out := r.KnTest().Kn().Run("service", "list")
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAll(out.Stdout, "No services found."))
 }
 
+// ServiceList verifies if given service exists
 func ServiceList(r *KnRunResultCollector, serviceName string) {
 	out := r.KnTest().Kn().Run("service", "list", serviceName)
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAll(out.Stdout, serviceName))
 }
 
+// ServiceDescribe describes given service and verifies the keys in the output
 func ServiceDescribe(r *KnRunResultCollector, serviceName string) {
 	out := r.KnTest().Kn().Run("service", "describe", serviceName)
 	r.AssertNoError(out)
@@ -45,12 +49,14 @@ func ServiceDescribe(r *KnRunResultCollector, serviceName string) {
 	assert.Assert(r.T(), util.ContainsAll(out.Stdout, "Name", "Namespace", "URL", "Age", "Revisions"))
 }
 
+// ServiceListOutput verifies listing given service using '--output name' flag
 func ServiceListOutput(r *KnRunResultCollector, serviceName string) {
 	out := r.KnTest().Kn().Run("service", "list", serviceName, "--output", "name")
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAll(out.Stdout, serviceName, "service.serving.knative.dev"))
 }
 
+// ServiceUpdate verifies service update operation with given arguments in sync mode
 func ServiceUpdate(r *KnRunResultCollector, serviceName string, args ...string) {
 	fullArgs := append([]string{}, "service", "update", serviceName)
 	fullArgs = append(fullArgs, args...)
@@ -59,22 +65,16 @@ func ServiceUpdate(r *KnRunResultCollector, serviceName string, args ...string) 
 	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "updating", "service", serviceName, "ready"))
 }
 
+// ServiceDelete verifies service deletion in sync mode
 func ServiceDelete(r *KnRunResultCollector, serviceName string) {
 	out := r.KnTest().Kn().Run("service", "delete", "--wait", serviceName)
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAll(out.Stdout, "Service", serviceName, "successfully deleted in namespace", r.KnTest().Kn().Namespace()))
 }
 
+// ServiceDescribeWithJSONPath returns output of given JSON path by describing the service
 func ServiceDescribeWithJSONPath(r *KnRunResultCollector, serviceName, jsonpath string) string {
 	out := r.KnTest().Kn().Run("service", "describe", serviceName, "-o", jsonpath)
 	r.AssertNoError(out)
 	return out.Stdout
-}
-
-func ServiceUpdateWithOptions(r *KnRunResultCollector, serviceName string, options ...string) {
-	command := []string{"service", "update", serviceName}
-	command = append(command, options...)
-	out := r.KnTest().Kn().Run(command...)
-	r.AssertNoError(out)
-	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "Service", serviceName, "updating", "namespace", r.KnTest().Kn().Namespace()))
 }

--- a/lib/test/utils.go
+++ b/lib/test/utils.go
@@ -1,0 +1,26 @@
+// Copyright 2020 The Knative Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import "testing"
+
+func GetResourceFieldsWithJSONPath(t *testing.T, it *KnTest, resource, name, jsonpath string) (string, error) {
+	out, err := NewKubectl(it.Kn().Namespace()).Run("get", resource, name, "-o", jsonpath, "-n", it.Kn().Namespace())
+	if err != nil {
+		return "", err
+	}
+
+	return out, nil
+}

--- a/lib/test/utils.go
+++ b/lib/test/utils.go
@@ -16,6 +16,7 @@ package test
 
 import "testing"
 
+// GetResourceFieldsWithJSONPath returns output of given JSON path for given resource using kubectl and error if any
 func GetResourceFieldsWithJSONPath(t *testing.T, it *KnTest, resource, name, jsonpath string) (string, error) {
 	out, err := NewKubectl(it.Kn().Namespace()).Run("get", resource, name, "-o", jsonpath, "-n", it.Kn().Namespace())
 	if err != nil {

--- a/test/e2e/basic_workflow_test.go
+++ b/test/e2e/basic_workflow_test.go
@@ -42,7 +42,7 @@ func TestBasicWorkflow(t *testing.T) {
 	serviceListEmpty(r)
 
 	t.Log("create hello service and return no error")
-	serviceCreate(r, "hello")
+	test.ServiceCreate(r, "hello")
 
 	t.Log("return valid info about hello service")
 	serviceList(r, "hello")
@@ -55,7 +55,7 @@ func TestBasicWorkflow(t *testing.T) {
 	serviceUpdate(r, "hello", "--env", "TARGET=kn", "--port", "8888")
 
 	t.Log("create another service and return no error")
-	serviceCreate(r, "svc2")
+	test.ServiceCreate(r, "svc2")
 
 	t.Log("return a list of revisions associated with hello and svc2 services")
 	revisionListForService(r, "hello")
@@ -94,12 +94,6 @@ func serviceListEmpty(r *test.KnRunResultCollector) {
 	out := r.KnTest().Kn().Run("service", "list")
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAll(out.Stdout, "No services found."))
-}
-
-func serviceCreate(r *test.KnRunResultCollector, serviceName string) {
-	out := r.KnTest().Kn().Run("service", "create", serviceName, "--image", test.KnDefaultTestImage)
-	r.AssertNoError(out)
-	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "service", serviceName, "creating", "namespace", r.KnTest().Kn().Namespace(), "ready"))
 }
 
 func serviceList(r *test.KnRunResultCollector, serviceName string) {

--- a/test/e2e/ping_test.go
+++ b/test/e2e/ping_test.go
@@ -38,7 +38,7 @@ func TestSourcePing(t *testing.T) {
 	defer r.DumpIfFailed()
 
 	t.Log("Creating a testservice")
-	serviceCreate(r, "testsvc0")
+	test.ServiceCreate(r, "testsvc0")
 
 	t.Log("create Ping sources with a sink to a service")
 
@@ -53,10 +53,10 @@ func TestSourcePing(t *testing.T) {
 
 	t.Log("update Ping source sink service")
 	pingSourceCreate(r, "testpingsource2", "* * * * */1", "ping", "svc:testsvc0")
-	serviceCreate(r, "testsvc1")
+	test.ServiceCreate(r, "testsvc1")
 	pingSourceUpdateSink(r, "testpingsource2", "svc:testsvc1")
 	jpSinkRefNameInSpec := "jsonpath={.spec.sink.ref.name}"
-	out, err := getResourceFieldsWithJSONPath(t, it, "pingsource", "testpingsource2", jpSinkRefNameInSpec)
+	out, err := test.GetResourceFieldsWithJSONPath(t, it, "pingsource", "testpingsource2", jpSinkRefNameInSpec)
 	assert.NilError(t, err)
 	assert.Equal(t, out, "testsvc1")
 

--- a/test/e2e/revision_test.go
+++ b/test/e2e/revision_test.go
@@ -41,7 +41,7 @@ func TestRevision(t *testing.T) {
 	defer r.DumpIfFailed()
 
 	t.Log("create hello service and return no error")
-	serviceCreate(r, "hello")
+	test.ServiceCreate(r, "hello")
 
 	t.Log("describe revision from hello service with print flags")
 	revName := findRevision(r, "hello")

--- a/test/e2e/revision_test.go
+++ b/test/e2e/revision_test.go
@@ -18,15 +18,11 @@
 package e2e
 
 import (
-	"fmt"
-	"strconv"
-	"strings"
 	"testing"
 
 	"gotest.tools/assert"
 
 	"knative.dev/client/lib/test"
-	"knative.dev/client/pkg/util"
 )
 
 func TestRevision(t *testing.T) {
@@ -44,116 +40,29 @@ func TestRevision(t *testing.T) {
 	test.ServiceCreate(r, "hello")
 
 	t.Log("describe revision from hello service with print flags")
-	revName := findRevision(r, "hello")
-	revisionListOutputName(r, revName)
-	revisionDescribeWithPrintFlags(r, revName)
+	revName := test.FindRevision(r, "hello")
+	test.RevisionListOutputName(r, revName)
+	test.RevisionDescribeWithPrintFlags(r, revName)
 
 	t.Log("update hello service and increase revision count to 2")
-	serviceUpdate(r, "hello", "--env", "TARGET=kn", "--port", "8888")
+	test.ServiceUpdate(r, "hello", "--env", "TARGET=kn", "--port", "8888")
 
 	t.Log("show a list of revisions sorted by the count of configuration generation")
-	revisionListWithService(r, "hello")
+	test.RevisionListWithService(r, "hello")
 
 	t.Log("update hello service and increase revision count to 3")
-	serviceUpdate(r, "hello", "--env", "TARGET=kn", "--port", "8888")
+	test.ServiceUpdate(r, "hello", "--env", "TARGET=kn", "--port", "8888")
 
 	t.Log("delete three revisions with one revision a nonexistent")
-	existRevision1 := findRevisionByGeneration(r, "hello", 1)
-	existRevision2 := findRevisionByGeneration(r, "hello", 2)
+	existRevision1 := test.FindRevisionByGeneration(r, "hello", 1)
+	existRevision2 := test.FindRevisionByGeneration(r, "hello", 2)
 	nonexistRevision := "hello-nonexist"
-	revisionMultipleDelete(r, existRevision1, existRevision2, nonexistRevision)
+	test.RevisionMultipleDelete(r, existRevision1, existRevision2, nonexistRevision)
 
 	t.Log("delete latest revision from hello service and return no error")
-	revName = findRevision(r, "hello")
-	revisionDelete(r, revName)
+	revName = test.FindRevision(r, "hello")
+	test.RevisionDelete(r, revName)
 
 	t.Log("delete hello service and return no error")
-	serviceDelete(r, "hello")
-}
-
-func revisionListOutputName(r *test.KnRunResultCollector, revisionName string) {
-	out := r.KnTest().Kn().Run("revision", "list", "--output", "name")
-	r.AssertNoError(out)
-	assert.Check(r.T(), util.ContainsAll(out.Stdout, revisionName, "revision.serving.knative.dev"))
-}
-
-func revisionListWithService(r *test.KnRunResultCollector, serviceNames ...string) {
-	for _, svcName := range serviceNames {
-		confGen := findConfigurationGeneration(r, svcName)
-		out := r.KnTest().Kn().Run("revision", "list", "-s", svcName)
-		r.AssertNoError(out)
-
-		outputLines := strings.Split(out.Stdout, "\n")
-		// Ignore the last line because it is an empty string caused by splitting a line break
-		// at the end of the output string
-		for _, line := range outputLines[1 : len(outputLines)-1] {
-			revName := findRevisionByGeneration(r, svcName, confGen)
-			assert.Check(r.T(), util.ContainsAll(line, revName, svcName, strconv.Itoa(confGen)))
-			confGen--
-		}
-		if r.T().Failed() {
-			r.AddDump("service", svcName, r.KnTest().Kn().Namespace())
-		}
-	}
-}
-
-func revisionDelete(r *test.KnRunResultCollector, revName string) {
-	out := r.KnTest().Kn().Run("revision", "delete", "--wait", revName)
-	assert.Check(r.T(), util.ContainsAll(out.Stdout, "Revision", revName, "deleted", "namespace", r.KnTest().Kn().Namespace()))
-	r.AssertNoError(out)
-}
-
-func revisionMultipleDelete(r *test.KnRunResultCollector, existRevision1, existRevision2, nonexistRevision string) {
-	out := r.KnTest().Kn().Run("revision", "list")
-	r.AssertNoError(out)
-	assert.Check(r.T(), strings.Contains(out.Stdout, existRevision1), "Required revision1 does not exist")
-	assert.Check(r.T(), strings.Contains(out.Stdout, existRevision2), "Required revision2 does not exist")
-
-	out = r.KnTest().Kn().Run("revision", "delete", existRevision1, existRevision2, nonexistRevision)
-	r.AssertNoError(out)
-
-	assert.Check(r.T(), util.ContainsAll(out.Stdout, "Revision", existRevision1, "deleted", "namespace", r.KnTest().Kn().Namespace()), "Failed to get 'deleted' first revision message")
-	assert.Check(r.T(), util.ContainsAll(out.Stdout, "Revision", existRevision2, "deleted", "namespace", r.KnTest().Kn().Namespace()), "Failed to get 'deleted' second revision message")
-	assert.Check(r.T(), util.ContainsAll(out.Stdout, "revisions.serving.knative.dev", nonexistRevision, "not found"), "Failed to get 'not found' error")
-}
-
-func revisionDescribeWithPrintFlags(r *test.KnRunResultCollector, revName string) {
-	out := r.KnTest().Kn().Run("revision", "describe", revName, "-o=name")
-	r.AssertNoError(out)
-	expectedName := fmt.Sprintf("revision.serving.knative.dev/%s", revName)
-	assert.Equal(r.T(), strings.TrimSpace(out.Stdout), expectedName)
-}
-
-func findRevision(r *test.KnRunResultCollector, serviceName string) string {
-	out := r.KnTest().Kn().Run("revision", "list", "-s", serviceName, "-o=jsonpath={.items[0].metadata.name}")
-	r.AssertNoError(out)
-	if strings.Contains(out.Stdout, "No resources") {
-		r.T().Errorf("Could not find revision name.")
-	}
-	return out.Stdout
-}
-
-func findRevisionByGeneration(r *test.KnRunResultCollector, serviceName string, generation int) string {
-	maxGen := findConfigurationGeneration(r, serviceName)
-	out := r.KnTest().Kn().Run("revision", "list", "-s", serviceName,
-		fmt.Sprintf("-o=jsonpath={.items[%d].metadata.name}", maxGen-generation))
-	r.AssertNoError(out)
-	if strings.Contains(out.Stdout, "No resources found.") {
-		r.T().Errorf("Could not find revision name.")
-	}
-	return out.Stdout
-}
-
-func findConfigurationGeneration(r *test.KnRunResultCollector, serviceName string) int {
-	out := r.KnTest().Kn().Run("revision", "list", "-s", serviceName, "-o=jsonpath={.items[0].metadata.labels.serving\\.knative\\.dev/configurationGeneration}")
-	r.AssertNoError(out)
-	if out.Stdout == "" {
-		r.T().Errorf("Could not find configuration generation.")
-	}
-	confGen, err := strconv.Atoi(out.Stdout)
-	if err != nil {
-		r.T().Errorf("Invalid type of configuration generation: %s", err)
-	}
-
-	return confGen
+	test.ServiceDelete(r, "hello")
 }

--- a/test/e2e/route_test.go
+++ b/test/e2e/route_test.go
@@ -61,7 +61,7 @@ func TestRoute(t *testing.T) {
 	routeDescribeWithPrintFlags(r, "hello")
 
 	t.Log("delete hello service and return no error")
-	serviceDelete(r, "hello")
+	test.ServiceDelete(r, "hello")
 }
 
 func routeList(r *test.KnRunResultCollector) {

--- a/test/e2e/route_test.go
+++ b/test/e2e/route_test.go
@@ -40,7 +40,7 @@ func TestRoute(t *testing.T) {
 	defer r.DumpIfFailed()
 
 	t.Log("create hello service and return no error")
-	serviceCreate(r, "hello")
+	test.ServiceCreate(r, "hello")
 
 	t.Log("return a list of routes")
 	routeList(r)

--- a/test/e2e/service_export_import_apply_test.go
+++ b/test/e2e/service_export_import_apply_test.go
@@ -64,7 +64,7 @@ func TestServiceExport(t *testing.T) {
 	), "-o", "json")
 
 	t.Log("update service - add env variable")
-	test.ServiceUpdateWithOptions(r, "hello", "--env", "a=mouse", "--revision-name", "rev2", "--no-lock-to-digest")
+	test.ServiceUpdate(r, "hello", "--env", "a=mouse", "--revision-name", "rev2", "--no-lock-to-digest")
 	serviceExport(r, "hello", getServiceWithOptions(
 		withServiceName("hello"),
 		withServiceRevisionName("hello-rev2"),
@@ -99,7 +99,7 @@ func TestServiceExport(t *testing.T) {
 	), getRevisionListWithOptions(), "--with-revisions", "--mode", "resources", "-o", "yaml")
 
 	t.Log("update service with tag and split traffic")
-	test.ServiceUpdateWithOptions(r, "hello", "--tag", "hello-rev1=candidate", "--traffic", "candidate=2%,@latest=98%")
+	test.ServiceUpdate(r, "hello", "--tag", "hello-rev1=candidate", "--traffic", "candidate=2%,@latest=98%")
 
 	t.Log("export service-revision2 after tagging kubernetes-resources")
 	serviceExportWithServiceList(r, "hello", getServiceListWithOptions(
@@ -152,8 +152,8 @@ func TestServiceExport(t *testing.T) {
 	), "--with-revisions", "--mode", "resources", "-o", "yaml")
 
 	t.Log("update service - untag, add env variable, traffic split and system revision name")
-	test.ServiceUpdateWithOptions(r, "hello", "--untag", "candidate")
-	test.ServiceUpdateWithOptions(r, "hello", "--env", "b=cat", "--revision-name", "hello-rev3", "--traffic", "hello-rev1=30,hello-rev2=30,hello-rev3=40")
+	test.ServiceUpdate(r, "hello", "--untag", "candidate")
+	test.ServiceUpdate(r, "hello", "--env", "b=cat", "--revision-name", "hello-rev3", "--traffic", "hello-rev1=30,hello-rev2=30,hello-rev3=40")
 
 	t.Log("export service-revision3 with kubernetes-resources")
 	serviceExportWithServiceList(r, "hello", getServiceListWithOptions(
@@ -232,7 +232,7 @@ func TestServiceExport(t *testing.T) {
 	), "--with-revisions", "--mode", "resources", "-o", "yaml")
 
 	t.Log("send all traffic to revision 2")
-	test.ServiceUpdateWithOptions(r, "hello", "--traffic", "hello-rev2=100")
+	test.ServiceUpdate(r, "hello", "--traffic", "hello-rev2=100")
 
 	t.Log("export kubernetes-resources - all traffic to revision 2")
 	serviceExportWithServiceList(r, "hello", getServiceListWithOptions(

--- a/test/e2e/service_export_import_apply_test.go
+++ b/test/e2e/service_export_import_apply_test.go
@@ -64,7 +64,7 @@ func TestServiceExport(t *testing.T) {
 	), "-o", "json")
 
 	t.Log("update service - add env variable")
-	serviceUpdateWithOptions(r, "hello", "--env", "a=mouse", "--revision-name", "rev2", "--no-lock-to-digest")
+	test.ServiceUpdateWithOptions(r, "hello", "--env", "a=mouse", "--revision-name", "rev2", "--no-lock-to-digest")
 	serviceExport(r, "hello", getServiceWithOptions(
 		withServiceName("hello"),
 		withServiceRevisionName("hello-rev2"),
@@ -99,7 +99,7 @@ func TestServiceExport(t *testing.T) {
 	), getRevisionListWithOptions(), "--with-revisions", "--mode", "resources", "-o", "yaml")
 
 	t.Log("update service with tag and split traffic")
-	serviceUpdateWithOptions(r, "hello", "--tag", "hello-rev1=candidate", "--traffic", "candidate=2%,@latest=98%")
+	test.ServiceUpdateWithOptions(r, "hello", "--tag", "hello-rev1=candidate", "--traffic", "candidate=2%,@latest=98%")
 
 	t.Log("export service-revision2 after tagging kubernetes-resources")
 	serviceExportWithServiceList(r, "hello", getServiceListWithOptions(
@@ -152,8 +152,8 @@ func TestServiceExport(t *testing.T) {
 	), "--with-revisions", "--mode", "resources", "-o", "yaml")
 
 	t.Log("update service - untag, add env variable, traffic split and system revision name")
-	serviceUpdateWithOptions(r, "hello", "--untag", "candidate")
-	serviceUpdateWithOptions(r, "hello", "--env", "b=cat", "--revision-name", "hello-rev3", "--traffic", "hello-rev1=30,hello-rev2=30,hello-rev3=40")
+	test.ServiceUpdateWithOptions(r, "hello", "--untag", "candidate")
+	test.ServiceUpdateWithOptions(r, "hello", "--env", "b=cat", "--revision-name", "hello-rev3", "--traffic", "hello-rev1=30,hello-rev2=30,hello-rev3=40")
 
 	t.Log("export service-revision3 with kubernetes-resources")
 	serviceExportWithServiceList(r, "hello", getServiceListWithOptions(
@@ -232,7 +232,7 @@ func TestServiceExport(t *testing.T) {
 	), "--with-revisions", "--mode", "resources", "-o", "yaml")
 
 	t.Log("send all traffic to revision 2")
-	serviceUpdateWithOptions(r, "hello", "--traffic", "hello-rev2=100")
+	test.ServiceUpdateWithOptions(r, "hello", "--traffic", "hello-rev2=100")
 
 	t.Log("export kubernetes-resources - all traffic to revision 2")
 	serviceExportWithServiceList(r, "hello", getServiceListWithOptions(

--- a/test/e2e/service_options_test.go
+++ b/test/e2e/service_options_test.go
@@ -52,7 +52,7 @@ func TestServiceOptions(t *testing.T) {
 	validateServiceConcurrencyUtilization(r, "svc1", "50")
 
 	t.Log("update and validate service with concurrency limit")
-	serviceUpdate(r, "svc1", "--concurrency-limit", "300")
+	test.ServiceUpdate(r, "svc1", "--concurrency-limit", "300")
 	validateServiceConcurrencyLimit(r, "svc1", "300")
 
 	t.Log("update concurrency options with invalid values for service")
@@ -66,7 +66,7 @@ func TestServiceOptions(t *testing.T) {
 	validateServiceConcurrencyUtilization(r, "svc1", "50")
 
 	t.Log("delete service")
-	serviceDelete(r, "svc1")
+	test.ServiceDelete(r, "svc1")
 
 	t.Log("create and validate service with min/max scale options ")
 	serviceCreateWithOptions(r, "svc2", "--min-scale", "1", "--max-scale", "3")
@@ -74,39 +74,39 @@ func TestServiceOptions(t *testing.T) {
 	validateServiceMaxScale(r, "svc2", "3")
 
 	t.Log("update and validate service with max scale option")
-	serviceUpdate(r, "svc2", "--max-scale", "2")
+	test.ServiceUpdate(r, "svc2", "--max-scale", "2")
 	validateServiceMaxScale(r, "svc2", "2")
 
 	t.Log("delete service")
-	serviceDelete(r, "svc2")
+	test.ServiceDelete(r, "svc2")
 
 	t.Log("create, update and validate service with annotations")
 	serviceCreateWithOptions(r, "svc3", "--annotation", "alpha=wolf", "--annotation", "brave=horse")
 	validateServiceAnnotations(r, "svc3", map[string]string{"alpha": "wolf", "brave": "horse"})
-	serviceUpdate(r, "svc3", "--annotation", "alpha=direwolf", "--annotation", "brave-")
+	test.ServiceUpdate(r, "svc3", "--annotation", "alpha=direwolf", "--annotation", "brave-")
 	validateServiceAnnotations(r, "svc3", map[string]string{"alpha": "direwolf", "brave": ""})
-	serviceDelete(r, "svc3")
+	test.ServiceDelete(r, "svc3")
 
 	t.Log("create, update and validate service with annotations but -a")
 	serviceCreateWithOptions(r, "svc3a", "-a", "alpha=wolf", "-a", "brave=horse")
 	validateServiceAnnotations(r, "svc3a", map[string]string{"alpha": "wolf", "brave": "horse"})
-	serviceUpdate(r, "svc3a", "-a", "alpha=direwolf", "-a", "brave-")
+	test.ServiceUpdate(r, "svc3a", "-a", "alpha=direwolf", "-a", "brave-")
 	validateServiceAnnotations(r, "svc3a", map[string]string{"alpha": "direwolf", "brave": ""})
-	serviceDelete(r, "svc3a")
+	test.ServiceDelete(r, "svc3a")
 
 	t.Log("create, update and validate service with autoscale window option")
 	serviceCreateWithOptions(r, "svc4", "--autoscale-window", "1m")
 	validateAutoscaleWindow(r, "svc4", "1m")
-	serviceUpdate(r, "svc4", "--autoscale-window", "15s")
+	test.ServiceUpdate(r, "svc4", "--autoscale-window", "15s")
 	validateAutoscaleWindow(r, "svc4", "15s")
-	serviceDelete(r, "svc4")
+	test.ServiceDelete(r, "svc4")
 
 	t.Log("create, update and validate service with cmd and arg options")
 	serviceCreateWithOptions(r, "svc5", "--cmd", "/go/bin/helloworld")
 	validateContainerField(r, "svc5", "command", "[/go/bin/helloworld]")
-	serviceUpdate(r, "svc5", "--arg", "myArg1", "--arg", "--myArg2")
+	test.ServiceUpdate(r, "svc5", "--arg", "myArg1", "--arg", "--myArg2")
 	validateContainerField(r, "svc5", "args", "[myArg1 --myArg2]")
-	serviceUpdate(r, "svc5", "--arg", "myArg1")
+	test.ServiceUpdate(r, "svc5", "--arg", "myArg1")
 	validateContainerField(r, "svc5", "args", "[myArg1]")
 
 	t.Log("create, update and validate service with user defined")
@@ -118,7 +118,7 @@ func TestServiceOptions(t *testing.T) {
 
 	serviceCreateWithOptions(r, "svc6", "--user", strconv.FormatInt(uid, 10))
 	validateUserID(r, "svc6", uid)
-	serviceUpdate(r, "svc6", "--user", strconv.FormatInt(uid+1, 10))
+	test.ServiceUpdate(r, "svc6", "--user", strconv.FormatInt(uid+1, 10))
 	validateUserID(r, "svc6", uid+1)
 
 	t.Log("create and validate service and revision labels")

--- a/test/e2e/service_test.go
+++ b/test/e2e/service_test.go
@@ -41,7 +41,7 @@ func TestService(t *testing.T) {
 	defer r.DumpIfFailed()
 
 	t.Log("create hello service, delete, and try to create duplicate and get service already exists error")
-	serviceCreate(r, "hello")
+	test.ServiceCreate(r, "hello")
 	serviceCreatePrivate(r, "hello-private")
 	serviceCreateDuplicate(r, "hello-private")
 
@@ -53,7 +53,7 @@ func TestService(t *testing.T) {
 	serviceDeleteNonexistent(r, "hello")
 
 	t.Log("delete two services with a service nonexistent")
-	serviceCreate(r, "hello")
+	test.ServiceCreate(r, "hello")
 	serviceMultipleDelete(r, "hello", "bla123")
 
 	t.Log("create service private and make public")

--- a/test/e2e/service_test.go
+++ b/test/e2e/service_test.go
@@ -49,7 +49,7 @@ func TestService(t *testing.T) {
 	serviceDescribeWithPrintFlags(r, "hello")
 
 	t.Log("delete hello service repeatedly and get an error")
-	serviceDelete(r, "hello")
+	test.ServiceDelete(r, "hello")
 	serviceDeleteNonexistent(r, "hello")
 
 	t.Log("delete two services with a service nonexistent")

--- a/test/e2e/sinkprefix_test.go
+++ b/test/e2e/sinkprefix_test.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // +build e2e
+// +build !serving
 
 package e2e
 
@@ -73,12 +74,12 @@ func TestSinkPrefixConfig(t *testing.T) {
 	defer tc.teardown()
 
 	t.Log("Creating a testservice")
-	serviceCreate(r, "testsvc0")
+	test.ServiceCreate(r, "testsvc0")
 	t.Log("create Ping sources with a sink to hello:testsvc0")
 	pingSourceCreateWithConfig(r, "testpingsource0", "* * * * */1", "ping", "hello:testsvc0", tc.knConfigPath)
 
 	jpSinkRefNameInSpec := "jsonpath={.spec.sink.ref.name}"
-	out, err := getResourceFieldsWithJSONPath(t, it, "pingsource", "testpingsource0", jpSinkRefNameInSpec)
+	out, err := test.GetResourceFieldsWithJSONPath(t, it, "pingsource", "testpingsource0", jpSinkRefNameInSpec)
 	assert.NilError(t, err)
 	assert.Equal(t, out, "testsvc0")
 

--- a/test/e2e/source_apiserver_test.go
+++ b/test/e2e/source_apiserver_test.go
@@ -51,7 +51,7 @@ func TestSourceApiServer(t *testing.T) {
 	defer r.DumpIfFailed()
 
 	setupForSourceAPIServer(t, it)
-	serviceCreate(r, "testsvc0")
+	test.ServiceCreate(r, "testsvc0")
 
 	t.Log("create apiserver sources with a sink to a service")
 	apiServerSourceCreate(r, "testapisource0", "Event:v1:key1=value1", "testsa", "svc:testsvc0")
@@ -77,10 +77,10 @@ func TestSourceApiServer(t *testing.T) {
 
 	t.Log("update apiserver source sink service")
 	apiServerSourceCreate(r, "testapisource3", "Event:v1", "testsa", "svc:testsvc0")
-	serviceCreate(r, "testsvc1")
+	test.ServiceCreate(r, "testsvc1")
 	apiServerSourceUpdateSink(r, "testapisource3", "svc:testsvc1")
 	jpSinkRefNameInSpec := "jsonpath={.spec.sink.ref.name}"
-	out, err := getResourceFieldsWithJSONPath(t, it, "apiserversource.sources.knative.dev", "testapisource3", jpSinkRefNameInSpec)
+	out, err := test.GetResourceFieldsWithJSONPath(t, it, "apiserversource.sources.knative.dev", "testapisource3", jpSinkRefNameInSpec)
 	assert.NilError(t, err)
 	assert.Equal(t, out, "testsvc1")
 	// TODO(navidshaikh): Verify the source's status with synchronous create/update
@@ -151,13 +151,4 @@ func apiServerSourceUpdateSink(r *test.KnRunResultCollector, sourceName string, 
 	out := r.KnTest().Kn().Run("source", "apiserver", "update", sourceName, "--sink", sink)
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAll(out.Stdout, sourceName, "updated", "namespace", r.KnTest().Kn().Namespace()))
-}
-
-func getResourceFieldsWithJSONPath(t *testing.T, it *test.KnTest, resource, name, jsonpath string) (string, error) {
-	out, err := test.NewKubectl(it.Kn().Namespace()).Run("get", resource, name, "-o", jsonpath, "-n", it.Kn().Namespace())
-	if err != nil {
-		return "", err
-	}
-
-	return out, nil
 }

--- a/test/e2e/source_binding_test.go
+++ b/test/e2e/source_binding_test.go
@@ -37,7 +37,7 @@ func TestSourceBinding(t *testing.T) {
 	r := test.NewKnRunResultCollector(t, it)
 	defer r.DumpIfFailed()
 
-	serviceCreate(r, "testsvc0")
+	test.ServiceCreate(r, "testsvc0")
 
 	t.Log("create source binding")
 	sourceBindingCreate(r, "my-binding0", "Deployment:apps/v1:myapp", "svc:testsvc0")
@@ -48,10 +48,10 @@ func TestSourceBinding(t *testing.T) {
 
 	t.Log("update source binding")
 	sourceBindingCreate(r, "my-binding1", "Deployment:apps/v1:myapp", "svc:testsvc0")
-	serviceCreate(r, "testsvc1")
+	test.ServiceCreate(r, "testsvc1")
 	sourceBindingUpdate(r, "my-binding1", "Deployment:apps/v1:myapp", "svc:testsvc1")
 	jpSinkRefNameInSpec := "jsonpath={.spec.sink.ref.name}"
-	out, err := getResourceFieldsWithJSONPath(t, it, "sinkbindings.sources.knative.dev", "my-binding1", jpSinkRefNameInSpec)
+	out, err := test.GetResourceFieldsWithJSONPath(t, it, "sinkbindings.sources.knative.dev", "my-binding1", jpSinkRefNameInSpec)
 	assert.NilError(t, err)
 	assert.Equal(t, out, "testsvc1")
 }

--- a/test/e2e/traffic_split_test.go
+++ b/test/e2e/traffic_split_test.go
@@ -94,14 +94,14 @@ func TestTrafficSplit(t *testing.T) {
 			test.ServiceCreate(r, serviceName)
 
 			rev1 := fmt.Sprintf("%s-rev-1", serviceName)
-			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v1", "--revision-name", rev1)
+			test.ServiceUpdate(r, serviceName, "--env", "TARGET=v1", "--revision-name", rev1)
 
 			rev2 := fmt.Sprintf("%s-rev-2", serviceName)
-			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
+			test.ServiceUpdate(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
 
 			tflags := []string{"--tag", fmt.Sprintf("%s=v1,%s=v2", rev1, rev2),
 				"--traffic", "v1=50,v2=50"}
-			test.ServiceUpdateWithOptions(r, serviceName, tflags...)
+			test.ServiceUpdate(r, serviceName, tflags...)
 
 			// make ordered fields per tflags (tag, revision, percent, latest)
 			expectedTargets := []TargetFields{newTargetFields("v1", rev1, 50, false), newTargetFields("v2", rev2, 50, false)}
@@ -119,12 +119,12 @@ func TestTrafficSplit(t *testing.T) {
 			test.ServiceCreate(r, serviceName)
 
 			rev1 := fmt.Sprintf("%s-rev-1", serviceName)
-			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v1", "--revision-name", rev1)
+			test.ServiceUpdate(r, serviceName, "--env", "TARGET=v1", "--revision-name", rev1)
 
 			rev2 := fmt.Sprintf("%s-rev-2", serviceName)
-			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
+			test.ServiceUpdate(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
 
-			test.ServiceUpdateWithOptions(r, serviceName, "--traffic", fmt.Sprintf("%s=20,%s=80", rev1, rev2))
+			test.ServiceUpdate(r, serviceName, "--traffic", fmt.Sprintf("%s=20,%s=80", rev1, rev2))
 
 			expectedTargets := []TargetFields{newTargetFields("", rev1, 20, false), newTargetFields("", rev2, 80, false)}
 			verifyTargets(r, serviceName, expectedTargets)
@@ -142,10 +142,10 @@ func TestTrafficSplit(t *testing.T) {
 			serviceCreateWithOptions(r, serviceName, "--revision-name", rev1)
 
 			rev2 := fmt.Sprintf("%s-rev-2", serviceName)
-			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v1", "--revision-name", rev2)
+			test.ServiceUpdate(r, serviceName, "--env", "TARGET=v1", "--revision-name", rev2)
 
 			// no traffic, append new target with tag in traffic block
-			test.ServiceUpdateWithOptions(r, serviceName, "--tag", fmt.Sprintf("%s=%s", rev1, "candidate"))
+			test.ServiceUpdate(r, serviceName, "--tag", fmt.Sprintf("%s=%s", rev1, "candidate"))
 
 			expectedTargets := []TargetFields{newTargetFields("", rev2, 100, true), newTargetFields("candidate", rev1, 0, false)}
 			verifyTargets(r, serviceName, expectedTargets)
@@ -163,10 +163,10 @@ func TestTrafficSplit(t *testing.T) {
 			serviceCreateWithOptions(r, serviceName, "--revision-name", rev1)
 
 			rev2 := fmt.Sprintf("%s-rev-2", serviceName)
-			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v1", "--revision-name", rev2)
+			test.ServiceUpdate(r, serviceName, "--env", "TARGET=v1", "--revision-name", rev2)
 
 			// traffic by tag name and use % at the end
-			test.ServiceUpdateWithOptions(r, serviceName,
+			test.ServiceUpdate(r, serviceName,
 				"--tag", fmt.Sprintf("%s=%s", rev1, "candidate"),
 				"--traffic", "candidate=2%,@latest=98%")
 
@@ -187,17 +187,17 @@ func TestTrafficSplit(t *testing.T) {
 			serviceCreateWithOptions(r, serviceName, "--revision-name", rev1)
 
 			rev2 := fmt.Sprintf("%s-rev-2", serviceName)
-			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
+			test.ServiceUpdate(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
 
 			rev3 := fmt.Sprintf("%s-rev-3", serviceName)
-			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v3", "--revision-name", rev3) //note that this gives 100% traffic to latest revision (rev3)
+			test.ServiceUpdate(r, serviceName, "--env", "TARGET=v3", "--revision-name", rev3) //note that this gives 100% traffic to latest revision (rev3)
 
 			// make existing state: tag current and candidate exist in traffic block
-			test.ServiceUpdateWithOptions(r, serviceName, "--tag", fmt.Sprintf("%s=current,%s=candidate", rev1, rev2))
+			test.ServiceUpdate(r, serviceName, "--tag", fmt.Sprintf("%s=current,%s=candidate", rev1, rev2))
 
 			// desired state of tags: update tag of revision (rev2) from candidate to current (which is present on rev1)
 			//untag first to update
-			test.ServiceUpdateWithOptions(r, serviceName,
+			test.ServiceUpdate(r, serviceName,
 				"--untag", "current,candidate",
 				"--tag", fmt.Sprintf("%s=current", rev2))
 
@@ -219,10 +219,10 @@ func TestTrafficSplit(t *testing.T) {
 			serviceCreateWithOptions(r, serviceName, "--revision-name", rev1)
 
 			// make existing state: tag @latest as testing
-			test.ServiceUpdateWithOptions(r, serviceName, "--tag", "@latest=testing")
+			test.ServiceUpdate(r, serviceName, "--tag", "@latest=testing")
 
 			// desired state: change tag from testing to staging
-			test.ServiceUpdateWithOptions(r, serviceName, "--untag", "testing", "--tag", "@latest=staging")
+			test.ServiceUpdate(r, serviceName, "--untag", "testing", "--tag", "@latest=staging")
 
 			expectedTargets := []TargetFields{newTargetFields("staging", rev1, 100, true)}
 			verifyTargets(r, serviceName, expectedTargets)
@@ -240,13 +240,13 @@ func TestTrafficSplit(t *testing.T) {
 			serviceCreateWithOptions(r, serviceName, "--revision-name", rev1)
 
 			rev2 := fmt.Sprintf("%s-rev-2", serviceName)
-			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
+			test.ServiceUpdate(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
 
 			// make existing state: tag a revision as testing
-			test.ServiceUpdateWithOptions(r, serviceName, "--tag", fmt.Sprintf("%s=testing", rev1))
+			test.ServiceUpdate(r, serviceName, "--tag", fmt.Sprintf("%s=testing", rev1))
 
 			// desired state: change tag from testing to staging
-			test.ServiceUpdateWithOptions(r, serviceName, "--untag", "testing", "--tag", fmt.Sprintf("%s=staging", rev1))
+			test.ServiceUpdate(r, serviceName, "--untag", "testing", "--tag", fmt.Sprintf("%s=staging", rev1))
 
 			expectedTargets := []TargetFields{newTargetFields("", rev2, 100, true),
 				newTargetFields("staging", rev1, 0, false)}
@@ -266,15 +266,15 @@ func TestTrafficSplit(t *testing.T) {
 			serviceCreateWithOptions(r, serviceName, "--revision-name", rev1)
 
 			rev2 := fmt.Sprintf("%s-rev-2", serviceName)
-			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
+			test.ServiceUpdate(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
 
 			// existing state: traffic block having a revision with tag old and some traffic
-			test.ServiceUpdateWithOptions(r, serviceName,
+			test.ServiceUpdate(r, serviceName,
 				"--tag", fmt.Sprintf("%s=old", rev1),
 				"--traffic", "old=2,@latest=98")
 
 			// desired state: remove revision with tag old
-			test.ServiceUpdateWithOptions(r, serviceName, "--untag", "old", "--traffic", "@latest=100")
+			test.ServiceUpdate(r, serviceName, "--untag", "old", "--traffic", "@latest=100")
 
 			expectedTargets := []TargetFields{newTargetFields("", rev2, 100, true)}
 			verifyTargets(r, serviceName, expectedTargets)
@@ -292,10 +292,10 @@ func TestTrafficSplit(t *testing.T) {
 			serviceCreateWithOptions(r, serviceName, "--revision-name", rev1)
 
 			// existing state: traffic block having two targets
-			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2")
+			test.ServiceUpdate(r, serviceName, "--env", "TARGET=v2")
 
 			// desired state: tag non-@latest revision with two tags and 50-50% traffic each
-			test.ServiceUpdateWithOptions(r, serviceName,
+			test.ServiceUpdate(r, serviceName,
 				"--tag", fmt.Sprintf("%s=stable,%s=current", rev1, rev1),
 				"--traffic", "stable=50%,current=50%")
 
@@ -315,13 +315,13 @@ func TestTrafficSplit(t *testing.T) {
 			serviceCreateWithOptions(r, serviceName, "--revision-name", rev1)
 
 			rev2 := fmt.Sprintf("%s-rev-2", serviceName)
-			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
+			test.ServiceUpdate(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
 
 			// existing state: latest ready revision not getting any traffic
-			test.ServiceUpdateWithOptions(r, serviceName, "--traffic", fmt.Sprintf("%s=100", rev1))
+			test.ServiceUpdate(r, serviceName, "--traffic", fmt.Sprintf("%s=100", rev1))
 
 			// desired state: revert traffic to latest ready revision
-			test.ServiceUpdateWithOptions(r, serviceName, "--traffic", "@latest=100")
+			test.ServiceUpdate(r, serviceName, "--traffic", "@latest=100")
 
 			expectedTargets := []TargetFields{newTargetFields("", rev2, 100, true)}
 			verifyTargets(r, serviceName, expectedTargets)
@@ -340,7 +340,7 @@ func TestTrafficSplit(t *testing.T) {
 			serviceCreateWithOptions(r, serviceName, "--revision-name", rev1)
 
 			// desired state: tag latest ready revision as 'current'
-			test.ServiceUpdateWithOptions(r, serviceName, "--tag", "@latest=current")
+			test.ServiceUpdate(r, serviceName, "--tag", "@latest=current")
 
 			expectedTargets := []TargetFields{newTargetFields("current", rev1, 100, true)}
 			verifyTargets(r, serviceName, expectedTargets)
@@ -358,16 +358,16 @@ func TestTrafficSplit(t *testing.T) {
 			serviceCreateWithOptions(r, serviceName, "--revision-name", rev1)
 
 			rev2 := fmt.Sprintf("%s-rev-2", serviceName)
-			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
+			test.ServiceUpdate(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
 
 			// existing state: two revision exists with traffic share and
 			// each revision has tag and traffic portions
-			test.ServiceUpdateWithOptions(r, serviceName,
+			test.ServiceUpdate(r, serviceName,
 				"--tag", fmt.Sprintf("@latest=current,%s=candidate", rev1),
 				"--traffic", "current=90,candidate=10")
 
 			// desired state: update tag for rev1 as testing (from candidate) with 100% traffic
-			test.ServiceUpdateWithOptions(r, serviceName,
+			test.ServiceUpdate(r, serviceName,
 				"--untag", "candidate", "--tag", fmt.Sprintf("%s=testing", rev1),
 				"--traffic", "testing=100")
 
@@ -388,13 +388,13 @@ func TestTrafficSplit(t *testing.T) {
 			serviceCreateWithOptions(r, serviceName, "--revision-name", rev1)
 
 			rev2 := fmt.Sprintf("%s-rev-2", serviceName)
-			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
+			test.ServiceUpdate(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
 
 			// existing state: a revision exist with latest tag
-			test.ServiceUpdateWithOptions(r, serviceName, "--tag", fmt.Sprintf("%s=latest", rev1))
+			test.ServiceUpdate(r, serviceName, "--tag", fmt.Sprintf("%s=latest", rev1))
 
 			// desired state of revision tags: rev1=old rev2=latest
-			test.ServiceUpdateWithOptions(r, serviceName,
+			test.ServiceUpdate(r, serviceName,
 				"--untag", "latest",
 				"--tag", fmt.Sprintf("%s=old,%s=latest", rev1, rev2))
 

--- a/test/e2e/traffic_split_test.go
+++ b/test/e2e/traffic_split_test.go
@@ -92,7 +92,7 @@ func TestTrafficSplit(t *testing.T) {
 			defer r.DumpIfFailed()
 
 			serviceName := test.GetNextServiceName(serviceBase)
-			serviceCreate(r, serviceName)
+			test.ServiceCreate(r, serviceName)
 
 			rev1 := fmt.Sprintf("%s-rev-1", serviceName)
 			serviceUpdateWithOptions(r, serviceName, "--env", "TARGET=v1", "--revision-name", rev1)
@@ -117,7 +117,7 @@ func TestTrafficSplit(t *testing.T) {
 			defer r.DumpIfFailed()
 
 			serviceName := test.GetNextServiceName(serviceBase)
-			serviceCreate(r, serviceName)
+			test.ServiceCreate(r, serviceName)
 
 			rev1 := fmt.Sprintf("%s-rev-1", serviceName)
 			serviceUpdateWithOptions(r, serviceName, "--env", "TARGET=v1", "--revision-name", rev1)

--- a/test/e2e/traffic_split_test.go
+++ b/test/e2e/traffic_split_test.go
@@ -26,7 +26,6 @@ import (
 	"gotest.tools/assert"
 
 	"knative.dev/client/lib/test"
-	"knative.dev/client/pkg/util"
 )
 
 var targetsSeparator = "|"
@@ -95,19 +94,19 @@ func TestTrafficSplit(t *testing.T) {
 			test.ServiceCreate(r, serviceName)
 
 			rev1 := fmt.Sprintf("%s-rev-1", serviceName)
-			serviceUpdateWithOptions(r, serviceName, "--env", "TARGET=v1", "--revision-name", rev1)
+			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v1", "--revision-name", rev1)
 
 			rev2 := fmt.Sprintf("%s-rev-2", serviceName)
-			serviceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
+			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
 
 			tflags := []string{"--tag", fmt.Sprintf("%s=v1,%s=v2", rev1, rev2),
 				"--traffic", "v1=50,v2=50"}
-			serviceUpdateWithOptions(r, serviceName, tflags...)
+			test.ServiceUpdateWithOptions(r, serviceName, tflags...)
 
 			// make ordered fields per tflags (tag, revision, percent, latest)
 			expectedTargets := []TargetFields{newTargetFields("v1", rev1, 50, false), newTargetFields("v2", rev2, 50, false)}
 			verifyTargets(r, serviceName, expectedTargets)
-			serviceDelete(r, serviceName)
+			test.ServiceDelete(r, serviceName)
 		},
 	)
 	t.Run("20:80",
@@ -120,16 +119,16 @@ func TestTrafficSplit(t *testing.T) {
 			test.ServiceCreate(r, serviceName)
 
 			rev1 := fmt.Sprintf("%s-rev-1", serviceName)
-			serviceUpdateWithOptions(r, serviceName, "--env", "TARGET=v1", "--revision-name", rev1)
+			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v1", "--revision-name", rev1)
 
 			rev2 := fmt.Sprintf("%s-rev-2", serviceName)
-			serviceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
+			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
 
-			serviceUpdateWithOptions(r, serviceName, "--traffic", fmt.Sprintf("%s=20,%s=80", rev1, rev2))
+			test.ServiceUpdateWithOptions(r, serviceName, "--traffic", fmt.Sprintf("%s=20,%s=80", rev1, rev2))
 
 			expectedTargets := []TargetFields{newTargetFields("", rev1, 20, false), newTargetFields("", rev2, 80, false)}
 			verifyTargets(r, serviceName, expectedTargets)
-			serviceDelete(r, serviceName)
+			test.ServiceDelete(r, serviceName)
 		},
 	)
 	t.Run("TagCandidate",
@@ -143,14 +142,14 @@ func TestTrafficSplit(t *testing.T) {
 			serviceCreateWithOptions(r, serviceName, "--revision-name", rev1)
 
 			rev2 := fmt.Sprintf("%s-rev-2", serviceName)
-			serviceUpdateWithOptions(r, serviceName, "--env", "TARGET=v1", "--revision-name", rev2)
+			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v1", "--revision-name", rev2)
 
 			// no traffic, append new target with tag in traffic block
-			serviceUpdateWithOptions(r, serviceName, "--tag", fmt.Sprintf("%s=%s", rev1, "candidate"))
+			test.ServiceUpdateWithOptions(r, serviceName, "--tag", fmt.Sprintf("%s=%s", rev1, "candidate"))
 
 			expectedTargets := []TargetFields{newTargetFields("", rev2, 100, true), newTargetFields("candidate", rev1, 0, false)}
 			verifyTargets(r, serviceName, expectedTargets)
-			serviceDelete(r, serviceName)
+			test.ServiceDelete(r, serviceName)
 		},
 	)
 	t.Run("TagCandidate:2:98",
@@ -164,16 +163,16 @@ func TestTrafficSplit(t *testing.T) {
 			serviceCreateWithOptions(r, serviceName, "--revision-name", rev1)
 
 			rev2 := fmt.Sprintf("%s-rev-2", serviceName)
-			serviceUpdateWithOptions(r, serviceName, "--env", "TARGET=v1", "--revision-name", rev2)
+			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v1", "--revision-name", rev2)
 
 			// traffic by tag name and use % at the end
-			serviceUpdateWithOptions(r, serviceName,
+			test.ServiceUpdateWithOptions(r, serviceName,
 				"--tag", fmt.Sprintf("%s=%s", rev1, "candidate"),
 				"--traffic", "candidate=2%,@latest=98%")
 
 			expectedTargets := []TargetFields{newTargetFields("", rev2, 98, true), newTargetFields("candidate", rev1, 2, false)}
 			verifyTargets(r, serviceName, expectedTargets)
-			serviceDelete(r, serviceName)
+			test.ServiceDelete(r, serviceName)
 		},
 	)
 	t.Run("TagCurrent",
@@ -188,17 +187,17 @@ func TestTrafficSplit(t *testing.T) {
 			serviceCreateWithOptions(r, serviceName, "--revision-name", rev1)
 
 			rev2 := fmt.Sprintf("%s-rev-2", serviceName)
-			serviceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
+			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
 
 			rev3 := fmt.Sprintf("%s-rev-3", serviceName)
-			serviceUpdateWithOptions(r, serviceName, "--env", "TARGET=v3", "--revision-name", rev3) //note that this gives 100% traffic to latest revision (rev3)
+			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v3", "--revision-name", rev3) //note that this gives 100% traffic to latest revision (rev3)
 
 			// make existing state: tag current and candidate exist in traffic block
-			serviceUpdateWithOptions(r, serviceName, "--tag", fmt.Sprintf("%s=current,%s=candidate", rev1, rev2))
+			test.ServiceUpdateWithOptions(r, serviceName, "--tag", fmt.Sprintf("%s=current,%s=candidate", rev1, rev2))
 
 			// desired state of tags: update tag of revision (rev2) from candidate to current (which is present on rev1)
 			//untag first to update
-			serviceUpdateWithOptions(r, serviceName,
+			test.ServiceUpdateWithOptions(r, serviceName,
 				"--untag", "current,candidate",
 				"--tag", fmt.Sprintf("%s=current", rev2))
 
@@ -206,7 +205,7 @@ func TestTrafficSplit(t *testing.T) {
 			// target for rev1 is removed as it had no traffic and we untagged it's tag current
 			expectedTargets := []TargetFields{newTargetFields("", rev3, 100, true), newTargetFields("current", rev2, 0, false)}
 			verifyTargets(r, serviceName, expectedTargets)
-			serviceDelete(r, serviceName)
+			test.ServiceDelete(r, serviceName)
 		},
 	)
 	t.Run("TagStagingLatest",
@@ -220,14 +219,14 @@ func TestTrafficSplit(t *testing.T) {
 			serviceCreateWithOptions(r, serviceName, "--revision-name", rev1)
 
 			// make existing state: tag @latest as testing
-			serviceUpdateWithOptions(r, serviceName, "--tag", "@latest=testing")
+			test.ServiceUpdateWithOptions(r, serviceName, "--tag", "@latest=testing")
 
 			// desired state: change tag from testing to staging
-			serviceUpdateWithOptions(r, serviceName, "--untag", "testing", "--tag", "@latest=staging")
+			test.ServiceUpdateWithOptions(r, serviceName, "--untag", "testing", "--tag", "@latest=staging")
 
 			expectedTargets := []TargetFields{newTargetFields("staging", rev1, 100, true)}
 			verifyTargets(r, serviceName, expectedTargets)
-			serviceDelete(r, serviceName)
+			test.ServiceDelete(r, serviceName)
 		},
 	)
 	t.Run("TagStagingNonLatest",
@@ -241,18 +240,18 @@ func TestTrafficSplit(t *testing.T) {
 			serviceCreateWithOptions(r, serviceName, "--revision-name", rev1)
 
 			rev2 := fmt.Sprintf("%s-rev-2", serviceName)
-			serviceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
+			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
 
 			// make existing state: tag a revision as testing
-			serviceUpdateWithOptions(r, serviceName, "--tag", fmt.Sprintf("%s=testing", rev1))
+			test.ServiceUpdateWithOptions(r, serviceName, "--tag", fmt.Sprintf("%s=testing", rev1))
 
 			// desired state: change tag from testing to staging
-			serviceUpdateWithOptions(r, serviceName, "--untag", "testing", "--tag", fmt.Sprintf("%s=staging", rev1))
+			test.ServiceUpdateWithOptions(r, serviceName, "--untag", "testing", "--tag", fmt.Sprintf("%s=staging", rev1))
 
 			expectedTargets := []TargetFields{newTargetFields("", rev2, 100, true),
 				newTargetFields("staging", rev1, 0, false)}
 			verifyTargets(r, serviceName, expectedTargets)
-			serviceDelete(r, serviceName)
+			test.ServiceDelete(r, serviceName)
 		},
 	)
 	// test reducing number of targets from traffic blockdd
@@ -267,19 +266,19 @@ func TestTrafficSplit(t *testing.T) {
 			serviceCreateWithOptions(r, serviceName, "--revision-name", rev1)
 
 			rev2 := fmt.Sprintf("%s-rev-2", serviceName)
-			serviceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
+			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
 
 			// existing state: traffic block having a revision with tag old and some traffic
-			serviceUpdateWithOptions(r, serviceName,
+			test.ServiceUpdateWithOptions(r, serviceName,
 				"--tag", fmt.Sprintf("%s=old", rev1),
 				"--traffic", "old=2,@latest=98")
 
 			// desired state: remove revision with tag old
-			serviceUpdateWithOptions(r, serviceName, "--untag", "old", "--traffic", "@latest=100")
+			test.ServiceUpdateWithOptions(r, serviceName, "--untag", "old", "--traffic", "@latest=100")
 
 			expectedTargets := []TargetFields{newTargetFields("", rev2, 100, true)}
 			verifyTargets(r, serviceName, expectedTargets)
-			serviceDelete(r, serviceName)
+			test.ServiceDelete(r, serviceName)
 		},
 	)
 	t.Run("TagStable:50:50",
@@ -293,16 +292,16 @@ func TestTrafficSplit(t *testing.T) {
 			serviceCreateWithOptions(r, serviceName, "--revision-name", rev1)
 
 			// existing state: traffic block having two targets
-			serviceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2")
+			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2")
 
 			// desired state: tag non-@latest revision with two tags and 50-50% traffic each
-			serviceUpdateWithOptions(r, serviceName,
+			test.ServiceUpdateWithOptions(r, serviceName,
 				"--tag", fmt.Sprintf("%s=stable,%s=current", rev1, rev1),
 				"--traffic", "stable=50%,current=50%")
 
 			expectedTargets := []TargetFields{newTargetFields("stable", rev1, 50, false), newTargetFields("current", rev1, 50, false)}
 			verifyTargets(r, serviceName, expectedTargets)
-			serviceDelete(r, serviceName)
+			test.ServiceDelete(r, serviceName)
 		},
 	)
 	t.Run("RevertToLatest",
@@ -316,17 +315,17 @@ func TestTrafficSplit(t *testing.T) {
 			serviceCreateWithOptions(r, serviceName, "--revision-name", rev1)
 
 			rev2 := fmt.Sprintf("%s-rev-2", serviceName)
-			serviceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
+			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
 
 			// existing state: latest ready revision not getting any traffic
-			serviceUpdateWithOptions(r, serviceName, "--traffic", fmt.Sprintf("%s=100", rev1))
+			test.ServiceUpdateWithOptions(r, serviceName, "--traffic", fmt.Sprintf("%s=100", rev1))
 
 			// desired state: revert traffic to latest ready revision
-			serviceUpdateWithOptions(r, serviceName, "--traffic", "@latest=100")
+			test.ServiceUpdateWithOptions(r, serviceName, "--traffic", "@latest=100")
 
 			expectedTargets := []TargetFields{newTargetFields("", rev2, 100, true)}
 			verifyTargets(r, serviceName, expectedTargets)
-			serviceDelete(r, serviceName)
+			test.ServiceDelete(r, serviceName)
 		},
 	)
 	t.Run("TagLatestAsCurrent",
@@ -341,11 +340,11 @@ func TestTrafficSplit(t *testing.T) {
 			serviceCreateWithOptions(r, serviceName, "--revision-name", rev1)
 
 			// desired state: tag latest ready revision as 'current'
-			serviceUpdateWithOptions(r, serviceName, "--tag", "@latest=current")
+			test.ServiceUpdateWithOptions(r, serviceName, "--tag", "@latest=current")
 
 			expectedTargets := []TargetFields{newTargetFields("current", rev1, 100, true)}
 			verifyTargets(r, serviceName, expectedTargets)
-			serviceDelete(r, serviceName)
+			test.ServiceDelete(r, serviceName)
 		},
 	)
 	t.Run("UpdateTag:100:0",
@@ -359,23 +358,23 @@ func TestTrafficSplit(t *testing.T) {
 			serviceCreateWithOptions(r, serviceName, "--revision-name", rev1)
 
 			rev2 := fmt.Sprintf("%s-rev-2", serviceName)
-			serviceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
+			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
 
 			// existing state: two revision exists with traffic share and
 			// each revision has tag and traffic portions
-			serviceUpdateWithOptions(r, serviceName,
+			test.ServiceUpdateWithOptions(r, serviceName,
 				"--tag", fmt.Sprintf("@latest=current,%s=candidate", rev1),
 				"--traffic", "current=90,candidate=10")
 
 			// desired state: update tag for rev1 as testing (from candidate) with 100% traffic
-			serviceUpdateWithOptions(r, serviceName,
+			test.ServiceUpdateWithOptions(r, serviceName,
 				"--untag", "candidate", "--tag", fmt.Sprintf("%s=testing", rev1),
 				"--traffic", "testing=100")
 
 			expectedTargets := []TargetFields{newTargetFields("current", rev2, 0, true),
 				newTargetFields("testing", rev1, 100, false)}
 			verifyTargets(r, serviceName, expectedTargets)
-			serviceDelete(r, serviceName)
+			test.ServiceDelete(r, serviceName)
 		},
 	)
 	t.Run("TagReplace",
@@ -389,13 +388,13 @@ func TestTrafficSplit(t *testing.T) {
 			serviceCreateWithOptions(r, serviceName, "--revision-name", rev1)
 
 			rev2 := fmt.Sprintf("%s-rev-2", serviceName)
-			serviceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
+			test.ServiceUpdateWithOptions(r, serviceName, "--env", "TARGET=v2", "--revision-name", rev2)
 
 			// existing state: a revision exist with latest tag
-			serviceUpdateWithOptions(r, serviceName, "--tag", fmt.Sprintf("%s=latest", rev1))
+			test.ServiceUpdateWithOptions(r, serviceName, "--tag", fmt.Sprintf("%s=latest", rev1))
 
 			// desired state of revision tags: rev1=old rev2=latest
-			serviceUpdateWithOptions(r, serviceName,
+			test.ServiceUpdateWithOptions(r, serviceName,
 				"--untag", "latest",
 				"--tag", fmt.Sprintf("%s=old,%s=latest", rev1, rev2))
 
@@ -407,13 +406,13 @@ func TestTrafficSplit(t *testing.T) {
 				newTargetFields("latest", rev2, 0, false)}
 
 			verifyTargets(r, serviceName, expectedTargets)
-			serviceDelete(r, serviceName)
+			test.ServiceDelete(r, serviceName)
 		},
 	)
 }
 
 func verifyTargets(r *test.KnRunResultCollector, serviceName string, expectedTargets []TargetFields) {
-	out := serviceDescribeWithJSONPath(r, serviceName, targetsJsonPath)
+	out := test.ServiceDescribeWithJSONPath(r, serviceName, targetsJsonPath)
 	assert.Check(r.T(), out != "")
 	actualTargets, err := splitTargets(out, targetsSeparator, len(expectedTargets))
 	assert.NilError(r.T(), err)
@@ -422,18 +421,4 @@ func verifyTargets(r *test.KnRunResultCollector, serviceName string, expectedTar
 	if r.T().Failed() {
 		r.AddDump("service", serviceName, r.KnTest().Kn().Namespace())
 	}
-}
-
-func serviceDescribeWithJSONPath(r *test.KnRunResultCollector, serviceName, jsonpath string) string {
-	out := r.KnTest().Kn().Run("service", "describe", serviceName, "-o", jsonpath)
-	r.AssertNoError(out)
-	return out.Stdout
-}
-
-func serviceUpdateWithOptions(r *test.KnRunResultCollector, serviceName string, options ...string) {
-	command := []string{"service", "update", serviceName}
-	command = append(command, options...)
-	out := r.KnTest().Kn().Run(command...)
-	r.AssertNoError(out)
-	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "Service", serviceName, "updating", "namespace", r.KnTest().Kn().Namespace()))
 }

--- a/test/e2e/trigger_inject_broker_test.go
+++ b/test/e2e/trigger_inject_broker_test.go
@@ -39,8 +39,8 @@ func TestInjectBrokerTrigger(t *testing.T) {
 
 	assert.NilError(t, err)
 
-	serviceCreate(r, "sinksvc0")
-	serviceCreate(r, "sinksvc1")
+	test.ServiceCreate(r, "sinksvc0")
+	test.ServiceCreate(r, "sinksvc1")
 
 	t.Log("create triggers and list them")
 	triggerCreateWithInject(r, "trigger1", "sinksvc0", []string{"a=b"})

--- a/test/e2e/trigger_test.go
+++ b/test/e2e/trigger_test.go
@@ -44,8 +44,8 @@ func TestBrokerTrigger(t *testing.T) {
 	assert.NilError(t, err)
 	defer unlableNamespaceForDefaultBroker(t, it)
 
-	serviceCreate(r, "sinksvc0")
-	serviceCreate(r, "sinksvc1")
+	test.ServiceCreate(r, "sinksvc0")
+	test.ServiceCreate(r, "sinksvc1")
 
 	t.Log("create triggers and list them")
 	triggerCreate(r, "trigger1", "sinksvc0", []string{"a=b"})


### PR DESCRIPTION
## Description 
brings commonly re-used utilities into lib/test so they can be resused
and e2e can be run selectively for eventing/serving.

Fixes #828 
