### PR TITLE
fix(e2e): Create next namespace for e2e if one exists

### DIFF
--- a/lib/test/integration.go
+++ b/lib/test/integration.go
@@ -46,13 +46,22 @@ type KnTest struct {
 
 // NewKnTest creates a new KnTest object
 func NewKnTest() (*KnTest, error) {
-	ns := NextNamespace()
-
-	err := CreateNamespace(ns)
-	if err != nil {
-		return nil, err
+	ns := ""
+	// try next 20 namespace before giving up creating a namespace if it already exists
+	for i := 0; i < 20; i++ {
+		ns = NextNamespace()
+		err := CreateNamespace(ns)
+		if err == nil {
+			break
+		}
+		if strings.Contains(err.Error(), "AlreadyExists") {
+			continue
+		} else {
+			return nil, err
+		}
 	}
-	err = WaitForNamespaceCreated(ns)
+
+	err := WaitForNamespaceCreated(ns)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/test/utils.go
+++ b/lib/test/utils.go
@@ -14,7 +14,17 @@
 
 package test
 
-import "testing"
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const (
+	FileModeReadWrite  = 0666
+	FileModeExecutable = 0777
+)
 
 // GetResourceFieldsWithJSONPath returns output of given JSON path for given resource using kubectl and error if any
 func GetResourceFieldsWithJSONPath(t *testing.T, it *KnTest, resource, name, jsonpath string) (string, error) {
@@ -24,4 +34,11 @@ func GetResourceFieldsWithJSONPath(t *testing.T, it *KnTest, resource, name, jso
 	}
 
 	return out, nil
+}
+
+// CreateFile creates a file with given name, content, path, fileMode and returns absolute filepath and error if any
+func CreateFile(fileName, fileContent, filePath string, fileMode os.FileMode) (string, error) {
+	file := filepath.Join(filePath, fileName)
+	err := ioutil.WriteFile(file, []byte(fileContent), fileMode)
+	return file, err
 }

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -52,7 +52,6 @@ run() {
 integration_test() {
   header "Running tests for Knative Serving $KNATIVE_SERVING_VERSION and Eventing $KNATIVE_EVENTING_VERSION"
 
-  kubectl create namespace kne2etests0
   go_test_e2e -timeout=45m ./test/e2e || fail_test
 }
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -52,6 +52,7 @@ run() {
 integration_test() {
   header "Running tests for Knative Serving $KNATIVE_SERVING_VERSION and Eventing $KNATIVE_EVENTING_VERSION"
 
+  kubectl create namespace kne2etests0
   go_test_e2e -timeout=45m ./test/e2e || fail_test
 }
 

--- a/test/e2e/plugins_test.go
+++ b/test/e2e/plugins_test.go
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 // +build e2e
+// +build !eventing
+// +build !serving
 
 package e2e
 

--- a/test/e2e/plugins_test.go
+++ b/test/e2e/plugins_test.go
@@ -37,9 +37,6 @@ const (
 echo "Hello Knative, I'm a Kn plugin"
 echo "  My plugin file is $0"
 echo "  I received arguments: $1 $2 $3 $4"`
-
-	FileModeReadWrite  = 0666
-	FileModeExecutable = 0777
 )
 
 type pluginTestConfig struct {
@@ -55,27 +52,27 @@ func (pc *pluginTestConfig) setup() error {
 	}
 
 	pc.knPluginsDir = filepath.Join(pc.knConfigDir, "plugins")
-	err = os.MkdirAll(pc.knPluginsDir, FileModeExecutable)
+	err = os.MkdirAll(pc.knPluginsDir, test.FileModeExecutable)
 	if err != nil {
 		return err
 	}
 
 	pc.knPluginsDir2 = filepath.Join(pc.knConfigDir, "plugins2")
-	err = os.MkdirAll(pc.knPluginsDir2, FileModeExecutable)
+	err = os.MkdirAll(pc.knPluginsDir2, test.FileModeExecutable)
 	if err != nil {
 		return err
 	}
 
-	pc.knConfigPath, err = createPluginFile("config.yaml", "", pc.knConfigDir, FileModeReadWrite)
+	pc.knConfigPath, err = test.CreateFile("config.yaml", "", pc.knConfigDir, test.FileModeReadWrite)
 	if err != nil {
 		return err
 	}
 
-	pc.knPluginPath, err = createPluginFile("kn-helloe2e", TestPluginCode, pc.knPluginsDir, FileModeExecutable)
+	pc.knPluginPath, err = test.CreateFile("kn-helloe2e", TestPluginCode, pc.knPluginsDir, test.FileModeExecutable)
 	if err != nil {
 		return err
 	}
-	pc.knPluginPath2, err = createPluginFile("kn-hello2e2e", TestPluginCode, pc.knPluginsDir2, FileModeExecutable)
+	pc.knPluginPath2, err = test.CreateFile("kn-hello2e2e", TestPluginCode, pc.knPluginsDir2, test.FileModeExecutable)
 	if err != nil {
 		return err
 	}
@@ -84,12 +81,6 @@ func (pc *pluginTestConfig) setup() error {
 
 func (pc *pluginTestConfig) teardown() {
 	os.RemoveAll(pc.knConfigDir)
-}
-
-func createPluginFile(fileName, fileContent, filePath string, fileMode os.FileMode) (string, error) {
-	file := filepath.Join(filePath, fileName)
-	err := ioutil.WriteFile(file, []byte(fileContent), fileMode)
-	return file, err
 }
 
 func TestPluginWithoutLookup(t *testing.T) {

--- a/test/e2e/sinkprefix_test.go
+++ b/test/e2e/sinkprefix_test.go
@@ -47,7 +47,7 @@ func (tc *sinkprefixTestConfig) setup() error {
 	if err != nil {
 		return err
 	}
-	tc.knConfigPath, err = createPluginFile("config.yaml", KnConfigContent, tc.knConfigDir, FileModeReadWrite)
+	tc.knConfigPath, err = test.CreateFile("config.yaml", KnConfigContent, tc.knConfigDir, test.FileModeReadWrite)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
- If a namespace (kne2etestsN) is being created to run e2e tests and it exists, e2e execution fails. This patch tries creating the next namespace (kne2etestsN+1) if earlier exists, retries cap at 20.
- Tags plugins tests to run into serving or eventing scope but only in e2e scope.
