### PR TITLE
Fix kn source -h

### DIFF
--- a/pkg/kn/commands/plugin/handler.go
+++ b/pkg/kn/commands/plugin/handler.go
@@ -15,7 +15,6 @@
 package plugin
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -127,10 +126,11 @@ func HandlePluginCommand(pluginHandler PluginHandler, cmdArgs []string) error {
 	remainingArgs := []string{}
 
 	for idx := range cmdArgs {
-		if strings.HasPrefix(cmdArgs[idx], "-") {
+		cmdArg := cmdArgs[idx]
+		if strings.HasPrefix(cmdArg, "-") {
 			continue
 		}
-		remainingArgs = append(remainingArgs, strings.Replace(cmdArgs[idx], "-", "_", -1))
+		remainingArgs = append(remainingArgs, strings.Replace(cmdArg, "-", "_", -1))
 	}
 
 	foundBinaryPath := ""
@@ -147,16 +147,14 @@ func HandlePluginCommand(pluginHandler PluginHandler, cmdArgs []string) error {
 		break
 	}
 
-	if len(foundBinaryPath) == 0 {
-		return errors.New("Could not find plugin to execute")
-	}
-
 	// invoke cmd binary relaying the current environment and args given
 	// remainingArgs will always have at least one element.
 	// execve will make remainingArgs[0] the "binary name".
-	err := pluginHandler.Execute(foundBinaryPath, append([]string{foundBinaryPath}, cmdArgs[len(remainingArgs):]...), os.Environ())
-	if err != nil {
-		return err
+	if len(foundBinaryPath) != 0 {
+		err := pluginHandler.Execute(foundBinaryPath, append([]string{foundBinaryPath}, cmdArgs[len(remainingArgs):]...), os.Environ())
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/kn/commands/plugin/handler_test.go
+++ b/pkg/kn/commands/plugin/handler_test.go
@@ -165,6 +165,14 @@ func TestPluginHandler(t *testing.T) {
 			err = HandlePluginCommand(tPluginHandler, []string{"bogus"})
 			assert.Assert(t, err != nil, fmt.Sprintf("test plugin %s expected to fail executing", "bogus"))
 		})
+
+		t.Run("doesn't return error with -h", func(t *testing.T) {
+			setup(t)
+			defer cleanup(t)
+
+			err = HandlePluginCommand(tPluginHandler, []string{"source", "-h"})
+			assert.Assert(t, err == nil, fmt.Sprintf("test plugin command with -h failed executing: %s", err.Error()))
+		})
 	})
 }
 

--- a/pkg/kn/core/root.go
+++ b/pkg/kn/core/root.go
@@ -403,7 +403,7 @@ func showSubcommands(cmd *cobra.Command, args []string, innerArg string) string 
 	for _, subcmd := range cmd.Commands() {
 		strs = append(strs, subcmd.Name())
 	}
-	return fmt.Sprintf("Error: unknown subcommand '%s' for '%s'. Available subcommands: %s\nRun 'kn --help' for usage.\n", innerArg, getCommands(args, innerArg), strings.Join(strs, ", "))
+	return fmt.Sprintf("Error: unknown subcommand '%s' for '%s'.\nAvailable subcommands: %s\nRun 'kn --help' for usage.\n", innerArg, getCommands(args, innerArg), strings.Join(strs, ", "))
 }
 
 func helpOptionsPresent(args []string) bool {

--- a/test/e2e/basic_workflow_test.go
+++ b/test/e2e/basic_workflow_test.go
@@ -77,12 +77,11 @@ func TestWrongCommand(t *testing.T) {
 	r := test.NewKnRunResultCollector(t, it)
 	defer r.DumpIfFailed()
 
-	out := test.Kn{}.Run("source", "apiserver", "noverb", "--tag=0.13")
-	assert.Check(t, util.ContainsAll(out.Stderr, "Error", "unknown sub-command", "noverb"))
+	out := test.Kn{}.Run("source", "apiserver", "noverb")
+	assert.Check(t, util.ContainsAll(out.Stderr, "unknown sub-command", "noverb"))
 	r.AssertError(out)
 
 	out = test.Kn{}.Run("rev")
-	assert.Check(t, util.ContainsAll(out.Stderr, "unknown command", "rev"))
+	assert.Check(t, util.ContainsAll(out.Stderr, "unknown command", "rev", "revision"))
 	r.AssertError(out)
-
 }


### PR DESCRIPTION
## Description

This pull request adds a check for if `-h` or `--help` is specified with a plugin command. There should be no need to check for plugin executable availability if `--help` is specified and will avoid an error being returned that a command does not exist as documented in #845.

## Changes

* Add check for if `-h` or `--help` is specified in `HandlePluginCommand`
* Add test

## Reference

Fixes #845 

/lint