### PR TITLE
Replace pkg/errors with stdlib errors.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,8 +17,8 @@
 | | Description | PR
 
 | 🐣
-| Replaced non-standard errors package with standard library functions.
-| https://github.com/knative/client/pull/852[#852]
+| Replaced non-standard errors package with standard library functions
+| https://github.com/knative/client/pull/853[#853]
 
 | 🐛
 | Fix Panic for kn source ping describe with Sink URI

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,10 @@
 |===
 | | Description | PR
 
+| 🐣
+| Replaced non-standard errors package with standard library functions.
+| https://github.com/knative/client/pull/852[#852]
+
 | 🐛
 | Fix Panic for kn source ping describe with Sink URI
 | https://github.com/knative/client/pull/848[#848]

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/google/go-containerregistry v0.0.0-20200413145205-82d30a103c0a // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/openzipkin/zipkin-go v0.2.2 // indirect
-	github.com/pkg/errors v0.8.1
 	github.com/robfig/cron v1.2.0 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/lib/test/cli.go
+++ b/lib/test/cli.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -107,7 +105,7 @@ func RunKubectl(namespace string, args ...string) (string, error) {
 	}
 	stdout, stderr, err := runCli("kubectl", args)
 	if err != nil {
-		return stdout, errors.Wrap(err, fmt.Sprintf("stderr: %s", stderr))
+		return stdout, fmt.Errorf("stderr: %s: %w", stderr, err)
 	}
 	return stdout, nil
 }

--- a/lib/test/integration.go
+++ b/lib/test/integration.go
@@ -23,8 +23,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -121,7 +119,7 @@ func CreateNamespace(namespace string) error {
 	expectedOutputRegexp := fmt.Sprintf("namespace?.+%s.+created", namespace)
 	out, err := createNamespaceWithRetry(namespace, MaxRetries)
 	if err != nil {
-		return errors.Wrap(err, "could not create namespace "+namespace)
+		return fmt.Errorf("could not create namespace %s: %w", namespace, err)
 	}
 
 	// check that last output indeed show created namespace
@@ -140,7 +138,7 @@ func DeleteNamespace(namespace string) error {
 	kubectl := Kubectl{namespace}
 	out, err := kubectl.Run("delete", "namespace", namespace)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("Cannot delete namespace %s", namespace))
+		return fmt.Errorf("Cannot delete namespace %s: %w", namespace, err)
 	}
 
 	expectedOutputRegexp := fmt.Sprintf("namespace?.+%s.+deleted", namespace)
@@ -226,7 +224,7 @@ func createNamespaceWithRetry(namespace string, maxRetries int) (string, error) 
 func matchRegexp(matchingRegexp, actual string) (bool, error) {
 	matched, err := regexp.MatchString(matchingRegexp, actual)
 	if err != nil {
-		return false, errors.Wrap(err, fmt.Sprintf("failed to match regexp '%s'", matchingRegexp))
+		return false, fmt.Errorf("failed to match regexp %q: %w", matchingRegexp, err)
 	}
 	return matched, nil
 }

