### PR TITLE
Fix Panic for kn source ping describe with Sink URI

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,10 @@
 |===
 | | Description | PR
 
+| 🐛
+| Fix Panic for kn source ping describe with Sink URI
+| https://github.com/knative/client/pull/848[#848]
+
 | 🎁
 | Add kn service delete --all
 | https://github.com/knative/client/pull/836[#836]

--- a/pkg/kn/commands/source/ping/describe.go
+++ b/pkg/kn/commands/source/ping/describe.go
@@ -90,10 +90,10 @@ func NewPingDescribeCommand(p *commands.KnParams) *cobra.Command {
 
 func writeSink(dw printers.PrefixWriter, sink *duckv1.Destination) {
 	subWriter := dw.WriteAttribute("Sink", "")
-	subWriter.WriteAttribute("Name", sink.Ref.Name)
-	subWriter.WriteAttribute("Namespace", sink.Ref.Namespace)
 	ref := sink.Ref
 	if ref != nil {
+		subWriter.WriteAttribute("Name", sink.Ref.Name)
+		subWriter.WriteAttribute("Namespace", sink.Ref.Namespace)
 		subWriter.WriteAttribute("Resource", fmt.Sprintf("%s (%s)", sink.Ref.Kind, sink.Ref.APIVersion))
 	}
 	uri := sink.URI


### PR DESCRIPTION
## Description

This pull request moves all `Sink.Ref` properties from being referenced for `kn source ping describe` until after it has been checked if `Sink.Ref` is nil due to using a URI instead of a Ref. 

It also fixes tests for `kn source ping describe`, which are not asserting whether command output is successfully returned or not. 

## Reference

Fixes #847 

/lint
