### PR TITLE
Add kn service delete --all

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,10 @@
 |===
 | | Description | PR
 
+| 🎁
+| Add kn service delete --all
+| https://github.com/knative/client/pull/836[#836]
+
 | 🐛
 | Skip LatestReadyRevisionName if Revision is Pending or Unknown
 | https://github.com/knative/client/pull/825[#825]

--- a/docs/cmd/kn_service_delete.md
+++ b/docs/cmd/kn_service_delete.md
@@ -19,11 +19,15 @@ kn service delete NAME [flags]
 
   # Delete a service 'svc2' in 'ns1' namespace
   kn service delete svc2 -n ns1
+
+  # Delete all services in 'ns1' namespace
+  kn service delete --all -n ns1
 ```
 
 ### Options
 
 ```
+      --all                Delete all services in a namespace.
       --async              DEPRECATED: please use --no-wait instead. Do not wait for 'service delete' operation to be completed. (default true)
   -h, --help               help for delete
   -n, --namespace string   Specify the namespace to operate in.

--- a/pkg/kn/commands/service/list_mock_test.go
+++ b/pkg/kn/commands/service/list_mock_test.go
@@ -94,8 +94,8 @@ func TestServiceListDefaultOutputMock(t *testing.T) {
 	r := client.Recorder()
 
 	service1 := createMockServiceWithParams("foo", "default", "http://foo.default.example.com", "foo-xyz")
-	service3 := createMockServiceWithParams("sss", "default", "http://sss.default.example.com", "sss-xyz")
 	service2 := createMockServiceWithParams("bar", "default", "http://bar.default.example.com", "bar-xyz")
+	service3 := createMockServiceWithParams("sss", "default", "http://sss.default.example.com", "sss-xyz")
 	serviceList := &servingv1.ServiceList{Items: []servingv1.Service{*service1, *service2, *service3}}
 	r.ListServices(mock.Any(), serviceList, nil)
 


### PR DESCRIPTION
## Description

This pull request adds the ability to delete all Services in a namespace using `kn service delete --all`. Follows same behavior as `kubectl delete ksvc --all`.  

## Changes

* Add `--all` flag to `kn service delete`. Boolean value that will delete all Services when specified. False by default. 
* Add `getServiceNames` function to retrieve all the names of Services in a namespace when `--all` flag is specified.
* Unit tests
* Minor reordering of test data in `list_test_data`

## Reference

Fixes #792 

/lint