--- a/pkg/kn/commands/plugin/verifier.go
+++ b/pkg/kn/commands/plugin/verifier.go
@@ -21,6 +21,7 @@
 package plugin
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -29,7 +30,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/kn/commands/plugin/verifier_windows.go
+++ b/pkg/kn/commands/plugin/verifier_windows.go
@@ -18,6 +18,7 @@
 package plugin
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -25,7 +26,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -15,10 +15,10 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	corev1 "k8s.io/api/core/v1"
@@ -263,7 +263,7 @@ func (p *ConfigurationEditFlags) Apply(
 	if cmd.Flags().Changed("env") {
 		envMap, err := util.MapFromArrayAllowingSingles(p.Env, "=")
 		if err != nil {
-			return errors.Wrap(err, "Invalid --env")
+			return fmt.Errorf("Invalid --env: %w", err)
 		}
 
 		envToRemove := util.ParseMinusSuffix(envMap)
@@ -295,12 +295,12 @@ func (p *ConfigurationEditFlags) Apply(
 	if cmd.Flags().Changed("mount") || cmd.Flags().Changed("volume") {
 		mountsToUpdate, mountsToRemove, err := util.OrderedMapAndRemovalListFromArray(p.Mount, "=")
 		if err != nil {
-			return errors.Wrap(err, "Invalid --mount")
+			return fmt.Errorf("Invalid --mount: %w", err)
 		}
 
 		volumesToUpdate, volumesToRemove, err := util.OrderedMapAndRemovalListFromArray(p.Volume, "=")
 		if err != nil {
-			return errors.Wrap(err, "Invalid --volume")
+			return fmt.Errorf("Invalid --volume: %w", err)
 		}
 
 		err = servinglib.UpdateVolumeMountsAndVolumes(template, mountsToUpdate, mountsToRemove, volumesToUpdate, volumesToRemove)
@@ -429,24 +429,24 @@ func (p *ConfigurationEditFlags) Apply(
 	if cmd.Flags().Changed("label") || cmd.Flags().Changed("label-service") || cmd.Flags().Changed("label-revision") {
 		labelsAllMap, err := util.MapFromArrayAllowingSingles(p.Labels, "=")
 		if err != nil {
-			return errors.Wrap(err, "Invalid --label")
+			return fmt.Errorf("Invalid --label: %w", err)
 		}
 
 		err = p.updateLabels(&service.ObjectMeta, p.LabelsService, labelsAllMap)
 		if err != nil {
-			return errors.Wrap(err, "Invalid --label-service")
+			return fmt.Errorf("Invalid --label-service: %w", err)
 		}
 
 		err = p.updateLabels(&template.ObjectMeta, p.LabelsRevision, labelsAllMap)
 		if err != nil {
-			return errors.Wrap(err, "Invalid --label-revision")
+			return fmt.Errorf("Invalid --label-revision: %w", err)
 		}
 	}
 
 	if cmd.Flags().Changed("annotation") {
 		annotationsMap, err := util.MapFromArrayAllowingSingles(p.Annotations, "=")
 		if err != nil {
-			return errors.Wrap(err, "Invalid --annotation")
+			return fmt.Errorf("Invalid --annotation: %w", err)
 		}
 
 		annotationsToRemove := util.ParseMinusSuffix(annotationsMap)
@@ -477,7 +477,7 @@ func (p *ConfigurationEditFlags) Apply(
 func (p *ConfigurationEditFlags) updateLabels(obj *metav1.ObjectMeta, flagLabels []string, labelsAllMap map[string]string) error {
 	labelFlagMap, err := util.MapFromArrayAllowingSingles(flagLabels, "=")
 	if err != nil {
-		return errors.Wrap(err, "Unable to parse label flags")
+		return fmt.Errorf("Unable to parse label flags: %w", err)
 	}
 	labelsMap := make(util.StringMap)
 	labelsMap.Merge(labelsAllMap)
@@ -495,7 +495,7 @@ func (p *ConfigurationEditFlags) computeResources(resourceFlags ResourceFlags) (
 		cpuQuantity, err := resource.ParseQuantity(resourceFlags.CPU)
 		if err != nil {
 			return corev1.ResourceList{},
-				errors.Wrapf(err, "Error parsing %q", resourceFlags.CPU)
+				fmt.Errorf("Error parsing %q: %w", resourceFlags.CPU, err)
 		}
 
 		resourceList[corev1.ResourceCPU] = cpuQuantity
@@ -505,7 +505,7 @@ func (p *ConfigurationEditFlags) computeResources(resourceFlags ResourceFlags) (
 		memoryQuantity, err := resource.ParseQuantity(resourceFlags.Memory)
 		if err != nil {
 			return corev1.ResourceList{},
-				errors.Wrapf(err, "Error parsing %q", resourceFlags.Memory)
+				fmt.Errorf("Error parsing %q: %w", resourceFlags.Memory, err)
 		}
 
 		resourceList[corev1.ResourceMemory] = memoryQuantity

--- a/pkg/kn/commands/service/delete_test.go
+++ b/pkg/kn/commands/service/delete_test.go
@@ -15,9 +15,9 @@
 package service
 
 import (
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/kn/commands/trigger/update_flags.go
+++ b/pkg/kn/commands/trigger/update_flags.go
@@ -15,7 +15,8 @@
 package trigger
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"knative.dev/client/pkg/util"
@@ -32,7 +33,7 @@ type TriggerUpdateFlags struct {
 func (f *TriggerUpdateFlags) GetFilters() (map[string]string, error) {
 	filters, err := util.MapFromArray(f.Filters, "=")
 	if err != nil {
-		return nil, errors.Wrap(err, "Invalid --filter")
+		return nil, fmt.Errorf("Invalid --filter: %w", err)
 	}
 	return filters, nil
 }
@@ -41,7 +42,7 @@ func (f *TriggerUpdateFlags) GetFilters() (map[string]string, error) {
 func (f *TriggerUpdateFlags) GetUpdateFilters() (map[string]string, []string, error) {
 	filters, err := util.MapFromArrayAllowingSingles(f.Filters, "=")
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "Invalid --filter")
+		return nil, nil, fmt.Errorf("Invalid --filter: %w", err)
 	}
 	removes := util.ParseMinusSuffix(filters)
 	return filters, removes, nil

--- a/pkg/serving/v1/client.go
+++ b/pkg/serving/v1/client.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
 	"knative.dev/pkg/apis"
@@ -254,7 +253,7 @@ func updateServiceWithRetry(cl KnServingClient, name string, updateFunc serviceU
 				time.Sleep(time.Second)
 				continue
 			}
-			return errors.Wrap(err, fmt.Sprintf("giving up after %d retries", nrRetries))
+			return fmt.Errorf("giving up after %d retries: %w", nrRetries, err)
 		}
 		return nil
 	}

--- a/test/e2e/source_apiserver_test.go
+++ b/test/e2e/source_apiserver_test.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
 	"gotest.tools/assert"
 
 	"knative.dev/client/lib/test"
@@ -130,19 +129,19 @@ func tearDownForSourceAPIServer(t *testing.T, it *test.KnTest) error {
 	saCmd := []string{"delete", "serviceaccount", testServiceAccount}
 	_, err := test.NewKubectl(it.Kn().Namespace()).Run(saCmd...)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("Error executing '%s'", strings.Join(saCmd, " ")))
+		return fmt.Errorf("Error executing %q: %w", strings.Join(saCmd, " "), err)
 	}
 
 	crCmd := []string{"delete", "clusterrole", clusterRolePrefix + it.Kn().Namespace()}
 	_, err = test.Kubectl{}.Run(crCmd...)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("Error executing '%s'", strings.Join(saCmd, " ")))
+		return fmt.Errorf("Error executing %q: %w", strings.Join(saCmd, " "), err)
 	}
 
 	crbCmd := []string{"delete", "clusterrolebinding", clusterRoleBindingPrefix + it.Kn().Namespace()}
 	_, err = test.Kubectl{}.Run(crbCmd...)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("Error executing '%s'", strings.Join(saCmd, " ")))
+		return fmt.Errorf("Error executing %q: %w", strings.Join(saCmd, " "), err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

As per title. Since Golang 1.13, the stdlib has vastly improved regarding error wrapping etc. Make use of that.

## Changes

* Replaced `errors.New` with the stdlib.
* Replaced `errors.Wrap(f)` with `fmt.Errorf`

<!--
Please add an entrty to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
