### PR TITLE
Remove Use of os.Exit() and Return Error Instead

### DIFF
--- a/cmd/kn/main.go
+++ b/cmd/kn/main.go
@@ -33,8 +33,13 @@ var err error
 func main() {
 	defer cleanup()
 	rand.Seed(time.Now().UnixNano())
-	err = core.NewDefaultKnCommand().Execute()
+	kn, err := core.NewDefaultKnCommand()
 	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	if err := kn.Execute(); err != nil {
 		if err.Error() != "subcommand is required" {
 			fmt.Fprintln(os.Stderr, err)
 		}

--- a/pkg/kn/commands/plugin/handler.go
+++ b/pkg/kn/commands/plugin/handler.go
@@ -113,10 +113,10 @@ func (h *DefaultPluginHandler) Execute(executablePath string, cmdArgs, environme
 		cmd.Stdin = os.Stdin
 		cmd.Env = environment
 		err := cmd.Run()
-		if err == nil {
-			os.Exit(0)
+		if err != nil {
+			return err
 		}
-		return err
+		return nil
 	}
 	return syscall.Exec(executablePath, cmdArgs, environment)
 }

--- a/pkg/kn/core/root_test.go
+++ b/pkg/kn/core/root_test.go
@@ -30,7 +30,7 @@ func TestNewDefaultKnCommand(t *testing.T) {
 	var rootCmd *cobra.Command
 
 	setup := func(t *testing.T) {
-		rootCmd = NewDefaultKnCommand()
+		rootCmd, _ = NewDefaultKnCommand()
 	}
 
 	t.Run("returns a valid root command", func(t *testing.T) {
@@ -48,7 +48,7 @@ func TestNewDefaultKnCommandWithArgs(t *testing.T) {
 	)
 
 	setup := func(t *testing.T) {
-		rootCmd = NewDefaultKnCommandWithArgs(NewKnCommand(), pluginHandler, args, os.Stdin, os.Stdout, os.Stderr)
+		rootCmd, _ = NewDefaultKnCommandWithArgs(NewKnCommand(), pluginHandler, args, os.Stdin, os.Stdout, os.Stderr)
 	}
 
 	t.Run("when pluginHandler is nil", func(t *testing.T) {

--- a/test/e2e/basic_workflow_test.go
+++ b/test/e2e/basic_workflow_test.go
@@ -82,7 +82,7 @@ func TestWrongCommand(t *testing.T) {
 	r.AssertError(out)
 
 	out = test.Kn{}.Run("rev")
-	assert.Check(t, util.ContainsAll(out.Stderr, "Error", "unknown command", "rev"))
+	assert.Check(t, util.ContainsAll(out.Stderr, "unknown command", "rev"))
 	r.AssertError(out)
 
 }


### PR DESCRIPTION
## Description

This pull request removes the use of `os.Exit(1)` from areas of `kn` with the exception of `main.go` and `generate-docs.go`. Instead of using `os.Exit(1)` an error is returned now and handled in `main.go`.

Can also work of removing from `generate-docs.go`, but my thought was the issue was meant to address this in `kn`.

Can wait for #834 and rebase if that is preferred.

## Reference

Fixes #850 

/lint
