### PR TITLE
Refactor kn service delete --all e2e test

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -24,6 +24,8 @@
 | Skip LatestReadyRevisionName if Revision is Pending or Unknown
 | https://github.com/knative/client/pull/825[#825]
 
+|===
+
 ## v0.14.0 (2020-04-21)
 
 [cols="1,10,3", options="header", width="100%"]

--- a/test/e2e/service_test.go
+++ b/test/e2e/service_test.go
@@ -63,7 +63,7 @@ func TestService(t *testing.T) {
 	test.ServiceCreate(r, "svc1")
 	test.ServiceCreate(r, "service2")
 	test.ServiceCreate(r, "ksvc3")
-	serviceDeleteAll(r, "svc1", "service2", "ksvc3")
+	serviceDeleteAll(r)
 }
 
 func serviceCreatePrivate(r *test.KnRunResultCollector, serviceName string) {
@@ -140,18 +140,19 @@ func serviceMultipleDelete(r *test.KnRunResultCollector, existService, nonexistS
 	assert.Check(r.T(), strings.Contains(out.Stdout, expectedErr), "Failed to get 'not found' error")
 }
 
-func serviceDeleteAll(r *test.KnRunResultCollector, service1 string, service2 string, service3 string) {
+func serviceDeleteAll(r *test.KnRunResultCollector) {
 	out := r.KnTest().Kn().Run("service", "list")
 	r.AssertNoError(out)
-	assert.Check(r.T(), strings.Contains(out.Stdout, service1), "The service ", service1, " does not exist (but is expected to exist)")
-	assert.Check(r.T(), strings.Contains(out.Stdout, service2), "The service ", service2, " does not exist (but is expected to exist)")
-	assert.Check(r.T(), strings.Contains(out.Stdout, service3), "The service ", service3, " does not exist (but is expected to exist)")
+	// Check if services created successfully/available for test.
+	assert.Check(r.T(), !strings.Contains(out.Stdout, "No services found."), "No services created for kn service delete --all e2e (but should exist)")
 
 	out = r.KnTest().Kn().Run("service", "delete", "--all")
 	r.AssertNoError(out)
+	// Check if output contains successfully deleted to verify deletion took place.
+	assert.Check(r.T(), strings.Contains(out.Stdout, "successfully deleted"), "Failed to get 'successfully deleted' message")
 
-	namespace := r.KnTest().Kn().Namespace()
-	expectedSuccess := fmt.Sprintf("Service '%s' successfully deleted in namespace '%s'.\nService '%s' successfully deleted in namespace '%s'.\nService '%s' successfully deleted in namespace '%s'.\n",
-		service3, namespace, service2, namespace, service1, namespace)
-	assert.Check(r.T(), strings.Contains(out.Stdout, expectedSuccess), "Failed to get 'successfully deleted' message")
+	out = r.KnTest().Kn().Run("service", "list")
+	r.AssertNoError(out)
+	// Check if no services present after kn service delete --all.
+	assert.Check(r.T(), strings.Contains(out.Stdout, "No services found."), "Failed to show 'No services found' after kn service delete --all")
 }


### PR DESCRIPTION
## Description

Following up on some [pull request feedback](https://github.com/knative/client/pull/836#discussion_r425045139) from #836 to make the e2e test for `kn service delete --all` a bit easier to maintain.

## Changes

* Use list of services names to iterate over names to check output from `kn service list` and `kn service delete --all`
* Use `strings.Contains` instead of string from `fmt.Sprintf` for delete output validation
* Code comments 

**Edit:**

Changed original proposal based on feedback:
* Check if `len(kn service list) > 0` to verify data is available to delete
* Run `kn service delete --all`
* Check output message from delete contains `successfully deleted`
* Check if `len(kn service list) == 0` returns `No services found` message verifying deletion of all services.

/lint
