### PR TITLE
Add broker create, delete and list cmds

### DIFF
--- a/docs/cmd/kn.md
+++ b/docs/cmd/kn.md
@@ -19,6 +19,7 @@ kn is the command line interface for managing Knative Serving and Eventing resou
 
 ### SEE ALSO
 
+* [kn broker](kn_broker.md)	 - Manage message broker
 * [kn completion](kn_completion.md)	 - Output shell completion code
 * [kn options](kn_options.md)	 - Print the list of flags inherited by all commands
 * [kn plugin](kn_plugin.md)	 - Manage kn plugins

--- a/docs/cmd/kn_broker.md
+++ b/docs/cmd/kn_broker.md
@@ -1,0 +1,33 @@
+## kn broker
+
+Manage message broker
+
+### Synopsis
+
+Manage message broker
+
+```
+kn broker
+```
+
+### Options
+
+```
+  -h, --help   help for broker
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
+      --log-http            log http traffic
+```
+
+### SEE ALSO
+
+* [kn](kn.md)	 - kn manages Knative Serving and Eventing resources
+* [kn broker create](kn_broker_create.md)	 - Create a broker.
+* [kn broker delete](kn_broker_delete.md)	 - Delete a broker.
+* [kn broker list](kn_broker_list.md)	 - List brokers.
+

--- a/docs/cmd/kn_broker.md
+++ b/docs/cmd/kn_broker.md
@@ -27,7 +27,8 @@ kn broker
 ### SEE ALSO
 
 * [kn](kn.md)	 - kn manages Knative Serving and Eventing resources
-* [kn broker create](kn_broker_create.md)	 - Create a broker.
-* [kn broker delete](kn_broker_delete.md)	 - Delete a broker.
-* [kn broker list](kn_broker_list.md)	 - List brokers.
+* [kn broker create](kn_broker_create.md)	 - Create a broker
+* [kn broker delete](kn_broker_delete.md)	 - Delete a broker
+* [kn broker describe](kn_broker_describe.md)	 - Describe broker
+* [kn broker list](kn_broker_list.md)	 - List brokers
 

--- a/docs/cmd/kn_broker_create.md
+++ b/docs/cmd/kn_broker_create.md
@@ -16,6 +16,7 @@ kn broker create NAME
 
 # Create a broker 'mybroker' in the current namespace
   kn broker create mybroker
+  
 # Create a broker 'mybroker' in the 'myproject' namespace
   kn broker create mybroker --namespace myproject
 

--- a/docs/cmd/kn_broker_create.md
+++ b/docs/cmd/kn_broker_create.md
@@ -14,12 +14,11 @@ kn broker create NAME
 
 ```
 
-# Create a broker 'mybroker' in the current namespace
+  # Create a broker 'mybroker' in the current namespace
   kn broker create mybroker
 
-# Create a broker 'mybroker' in the 'myproject' namespace
+  # Create a broker 'mybroker' in the 'myproject' namespace
   kn broker create mybroker --namespace myproject
-
 ```
 
 ### Options

--- a/docs/cmd/kn_broker_create.md
+++ b/docs/cmd/kn_broker_create.md
@@ -1,0 +1,42 @@
+## kn broker create
+
+Create a broker.
+
+### Synopsis
+
+Create a broker.
+
+```
+kn broker create NAME
+```
+
+### Examples
+
+```
+
+# Create a broker 'mybroker' in the current namespace
+  kn broker create mybroker
+# Create a broker 'mybroker' in the 'myproject' namespace
+  kn broker create mybroker --namespace myproject
+
+```
+
+### Options
+
+```
+  -h, --help               help for create
+  -n, --namespace string   Specify the namespace to operate in.
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
+      --log-http            log http traffic
+```
+
+### SEE ALSO
+
+* [kn broker](kn_broker.md)	 - Manage message broker
+

--- a/docs/cmd/kn_broker_create.md
+++ b/docs/cmd/kn_broker_create.md
@@ -16,7 +16,7 @@ kn broker create NAME
 
 # Create a broker 'mybroker' in the current namespace
   kn broker create mybroker
-  
+
 # Create a broker 'mybroker' in the 'myproject' namespace
   kn broker create mybroker --namespace myproject
 

--- a/docs/cmd/kn_broker_delete.md
+++ b/docs/cmd/kn_broker_delete.md
@@ -16,7 +16,7 @@ kn broker delete NAME
 
 # Delete a broker 'mybroker' in the current namespace
   kn broker create mybroker
-  
+
 # Delete a broker 'mybroker' in the 'myproject' namespace
   kn broker create mybroker --namespace myproject
 

--- a/docs/cmd/kn_broker_delete.md
+++ b/docs/cmd/kn_broker_delete.md
@@ -14,12 +14,11 @@ kn broker delete NAME
 
 ```
 
-# Delete a broker 'mybroker' in the current namespace
+  # Delete a broker 'mybroker' in the current namespace
   kn broker create mybroker
 
-# Delete a broker 'mybroker' in the 'myproject' namespace
+  # Delete a broker 'mybroker' in the 'myproject' namespace
   kn broker create mybroker --namespace myproject
-
 ```
 
 ### Options

--- a/docs/cmd/kn_broker_delete.md
+++ b/docs/cmd/kn_broker_delete.md
@@ -1,0 +1,42 @@
+## kn broker delete
+
+Delete a broker.
+
+### Synopsis
+
+Delete a broker.
+
+```
+kn broker delete NAME
+```
+
+### Examples
+
+```
+
+# Delete a broker 'mybroker' in the current namespace
+  kn broker create mybroker
+# Delete a broker 'mybroker' in the 'myproject' namespace
+  kn broker create mybroker --namespace myproject
+
+```
+
+### Options
+
+```
+  -h, --help               help for delete
+  -n, --namespace string   Specify the namespace to operate in.
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
+      --log-http            log http traffic
+```
+
+### SEE ALSO
+
+* [kn broker](kn_broker.md)	 - Manage message broker
+

--- a/docs/cmd/kn_broker_delete.md
+++ b/docs/cmd/kn_broker_delete.md
@@ -1,10 +1,10 @@
 ## kn broker delete
 
-Delete a broker.
+Delete a broker
 
 ### Synopsis
 
-Delete a broker.
+Delete a broker
 
 ```
 kn broker delete NAME

--- a/docs/cmd/kn_broker_delete.md
+++ b/docs/cmd/kn_broker_delete.md
@@ -16,6 +16,7 @@ kn broker delete NAME
 
 # Delete a broker 'mybroker' in the current namespace
   kn broker create mybroker
+  
 # Delete a broker 'mybroker' in the 'myproject' namespace
   kn broker create mybroker --namespace myproject
 

--- a/docs/cmd/kn_broker_delete.md
+++ b/docs/cmd/kn_broker_delete.md
@@ -24,8 +24,12 @@ kn broker delete NAME
 ### Options
 
 ```
+      --async              DEPRECATED: please use --no-wait instead. Do not wait for 'broker delete' operation to be completed. (default true)
   -h, --help               help for delete
   -n, --namespace string   Specify the namespace to operate in.
+      --no-wait            Do not wait for 'broker delete' operation to be completed. (default true)
+      --wait               Wait for 'broker delete' operation to be completed.
+      --wait-timeout int   Seconds to wait before giving up on waiting for broker to be deleted. (default 600)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/kn_broker_describe.md
+++ b/docs/cmd/kn_broker_describe.md
@@ -1,13 +1,13 @@
-## kn broker create
+## kn broker describe
 
-Create a broker
+Describe broker
 
 ### Synopsis
 
-Create a broker
+Describe broker
 
 ```
-kn broker create NAME
+kn broker describe NAME
 ```
 
 ### Examples
@@ -24,7 +24,7 @@ kn broker create NAME
 ### Options
 
 ```
-  -h, --help               help for create
+  -h, --help               help for describe
   -n, --namespace string   Specify the namespace to operate in.
 ```
 

--- a/docs/cmd/kn_broker_describe.md
+++ b/docs/cmd/kn_broker_describe.md
@@ -14,11 +14,10 @@ kn broker describe NAME
 
 ```
 
-# Create a broker 'mybroker' in the current namespace
-  kn broker create mybroker
-# Create a broker 'mybroker' in the 'myproject' namespace
-  kn broker create mybroker --namespace myproject
-
+  # Describe broker 'mybroker' in the current namespace
+  kn broker describe mybroker
+  # Describe broker 'mybroker' in the 'myproject' namespace
+  kn broker describe mybroker --namespace myproject
 ```
 
 ### Options

--- a/docs/cmd/kn_broker_describe.md
+++ b/docs/cmd/kn_broker_describe.md
@@ -16,7 +16,7 @@ kn broker describe NAME
 
   # Describe broker 'mybroker' in the current namespace
   kn broker describe mybroker
-  
+
   # Describe broker 'mybroker' in the 'myproject' namespace
   kn broker describe mybroker --namespace myproject
 ```

--- a/docs/cmd/kn_broker_describe.md
+++ b/docs/cmd/kn_broker_describe.md
@@ -16,6 +16,7 @@ kn broker describe NAME
 
   # Describe broker 'mybroker' in the current namespace
   kn broker describe mybroker
+  
   # Describe broker 'mybroker' in the 'myproject' namespace
   kn broker describe mybroker --namespace myproject
 ```

--- a/docs/cmd/kn_broker_list.md
+++ b/docs/cmd/kn_broker_list.md
@@ -1,10 +1,10 @@
 ## kn broker list
 
-List brokers.
+List brokers
 
 ### Synopsis
 
-List brokers.
+List brokers
 
 ```
 kn broker list

--- a/docs/cmd/kn_broker_list.md
+++ b/docs/cmd/kn_broker_list.md
@@ -1,0 +1,48 @@
+## kn broker list
+
+List brokers.
+
+### Synopsis
+
+List brokers.
+
+```
+kn broker list
+```
+
+### Examples
+
+```
+
+# List all brokers
+  kn broker list
+
+# List all brokers in JSON output format
+  kn broker list -o json
+
+```
+
+### Options
+
+```
+  -A, --all-namespaces                If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.
+      --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
+  -h, --help                          help for list
+  -n, --namespace string              Specify the namespace to operate in.
+      --no-headers                    When using the default output format, don't print headers (default: print headers).
+  -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
+      --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
+      --log-http            log http traffic
+```
+
+### SEE ALSO
+
+* [kn broker](kn_broker.md)	 - Manage message broker
+

--- a/docs/cmd/kn_broker_list.md
+++ b/docs/cmd/kn_broker_list.md
@@ -14,12 +14,11 @@ kn broker list
 
 ```
 
-# List all brokers
+  # List all brokers
   kn broker list
 
-# List all brokers in JSON output format
+  # List all brokers in JSON output format
   kn broker list -o json
-
 ```
 
 ### Options

--- a/pkg/eventing/v1beta1/client.go
+++ b/pkg/eventing/v1beta1/client.go
@@ -105,7 +105,7 @@ func (c *knEventingClient) ListTriggers() (*v1beta1.TriggerList, error) {
 		return nil, kn_errors.GetError(err)
 	}
 	triggerListNew := triggerList.DeepCopy()
-	err = updateEventingGvk(triggerListNew)
+	err = updateEventingGVK(triggerListNew)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func (c *knEventingClient) ListTriggers() (*v1beta1.TriggerList, error) {
 	triggerListNew.Items = make([]v1beta1.Trigger, len(triggerList.Items))
 	for idx, trigger := range triggerList.Items {
 		triggerClone := trigger.DeepCopy()
-		err := updateEventingGvk(triggerClone)
+		err := updateEventingGVK(triggerClone)
 		if err != nil {
 			return nil, err
 		}
@@ -269,7 +269,7 @@ func (c *knEventingClient) ListBrokers() (*v1beta1.BrokerList, error) {
 		return nil, kn_errors.GetError(err)
 	}
 	brokerListNew := brokerList.DeepCopy()
-	err = updateEventingGvk(brokerListNew)
+	err = updateEventingGVK(brokerListNew)
 	if err != nil {
 		return nil, err
 	}
@@ -277,7 +277,7 @@ func (c *knEventingClient) ListBrokers() (*v1beta1.BrokerList, error) {
 	brokerListNew.Items = make([]v1beta1.Broker, len(brokerList.Items))
 	for idx, trigger := range brokerList.Items {
 		triggerClone := trigger.DeepCopy()
-		err := updateEventingGvk(triggerClone)
+		err := updateEventingGVK(triggerClone)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/eventing/v1beta1/client.go
+++ b/pkg/eventing/v1beta1/client.go
@@ -137,7 +137,7 @@ func (c *knEventingClient) Namespace() string {
 }
 
 // update with the v1beta1 group + version
-func updateEventingGvk(obj runtime.Object) error {
+func updateEventingGVK(obj runtime.Object) error {
 	return util.UpdateGroupVersionKindWithScheme(obj, v1beta1.SchemeGroupVersion, scheme.Scheme)
 }
 

--- a/pkg/eventing/v1beta1/client.go
+++ b/pkg/eventing/v1beta1/client.go
@@ -44,6 +44,8 @@ type KnEventingClient interface {
 	UpdateTrigger(trigger *v1beta1.Trigger) error
 	// CreateBroker is used to create an instance of broker
 	CreateBroker(broker *v1beta1.Broker) error
+	// GetBroker is used to get an instance of broker
+	GetBroker(name string) (*v1beta1.Broker, error)
 	// DeleteBroker is used to delete an instance of broker
 	DeleteBroker(name string) error
 	// ListBroker returns list of broker CRDs
@@ -214,6 +216,15 @@ func (c *knEventingClient) CreateBroker(broker *v1beta1.Broker) error {
 		return kn_errors.GetError(err)
 	}
 	return nil
+}
+
+//GetBroker is used to get an instance of broker
+func (c *knEventingClient) GetBroker(name string) (*v1beta1.Broker, error) {
+	trigger, err := c.client.Brokers(c.namespace).Get(name, apis_v1.GetOptions{})
+	if err != nil {
+		return nil, kn_errors.GetError(err)
+	}
+	return trigger, nil
 }
 
 // DeleteBroker is used to delete an instance of broker

--- a/pkg/eventing/v1beta1/client.go
+++ b/pkg/eventing/v1beta1/client.go
@@ -222,7 +222,7 @@ func (c *knEventingClient) CreateBroker(broker *v1beta1.Broker) error {
 	return nil
 }
 
-//GetBroker is used to get an instance of broker
+// GetBroker is used to get an instance of broker
 func (c *knEventingClient) GetBroker(name string) (*v1beta1.Broker, error) {
 	trigger, err := c.client.Brokers(c.namespace).Get(name, apis_v1.GetOptions{})
 	if err != nil {
@@ -231,11 +231,14 @@ func (c *knEventingClient) GetBroker(name string) (*v1beta1.Broker, error) {
 	return trigger, nil
 }
 
+// WatchBroker is used to create watcher object
 func (c *knEventingClient) WatchBroker(name string, timeout time.Duration) (watch.Interface, error) {
 	return wait.NewWatcher(c.client.Brokers(c.namespace).Watch,
 		c.client.RESTClient(), c.namespace, "brokers", name, timeout)
 }
 
+// DeleteBroker is used to delete an instance of broker and wait for completion until given timeout
+// For `timeout == 0` delete is performed async without any wait
 func (c *knEventingClient) DeleteBroker(name string, timeout time.Duration) error {
 	if timeout == 0 {
 		return c.deleteBroker(name, apis_v1.DeletePropagationBackground)
@@ -253,7 +256,7 @@ func (c *knEventingClient) DeleteBroker(name string, timeout time.Duration) erro
 	return <-waitC
 }
 
-// DeleteBroker is used to delete an instance of broker
+// deleteBroker is used to delete an instance of broker
 func (c *knEventingClient) deleteBroker(name string, propagationPolicy apis_v1.DeletionPropagation) error {
 	err := c.client.Brokers(c.namespace).Delete(name, &apis_v1.DeleteOptions{PropagationPolicy: &propagationPolicy})
 	if err != nil {

--- a/pkg/eventing/v1beta1/client_mock.go
+++ b/pkg/eventing/v1beta1/client_mock.go
@@ -16,6 +16,7 @@ package v1beta1
 
 import (
 	"testing"
+	"time"
 
 	v1beta1 "knative.dev/eventing/pkg/apis/eventing/v1beta1"
 
@@ -137,13 +138,13 @@ func (c *MockKnEventingClient) GetBroker(name string) (*v1beta1.Broker, error) {
 }
 
 // DeleteBroker records a call for DeleteBroker with the expected error (nil if none)
-func (sr *EventingRecorder) DeleteBroker(name interface{}, err error) {
-	sr.r.Add("DeleteBroker", []interface{}{name}, []interface{}{err})
+func (sr *EventingRecorder) DeleteBroker(name, timeout interface{}, err error) {
+	sr.r.Add("DeleteBroker", []interface{}{name, timeout}, []interface{}{err})
 }
 
 // DeleteBroker performs a previously recorded action, failing if non has been registered
-func (c *MockKnEventingClient) DeleteBroker(name string) error {
-	call := c.recorder.r.VerifyCall("DeleteBroker", name)
+func (c *MockKnEventingClient) DeleteBroker(name string, timeout time.Duration) error {
+	call := c.recorder.r.VerifyCall("DeleteBroker", name, timeout)
 	return mock.ErrorOrNil(call.Result[0])
 }
 

--- a/pkg/eventing/v1beta1/client_mock.go
+++ b/pkg/eventing/v1beta1/client_mock.go
@@ -114,6 +114,39 @@ func (c *MockKnEventingClient) UpdateTrigger(trigger *v1beta1.Trigger) error {
 	return mock.ErrorOrNil(call.Result[0])
 }
 
+// CreateBroker records a call for CreateBroker with the expected error
+func (sr *EventingRecorder) CreateBroker(broker interface{}, err error) {
+	sr.r.Add("CreateBroker", []interface{}{broker}, []interface{}{err})
+}
+
+// CreateBroker performs a previously recorded action
+func (c *MockKnEventingClient) CreateBroker(broker *v1beta1.Broker) error {
+	call := c.recorder.r.VerifyCall("CreateBroker", broker)
+	return mock.ErrorOrNil(call.Result[0])
+}
+
+// DeleteBroker records a call for DeleteBroker with the expected error (nil if none)
+func (sr *EventingRecorder) DeleteBroker(name interface{}, err error) {
+	sr.r.Add("DeleteBroker", []interface{}{name}, []interface{}{err})
+}
+
+// DeleteBroker performs a previously recorded action, failing if non has been registered
+func (c *MockKnEventingClient) DeleteBroker(name string) error {
+	call := c.recorder.r.VerifyCall("DeleteBroker", name)
+	return mock.ErrorOrNil(call.Result[0])
+}
+
+// ListBrokers records a call for ListBrokers with the expected result and error (nil if none)
+func (sr *EventingRecorder) ListBrokers(brokerList *v1beta1.BrokerList, err error) {
+	sr.r.Add("ListBrokers", nil, []interface{}{brokerList, err})
+}
+
+// ListBrokers performs a previously recorded action
+func (c *MockKnEventingClient) ListBrokers() (*v1beta1.BrokerList, error) {
+	call := c.recorder.r.VerifyCall("ListBrokers")
+	return call.Result[0].(*v1beta1.BrokerList), mock.ErrorOrNil(call.Result[1])
+}
+
 // Validate validates whether every recorded action has been called
 func (sr *EventingRecorder) Validate() {
 	sr.r.CheckThatAllRecordedMethodsHaveBeenCalled()

--- a/pkg/eventing/v1beta1/client_mock.go
+++ b/pkg/eventing/v1beta1/client_mock.go
@@ -125,6 +125,17 @@ func (c *MockKnEventingClient) CreateBroker(broker *v1beta1.Broker) error {
 	return mock.ErrorOrNil(call.Result[0])
 }
 
+// GetBroker records a call for GetBroker with the expected object or error. Either trigger or err should be nil
+func (sr *EventingRecorder) GetBroker(name interface{}, broker *v1beta1.Broker, err error) {
+	sr.r.Add("GetBroker", []interface{}{name}, []interface{}{broker, err})
+}
+
+// GetBroker performs a previously recorded action
+func (c *MockKnEventingClient) GetBroker(name string) (*v1beta1.Broker, error) {
+	call := c.recorder.r.VerifyCall("GetBroker", name)
+	return call.Result[0].(*v1beta1.Broker), mock.ErrorOrNil(call.Result[1])
+}
+
 // DeleteBroker records a call for DeleteBroker with the expected error (nil if none)
 func (sr *EventingRecorder) DeleteBroker(name interface{}, err error) {
 	sr.r.Add("DeleteBroker", []interface{}{name}, []interface{}{err})

--- a/pkg/eventing/v1beta1/client_mock_test.go
+++ b/pkg/eventing/v1beta1/client_mock_test.go
@@ -34,6 +34,7 @@ func TestMockKnClient(t *testing.T) {
 	recorder.UpdateTrigger(&v1beta1.Trigger{}, nil)
 
 	recorder.CreateBroker(&v1beta1.Broker{}, nil)
+	recorder.GetBroker("foo", nil, nil)
 	recorder.DeleteBroker("foo", nil)
 	recorder.ListBrokers(nil, nil)
 
@@ -45,6 +46,7 @@ func TestMockKnClient(t *testing.T) {
 	client.UpdateTrigger(&v1beta1.Trigger{})
 
 	client.CreateBroker(&v1beta1.Broker{})
+	client.GetBroker("foo")
 	client.DeleteBroker("foo")
 	client.ListBrokers()
 

--- a/pkg/eventing/v1beta1/client_mock_test.go
+++ b/pkg/eventing/v1beta1/client_mock_test.go
@@ -33,12 +33,20 @@ func TestMockKnClient(t *testing.T) {
 	recorder.ListTriggers(nil, nil)
 	recorder.UpdateTrigger(&v1beta1.Trigger{}, nil)
 
+	recorder.CreateBroker(&v1beta1.Broker{}, nil)
+	recorder.DeleteBroker("foo", nil)
+	recorder.ListBrokers(nil, nil)
+
 	// Call all service
 	client.GetTrigger("hello")
 	client.CreateTrigger(&v1beta1.Trigger{})
 	client.DeleteTrigger("hello")
 	client.ListTriggers()
 	client.UpdateTrigger(&v1beta1.Trigger{})
+
+	client.CreateBroker(&v1beta1.Broker{})
+	client.DeleteBroker("foo")
+	client.ListBrokers()
 
 	// Validate
 	recorder.Validate()

--- a/pkg/eventing/v1beta1/client_mock_test.go
+++ b/pkg/eventing/v1beta1/client_mock_test.go
@@ -16,6 +16,7 @@ package v1beta1
 
 import (
 	"testing"
+	"time"
 
 	v1beta1 "knative.dev/eventing/pkg/apis/eventing/v1beta1"
 )
@@ -35,7 +36,7 @@ func TestMockKnClient(t *testing.T) {
 
 	recorder.CreateBroker(&v1beta1.Broker{}, nil)
 	recorder.GetBroker("foo", nil, nil)
-	recorder.DeleteBroker("foo", nil)
+	recorder.DeleteBroker("foo", time.Duration(10)*time.Second, nil)
 	recorder.ListBrokers(nil, nil)
 
 	// Call all service
@@ -47,7 +48,7 @@ func TestMockKnClient(t *testing.T) {
 
 	client.CreateBroker(&v1beta1.Broker{})
 	client.GetBroker("foo")
-	client.DeleteBroker("foo")
+	client.DeleteBroker("foo", time.Duration(10)*time.Second)
 	client.ListBrokers()
 
 	// Validate

--- a/pkg/eventing/v1beta1/client_test.go
+++ b/pkg/eventing/v1beta1/client_test.go
@@ -212,6 +212,27 @@ func TestBrokerCreate(t *testing.T) {
 	})
 }
 
+func TestBrokerGet(t *testing.T) {
+	var name = "foo"
+	server, client := setup()
+
+	server.AddReactor("get", "brokers",
+		func(a client_testing.Action) (bool, runtime.Object, error) {
+			name := a.(client_testing.GetAction).GetName()
+			if name == "errorBroker" {
+				return true, nil, fmt.Errorf("error while getting broker %s", name)
+			}
+			return true, newBroker(name), nil
+		})
+
+	broker, err := client.GetBroker(name)
+	assert.NilError(t, err)
+	assert.Equal(t, broker.Name, name)
+
+	_, err = client.GetBroker("errorBroker")
+	assert.ErrorContains(t, err, "errorBroker")
+}
+
 func TestBrokerDelete(t *testing.T) {
 	var name = "fooBroker"
 	server, client := setup()

--- a/pkg/kn/commands/broker/broker.go
+++ b/pkg/kn/commands/broker/broker.go
@@ -29,6 +29,7 @@ func NewBrokerCommand(p *commands.KnParams) *cobra.Command {
 		Short: "Manage message broker",
 	}
 	brokerCmd.AddCommand(NewBrokerCreateCommand(p))
+	brokerCmd.AddCommand(NewBrokerDescribeCommand(p))
 	brokerCmd.AddCommand(NewBrokerDeleteCommand(p))
 	brokerCmd.AddCommand(NewBrokerListCommand(p))
 	return brokerCmd

--- a/pkg/kn/commands/broker/broker.go
+++ b/pkg/kn/commands/broker/broker.go
@@ -22,6 +22,7 @@ import (
 	"knative.dev/client/pkg/kn/commands"
 )
 
+// NewBrokerCommand represents broker management commands
 func NewBrokerCommand(p *commands.KnParams) *cobra.Command {
 	brokerCmd := &cobra.Command{
 		Use:   "broker",

--- a/pkg/kn/commands/broker/broker.go
+++ b/pkg/kn/commands/broker/broker.go
@@ -1,0 +1,32 @@
+// Copyright © 2020 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package broker
+
+import (
+	"github.com/spf13/cobra"
+
+	"knative.dev/client/pkg/kn/commands"
+)
+
+func NewBrokerCommand(p *commands.KnParams) *cobra.Command {
+	brokerCmd := &cobra.Command{
+		Use:   "broker",
+		Short: "Manage message broker",
+	}
+	brokerCmd.AddCommand(NewBrokerCreateCommand(p))
+	brokerCmd.AddCommand(NewBrokerDeleteCommand(p))
+	brokerCmd.AddCommand(NewBrokerListCommand(p))
+	return brokerCmd
+}

--- a/pkg/kn/commands/broker/broker.go
+++ b/pkg/kn/commands/broker/broker.go
@@ -1,16 +1,18 @@
-// Copyright © 2020 The Knative Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package broker
 

--- a/pkg/kn/commands/broker/broker_test.go
+++ b/pkg/kn/commands/broker/broker_test.go
@@ -1,17 +1,18 @@
-// Copyright © 2020 The Knative Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2020 The Knative Authors
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package broker
 
 import (

--- a/pkg/kn/commands/broker/broker_test.go
+++ b/pkg/kn/commands/broker/broker_test.go
@@ -1,0 +1,78 @@
+// Copyright © 2020 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package broker
+
+import (
+	"bytes"
+
+	"k8s.io/client-go/tools/clientcmd"
+
+	clientv1beta1 "knative.dev/client/pkg/eventing/v1beta1"
+	"knative.dev/client/pkg/kn/commands"
+	v1beta1 "knative.dev/eventing/pkg/apis/eventing/v1beta1"
+)
+
+// Helper methods
+var blankConfig clientcmd.ClientConfig
+
+func init() {
+	var err error
+	blankConfig, err = clientcmd.NewClientConfigFromBytes([]byte(`kind: Config
+version: v1
+users:
+- name: u
+clusters:
+- name: c
+  cluster:
+    server: example.com
+contexts:
+- name: x
+  context:
+    user: u
+    cluster: c
+current-context: x
+`))
+	if err != nil {
+		panic(err)
+	}
+}
+
+func executeBrokerCommand(brokerClient clientv1beta1.KnEventingClient, args ...string) (string, error) {
+	knParams := &commands.KnParams{}
+	knParams.ClientConfig = blankConfig
+
+	output := new(bytes.Buffer)
+	knParams.Output = output
+
+	knParams.NewEventingClient = func(namespace string) (clientv1beta1.KnEventingClient, error) {
+		return brokerClient, nil
+	}
+
+	cmd := NewBrokerCommand(knParams)
+	cmd.SetArgs(args)
+	cmd.SetOutput(output)
+
+	err := cmd.Execute()
+
+	return output.String(), err
+}
+
+func createBroker(brokerName string) *v1beta1.Broker {
+	return clientv1beta1.NewBrokerBuilder(brokerName).Namespace("default").Build()
+}
+
+func createBrokerWithNamespace(brokerName, namespace string) *v1beta1.Broker {
+	return clientv1beta1.NewBrokerBuilder(brokerName).Namespace(namespace).Build()
+}

--- a/pkg/kn/commands/broker/create.go
+++ b/pkg/kn/commands/broker/create.go
@@ -27,12 +27,11 @@ import (
 )
 
 var createExample = `
-# Create a broker 'mybroker' in the current namespace
+  # Create a broker 'mybroker' in the current namespace
   kn broker create mybroker
 
-# Create a broker 'mybroker' in the 'myproject' namespace
-  kn broker create mybroker --namespace myproject
-`
+  # Create a broker 'mybroker' in the 'myproject' namespace
+  kn broker create mybroker --namespace myproject`
 
 // NewBrokerCreateCommand represents command to create new broker instance
 func NewBrokerCreateCommand(p *commands.KnParams) *cobra.Command {

--- a/pkg/kn/commands/broker/create.go
+++ b/pkg/kn/commands/broker/create.go
@@ -29,7 +29,7 @@ import (
 var createExample = `
 # Create a broker 'mybroker' in the current namespace
   kn broker create mybroker
-  
+
 # Create a broker 'mybroker' in the 'myproject' namespace
   kn broker create mybroker --namespace myproject
 `

--- a/pkg/kn/commands/broker/create.go
+++ b/pkg/kn/commands/broker/create.go
@@ -38,7 +38,7 @@ func NewBrokerCreateCommand(p *commands.KnParams) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "create NAME",
-		Short:   "Create a broker.",
+		Short:   "Create a broker",
 		Example: createExample,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {

--- a/pkg/kn/commands/broker/create.go
+++ b/pkg/kn/commands/broker/create.go
@@ -1,16 +1,18 @@
-// Copyright © 2020 The Knative Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package broker
 

--- a/pkg/kn/commands/broker/create.go
+++ b/pkg/kn/commands/broker/create.go
@@ -29,6 +29,7 @@ import (
 var createExample = `
 # Create a broker 'mybroker' in the current namespace
   kn broker create mybroker
+  
 # Create a broker 'mybroker' in the 'myproject' namespace
   kn broker create mybroker --namespace myproject
 `

--- a/pkg/kn/commands/broker/create.go
+++ b/pkg/kn/commands/broker/create.go
@@ -1,0 +1,72 @@
+// Copyright © 2020 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package broker
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	clientv1beta1 "knative.dev/client/pkg/eventing/v1beta1"
+	"knative.dev/client/pkg/kn/commands"
+)
+
+var create_example = `
+# Create a broker 'mybroker' in the current namespace
+  kn broker create mybroker
+# Create a broker 'mybroker' in the 'myproject' namespace
+  kn broker create mybroker --namespace myproject
+`
+
+func NewBrokerCreateCommand(p *commands.KnParams) *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:     "create NAME",
+		Short:   "Create a broker.",
+		Example: create_example,
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			if len(args) != 1 {
+				return errors.New("'broker create' requires the broker name given as single argument")
+			}
+			name := args[0]
+
+			namespace, err := p.GetNamespace(cmd)
+			if err != nil {
+				return err
+			}
+
+			eventingClient, err := p.NewEventingClient(namespace)
+			if err != nil {
+				return err
+			}
+
+			brokerBuilder := clientv1beta1.
+				NewBrokerBuilder(name).
+				Namespace(namespace)
+
+			err = eventingClient.CreateBroker(brokerBuilder.Build())
+			if err != nil {
+				return fmt.Errorf(
+					"cannot create broker '%s' in namespace '%s' "+
+						"because: %s", name, namespace, err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Broker '%s' successfully created in namespace '%s'.\n", args[0], namespace)
+			return nil
+		},
+	}
+	commands.AddNamespaceFlags(cmd.Flags(), false)
+	return cmd
+}

--- a/pkg/kn/commands/broker/create.go
+++ b/pkg/kn/commands/broker/create.go
@@ -26,19 +26,20 @@ import (
 	"knative.dev/client/pkg/kn/commands"
 )
 
-var create_example = `
+var createExample = `
 # Create a broker 'mybroker' in the current namespace
   kn broker create mybroker
 # Create a broker 'mybroker' in the 'myproject' namespace
   kn broker create mybroker --namespace myproject
 `
 
+// NewBrokerCreateCommand represents command to create new broker instance
 func NewBrokerCreateCommand(p *commands.KnParams) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "create NAME",
 		Short:   "Create a broker.",
-		Example: create_example,
+		Example: createExample,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {
 				return errors.New("'broker create' requires the broker name given as single argument")

--- a/pkg/kn/commands/broker/create_test.go
+++ b/pkg/kn/commands/broker/create_test.go
@@ -1,0 +1,49 @@
+// Copyright © 2020 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package broker
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+
+	clienteventingv1beta1 "knative.dev/client/pkg/eventing/v1beta1"
+	"knative.dev/client/pkg/util"
+)
+
+var (
+	brokerName = "foo"
+)
+
+func TestBrokerCreate(t *testing.T) {
+	eventingClient := clienteventingv1beta1.NewMockKnEventingClient(t)
+
+	eventingRecorder := eventingClient.Recorder()
+	eventingRecorder.CreateBroker(createBroker(brokerName), nil)
+
+	out, err := executeBrokerCommand(eventingClient, "create", brokerName)
+	assert.NilError(t, err, "Broker should be created")
+	util.ContainsAll(out, "Broker", brokerName, "created", "namespace", "default")
+
+	eventingRecorder.Validate()
+}
+
+func TestBrokerCreateWithError(t *testing.T) {
+	eventingClient := clienteventingv1beta1.NewMockKnEventingClient(t)
+
+	_, err := executeBrokerCommand(eventingClient, "create")
+	assert.ErrorContains(t, err, "broker create")
+	util.ContainsAll(err.Error(), "broker create", "requires", "name", "argument")
+}

--- a/pkg/kn/commands/broker/create_test.go
+++ b/pkg/kn/commands/broker/create_test.go
@@ -1,16 +1,18 @@
-// Copyright © 2020 The Knative Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package broker
 

--- a/pkg/kn/commands/broker/delete.go
+++ b/pkg/kn/commands/broker/delete.go
@@ -37,7 +37,7 @@ func NewBrokerDeleteCommand(p *commands.KnParams) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "delete NAME",
-		Short:   "Delete a broker.",
+		Short:   "Delete a broker",
 		Example: deleteExample,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {

--- a/pkg/kn/commands/broker/delete.go
+++ b/pkg/kn/commands/broker/delete.go
@@ -29,6 +29,7 @@ import (
 var deleteExample = `
 # Delete a broker 'mybroker' in the current namespace
   kn broker create mybroker
+  
 # Delete a broker 'mybroker' in the 'myproject' namespace
   kn broker create mybroker --namespace myproject
 `

--- a/pkg/kn/commands/broker/delete.go
+++ b/pkg/kn/commands/broker/delete.go
@@ -27,12 +27,11 @@ import (
 )
 
 var deleteExample = `
-# Delete a broker 'mybroker' in the current namespace
+  # Delete a broker 'mybroker' in the current namespace
   kn broker create mybroker
 
-# Delete a broker 'mybroker' in the 'myproject' namespace
-  kn broker create mybroker --namespace myproject
-`
+  # Delete a broker 'mybroker' in the 'myproject' namespace
+  kn broker create mybroker --namespace myproject`
 
 // NewBrokerDeleteCommand represents command to existing delete broker
 func NewBrokerDeleteCommand(p *commands.KnParams) *cobra.Command {

--- a/pkg/kn/commands/broker/delete.go
+++ b/pkg/kn/commands/broker/delete.go
@@ -25,19 +25,20 @@ import (
 	"knative.dev/client/pkg/kn/commands"
 )
 
-var delete_example = `
+var deleteExample = `
 # Delete a broker 'mybroker' in the current namespace
   kn broker create mybroker
 # Delete a broker 'mybroker' in the 'myproject' namespace
   kn broker create mybroker --namespace myproject
 `
 
+// NewBrokerDeleteCommand represents command to existing delete broker
 func NewBrokerDeleteCommand(p *commands.KnParams) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "delete NAME",
 		Short:   "Delete a broker.",
-		Example: delete_example,
+		Example: deleteExample,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {
 				return errors.New("'broker delete' requires the broker name given as single argument")

--- a/pkg/kn/commands/broker/delete.go
+++ b/pkg/kn/commands/broker/delete.go
@@ -1,0 +1,67 @@
+// Copyright © 2020 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package broker
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"knative.dev/client/pkg/kn/commands"
+)
+
+var delete_example = `
+# Delete a broker 'mybroker' in the current namespace
+  kn broker create mybroker
+# Delete a broker 'mybroker' in the 'myproject' namespace
+  kn broker create mybroker --namespace myproject
+`
+
+func NewBrokerDeleteCommand(p *commands.KnParams) *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:     "delete NAME",
+		Short:   "Delete a broker.",
+		Example: delete_example,
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			if len(args) != 1 {
+				return errors.New("'broker delete' requires the broker name given as single argument")
+			}
+			name := args[0]
+
+			namespace, err := p.GetNamespace(cmd)
+			if err != nil {
+				return err
+			}
+
+			eventingClient, err := p.NewEventingClient(namespace)
+			if err != nil {
+				return err
+			}
+
+			err = eventingClient.DeleteBroker(name)
+			if err != nil {
+				return fmt.Errorf(
+					"cannot delete broker '%s' in namespace '%s' "+
+						"because: %s", name, namespace, err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Broker '%s' successfully deleted in namespace '%s'.\n", args[0], namespace)
+			return nil
+		},
+	}
+	commands.AddNamespaceFlags(cmd.Flags(), false)
+	return cmd
+}

--- a/pkg/kn/commands/broker/delete.go
+++ b/pkg/kn/commands/broker/delete.go
@@ -29,7 +29,7 @@ import (
 var deleteExample = `
 # Delete a broker 'mybroker' in the current namespace
   kn broker create mybroker
-  
+
 # Delete a broker 'mybroker' in the 'myproject' namespace
   kn broker create mybroker --namespace myproject
 `

--- a/pkg/kn/commands/broker/delete.go
+++ b/pkg/kn/commands/broker/delete.go
@@ -1,16 +1,18 @@
-// Copyright © 2020 The Knative Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package broker
 

--- a/pkg/kn/commands/broker/delete_test.go
+++ b/pkg/kn/commands/broker/delete_test.go
@@ -24,6 +24,7 @@ import (
 
 	clienteventingv1beta1 "knative.dev/client/pkg/eventing/v1beta1"
 	"knative.dev/client/pkg/util"
+	"knative.dev/client/pkg/util/mock"
 )
 
 func TestBrokerDelete(t *testing.T) {
@@ -31,7 +32,7 @@ func TestBrokerDelete(t *testing.T) {
 	eventingClient := clienteventingv1beta1.NewMockKnEventingClient(t)
 
 	eventingRecorder := eventingClient.Recorder()
-	eventingRecorder.DeleteBroker(brokerName, nil)
+	eventingRecorder.DeleteBroker(brokerName, mock.Any(), nil)
 
 	out, err := executeBrokerCommand(eventingClient, "delete", brokerName)
 	assert.NilError(t, err, "Broker should be deleted")
@@ -45,7 +46,7 @@ func TestBrokerWithDelete(t *testing.T) {
 	eventingClient := clienteventingv1beta1.NewMockKnEventingClient(t)
 
 	eventingRecorder := eventingClient.Recorder()
-	eventingRecorder.DeleteBroker(brokerName, fmt.Errorf("broker %s not found", brokerName))
+	eventingRecorder.DeleteBroker(brokerName, mock.Any(), fmt.Errorf("broker %s not found", brokerName))
 
 	out, err := executeBrokerCommand(eventingClient, "delete", brokerName)
 	assert.ErrorContains(t, err, brokerName)

--- a/pkg/kn/commands/broker/delete_test.go
+++ b/pkg/kn/commands/broker/delete_test.go
@@ -1,0 +1,53 @@
+// Copyright © 2020 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package broker
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/assert"
+
+	clienteventingv1beta1 "knative.dev/client/pkg/eventing/v1beta1"
+	"knative.dev/client/pkg/util"
+)
+
+func TestBrokerDelete(t *testing.T) {
+	brokerName := "foo"
+	eventingClient := clienteventingv1beta1.NewMockKnEventingClient(t)
+
+	eventingRecorder := eventingClient.Recorder()
+	eventingRecorder.DeleteBroker(brokerName, nil)
+
+	out, err := executeBrokerCommand(eventingClient, "delete", brokerName)
+	assert.NilError(t, err, "Broker should be deleted")
+	util.ContainsAll(out, "Broker", brokerName, "deleted", "namespace", "default")
+
+	eventingRecorder.Validate()
+}
+
+func TestBrokerWithDelete(t *testing.T) {
+	brokerName := "foo"
+	eventingClient := clienteventingv1beta1.NewMockKnEventingClient(t)
+
+	eventingRecorder := eventingClient.Recorder()
+	eventingRecorder.DeleteBroker(brokerName, fmt.Errorf("broker %s not found", brokerName))
+
+	out, err := executeBrokerCommand(eventingClient, "delete", brokerName)
+	assert.ErrorContains(t, err, brokerName)
+	util.ContainsAll(out, "broker", brokerName, "not found")
+
+	eventingRecorder.Validate()
+}

--- a/pkg/kn/commands/broker/delete_test.go
+++ b/pkg/kn/commands/broker/delete_test.go
@@ -1,16 +1,18 @@
-// Copyright © 2020 The Knative Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package broker
 

--- a/pkg/kn/commands/broker/describe.go
+++ b/pkg/kn/commands/broker/describe.go
@@ -31,6 +31,7 @@ import (
 var describeExample = `
   # Describe broker 'mybroker' in the current namespace
   kn broker describe mybroker
+  
   # Describe broker 'mybroker' in the 'myproject' namespace
   kn broker describe mybroker --namespace myproject`
 

--- a/pkg/kn/commands/broker/describe.go
+++ b/pkg/kn/commands/broker/describe.go
@@ -29,11 +29,10 @@ import (
 )
 
 var describeExample = `
-# Describe broker 'mybroker' in the current namespace
+  # Describe broker 'mybroker' in the current namespace
   kn broker describe mybroker
-# # Describe broker 'mybroker' in the 'myproject' namespace
-  kn broker describe mybroker --namespace myproject
-`
+  # Describe broker 'mybroker' in the 'myproject' namespace
+  kn broker describe mybroker --namespace myproject`
 
 // NewBrokerDescribeCommand represents command to describe details of broker instance
 func NewBrokerDescribeCommand(p *commands.KnParams) *cobra.Command {

--- a/pkg/kn/commands/broker/describe.go
+++ b/pkg/kn/commands/broker/describe.go
@@ -31,7 +31,7 @@ import (
 var describeExample = `
   # Describe broker 'mybroker' in the current namespace
   kn broker describe mybroker
-  
+
   # Describe broker 'mybroker' in the 'myproject' namespace
   kn broker describe mybroker --namespace myproject`
 

--- a/pkg/kn/commands/broker/describe.go
+++ b/pkg/kn/commands/broker/describe.go
@@ -40,7 +40,7 @@ func NewBrokerDescribeCommand(p *commands.KnParams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "describe NAME",
 		Short:   "Describe broker",
-		Example: createExample,
+		Example: describeExample,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {
 				return errors.New("'broker describe' requires the broker name given as single argument")

--- a/pkg/kn/commands/broker/describe.go
+++ b/pkg/kn/commands/broker/describe.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package broker
+
+import (
+	"errors"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	v1beta1 "knative.dev/eventing/pkg/apis/eventing/v1beta1"
+
+	"knative.dev/client/pkg/kn/commands"
+	"knative.dev/client/pkg/printers"
+)
+
+var describeExample = `
+# Describe broker 'mybroker' in the current namespace
+  kn broker describe mybroker
+# # Describe broker 'mybroker' in the 'myproject' namespace
+  kn broker describe mybroker --namespace myproject
+`
+
+// NewBrokerDescribeCommand represents command to describe details of broker instance
+func NewBrokerDescribeCommand(p *commands.KnParams) *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:     "describe NAME",
+		Short:   "Describe broker",
+		Example: createExample,
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			if len(args) != 1 {
+				return errors.New("'broker describe' requires the broker name given as single argument")
+			}
+			name := args[0]
+
+			namespace, err := p.GetNamespace(cmd)
+			if err != nil {
+				return err
+			}
+
+			eventingClient, err := p.NewEventingClient(namespace)
+			if err != nil {
+				return err
+			}
+
+			broker, err := eventingClient.GetBroker(name)
+			if err != nil {
+				return err
+			}
+			return describeBroker(cmd.OutOrStdout(), broker, false)
+		},
+	}
+	commands.AddNamespaceFlags(cmd.Flags(), false)
+	return cmd
+}
+
+// describeBroker print broker details to the provided output writer
+func describeBroker(out io.Writer, broker *v1beta1.Broker, printDetails bool) error {
+	dw := printers.NewPrefixWriter(out)
+	commands.WriteMetadata(dw, &broker.ObjectMeta, printDetails)
+	dw.WriteLine()
+	dw.WriteAttribute("Address", "").WriteAttribute("URL", broker.Status.Address.URL.String())
+	dw.WriteLine()
+	commands.WriteConditions(dw, broker.Status.Conditions, printDetails)
+	if err := dw.Flush(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/kn/commands/broker/describe_test.go
+++ b/pkg/kn/commands/broker/describe_test.go
@@ -1,0 +1,76 @@
+// Copyright © 2019 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package broker
+
+import (
+	"errors"
+	"testing"
+
+	"gotest.tools/assert"
+	"gotest.tools/assert/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1beta1 "knative.dev/eventing/pkg/apis/eventing/v1beta1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	clientv1beta1 "knative.dev/client/pkg/eventing/v1beta1"
+	"knative.dev/client/pkg/util"
+)
+
+func TestBrokerDescribe(t *testing.T) {
+	client := clientv1beta1.NewMockKnEventingClient(t, "mynamespace")
+
+	recorder := client.Recorder()
+	recorder.GetBroker("foo", getBroker(), nil)
+
+	out, err := executeBrokerCommand(client, "describe", "foo")
+	assert.NilError(t, err)
+
+	assert.Assert(t, cmp.Regexp("Name:\\s+foo", out))
+	assert.Assert(t, cmp.Regexp("Namespace:\\s+default", out))
+
+	assert.Assert(t, util.ContainsAll(out, "Address:", "URL:", "http://foo-broker.test"))
+
+	// Validate that all recorded API methods have been called
+	recorder.Validate()
+}
+
+func TestDescribeError(t *testing.T) {
+	client := clientv1beta1.NewMockKnEventingClient(t, "mynamespace")
+
+	recorder := client.Recorder()
+	recorder.GetBroker("foo", nil, errors.New("brokers.eventing.knative.dev 'foo' not found"))
+
+	_, err := executeBrokerCommand(client, "describe", "foo")
+	assert.ErrorContains(t, err, "foo", "not found")
+
+	recorder.Validate()
+}
+
+func getBroker() *v1beta1.Broker {
+	return &v1beta1.Broker{
+		TypeMeta: v1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+		Status: v1beta1.BrokerStatus{
+			Address: duckv1.Addressable{
+				URL: &apis.URL{Scheme: "http", Host: "foo-broker.test"},
+			},
+		},
+	}
+}

--- a/pkg/kn/commands/broker/describe_test.go
+++ b/pkg/kn/commands/broker/describe_test.go
@@ -1,16 +1,18 @@
-// Copyright © 2019 The Knative Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package broker
 

--- a/pkg/kn/commands/broker/describe_test.go
+++ b/pkg/kn/commands/broker/describe_test.go
@@ -18,6 +18,7 @@ package broker
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"gotest.tools/assert"
@@ -45,6 +46,16 @@ func TestBrokerDescribe(t *testing.T) {
 	assert.Assert(t, cmp.Regexp("Namespace:\\s+default", out))
 
 	assert.Assert(t, util.ContainsAll(out, "Address:", "URL:", "http://foo-broker.test"))
+	assert.Assert(t, util.ContainsAll(out, "Conditions:", "Ready"))
+
+	// There're 2 empty lines used in the "describe" formatting
+	lineCounter := 0
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line == "" {
+			lineCounter++
+		}
+	}
+	assert.Equal(t, lineCounter, 2)
 
 	// Validate that all recorded API methods have been called
 	recorder.Validate()
@@ -72,6 +83,14 @@ func getBroker() *v1beta1.Broker {
 		Status: v1beta1.BrokerStatus{
 			Address: duckv1.Addressable{
 				URL: &apis.URL{Scheme: "http", Host: "foo-broker.test"},
+			},
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{
+					apis.Condition{
+						Type:   "Ready",
+						Status: "True",
+					},
+				},
 			},
 		},
 	}

--- a/pkg/kn/commands/broker/list.go
+++ b/pkg/kn/commands/broker/list.go
@@ -31,12 +31,11 @@ import (
 )
 
 var listExample = `
-# List all brokers
+  # List all brokers
   kn broker list
 
-# List all brokers in JSON output format
-  kn broker list -o json
-`
+  # List all brokers in JSON output format
+  kn broker list -o json`
 
 // NewBrokerListCommand represents command to list all brokers
 func NewBrokerListCommand(p *commands.KnParams) *cobra.Command {

--- a/pkg/kn/commands/broker/list.go
+++ b/pkg/kn/commands/broker/list.go
@@ -43,7 +43,7 @@ func NewBrokerListCommand(p *commands.KnParams) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "list",
-		Short:   "List brokers.",
+		Short:   "List brokers",
 		Example: listExample,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			namespace, err := p.GetNamespace(cmd)

--- a/pkg/kn/commands/broker/list.go
+++ b/pkg/kn/commands/broker/list.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package broker
 
 import (
@@ -39,7 +40,7 @@ var listExample = `
 
 // NewBrokerListCommand represents command to list all brokers
 func NewBrokerListCommand(p *commands.KnParams) *cobra.Command {
-	brokerListFlags := flags.NewListPrintFlags(BrokerListHandlers)
+	brokerListFlags := flags.NewListPrintFlags(ListHandlers)
 
 	cmd := &cobra.Command{
 		Use:     "list",
@@ -82,8 +83,8 @@ func NewBrokerListCommand(p *commands.KnParams) *cobra.Command {
 	return cmd
 }
 
-// BrokerListHandlers handles printing human readable table for `kn broker list` command's output
-func BrokerListHandlers(h hprinters.PrintHandler) {
+// ListHandlers handles printing human readable table for `kn broker list` command's output
+func ListHandlers(h hprinters.PrintHandler) {
 	brokerColumnDefinitions := []metav1beta1.TableColumnDefinition{
 		{Name: "Namespace", Type: "string", Description: "Namespace of the Broker instance", Priority: 0},
 		{Name: "Name", Type: "string", Description: "Name of the Broker instance", Priority: 1},

--- a/pkg/kn/commands/broker/list.go
+++ b/pkg/kn/commands/broker/list.go
@@ -1,17 +1,18 @@
-// Copyright © 2020 The Knative Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2020 The Knative Authors
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package broker
 
 import (

--- a/pkg/kn/commands/broker/list.go
+++ b/pkg/kn/commands/broker/list.go
@@ -1,0 +1,137 @@
+// Copyright © 2020 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package broker
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"knative.dev/client/pkg/kn/commands"
+	"knative.dev/client/pkg/kn/commands/flags"
+	hprinters "knative.dev/client/pkg/printers"
+	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
+)
+
+var list_example = `
+# List all brokers
+  kn broker list
+
+# List all brokers in JSON output format
+  kn broker list -o json
+`
+
+func NewBrokerListCommand(p *commands.KnParams) *cobra.Command {
+	brokerListFlags := flags.NewListPrintFlags(BrokerListHandlers)
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List brokers.",
+		Example: list_example,
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			namespace, err := p.GetNamespace(cmd)
+			if err != nil {
+				return err
+			}
+
+			eventingClient, err := p.NewEventingClient(namespace)
+			if err != nil {
+				return err
+			}
+
+			brokerList, err := eventingClient.ListBrokers()
+			if err != nil {
+				return err
+			}
+			if len(brokerList.Items) == 0 {
+				fmt.Fprintf(cmd.OutOrStdout(), "No brokers found.\n")
+				return nil
+			}
+
+			// empty namespace indicates all-namespaces flag is specified
+			if namespace == "" {
+				brokerListFlags.EnsureWithNamespace()
+			}
+
+			err = brokerListFlags.Print(brokerList, cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	commands.AddNamespaceFlags(cmd.Flags(), true)
+	brokerListFlags.AddFlags(cmd)
+	return cmd
+}
+
+// BrokerListHandlers handles printing human readable table for `kn broker list` command's output
+func BrokerListHandlers(h hprinters.PrintHandler) {
+	brokerColumnDefinitions := []metav1beta1.TableColumnDefinition{
+		{Name: "Namespace", Type: "string", Description: "Namespace of the Broker instance", Priority: 0},
+		{Name: "Name", Type: "string", Description: "Name of the Broker instance", Priority: 1},
+		{Name: "URL", Type: "string", Description: "URL of the Broker instance", Priority: 1},
+		{Name: "Age", Type: "string", Description: "Age of the Broker instance", Priority: 1},
+		{Name: "Conditions", Type: "string", Description: "Ready state conditions", Priority: 1},
+		{Name: "Ready", Type: "string", Description: "Ready state of the Broker instance", Priority: 1},
+		{Name: "Reason", Type: "string", Description: "Reason if state is not Ready", Priority: 1},
+	}
+	h.TableHandler(brokerColumnDefinitions, printBroker)
+	h.TableHandler(brokerColumnDefinitions, printBrokerList)
+}
+
+// printBrokerList populates the broker list table rows
+func printBrokerList(kServiceList *v1beta1.BrokerList, options hprinters.PrintOptions) ([]metav1beta1.TableRow, error) {
+	rows := make([]metav1beta1.TableRow, 0, len(kServiceList.Items))
+
+	for _, ksvc := range kServiceList.Items {
+		r, err := printBroker(&ksvc, options)
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, r...)
+	}
+	return rows, nil
+}
+
+// printBroker populates the broker table rows
+func printBroker(broker *v1beta1.Broker, options hprinters.PrintOptions) ([]metav1beta1.TableRow, error) {
+	name := broker.Name
+	url := broker.Status.Address.URL
+	age := commands.TranslateTimestampSince(broker.CreationTimestamp)
+	conditions := commands.ConditionsValue(broker.Status.Conditions)
+	ready := commands.ReadyCondition(broker.Status.Conditions)
+	reason := commands.NonReadyConditionReason(broker.Status.Conditions)
+
+	row := metav1beta1.TableRow{
+		Object: runtime.RawExtension{Object: broker},
+	}
+
+	if options.AllNamespaces {
+		row.Cells = append(row.Cells, broker.Namespace)
+	}
+
+	row.Cells = append(row.Cells,
+		name,
+		url,
+		age,
+		conditions,
+		ready,
+		reason)
+	return []metav1beta1.TableRow{row}, nil
+}

--- a/pkg/kn/commands/broker/list.go
+++ b/pkg/kn/commands/broker/list.go
@@ -29,7 +29,7 @@ import (
 	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
 )
 
-var list_example = `
+var listExample = `
 # List all brokers
   kn broker list
 
@@ -37,13 +37,14 @@ var list_example = `
   kn broker list -o json
 `
 
+// NewBrokerListCommand represents command to list all brokers
 func NewBrokerListCommand(p *commands.KnParams) *cobra.Command {
 	brokerListFlags := flags.NewListPrintFlags(BrokerListHandlers)
 
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "List brokers.",
-		Example: list_example,
+		Example: listExample,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			namespace, err := p.GetNamespace(cmd)
 			if err != nil {

--- a/pkg/kn/commands/broker/list_test.go
+++ b/pkg/kn/commands/broker/list_test.go
@@ -1,0 +1,82 @@
+// Copyright © 2020 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package broker
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/assert"
+
+	clienteventingv1beta1 "knative.dev/client/pkg/eventing/v1beta1"
+	"knative.dev/client/pkg/util"
+	v1beta1 "knative.dev/eventing/pkg/apis/eventing/v1beta1"
+)
+
+func TestBrokerList(t *testing.T) {
+	eventingClient := clienteventingv1beta1.NewMockKnEventingClient(t)
+	eventingRecorder := eventingClient.Recorder()
+
+	broker1 := createBroker("foo1")
+	broker2 := createBroker("foo2")
+	broker3 := createBroker("foo3")
+	brokerList := &v1beta1.BrokerList{Items: []v1beta1.Broker{*broker1, *broker2, *broker3}}
+	eventingRecorder.ListBrokers(brokerList, nil)
+
+	output, err := executeBrokerCommand(eventingClient, "list")
+	assert.NilError(t, err)
+
+	outputLines := strings.Split(output, "\n")
+	assert.Check(t, util.ContainsAll(outputLines[0], "NAME", "URL", "AGE", "CONDITIONS", "READY", "REASON"))
+	assert.Check(t, util.ContainsAll(outputLines[1], "foo1"))
+	assert.Check(t, util.ContainsAll(outputLines[2], "foo2"))
+	assert.Check(t, util.ContainsAll(outputLines[3], "foo3"))
+
+	eventingRecorder.Validate()
+}
+
+func TestBrokerListEmpty(t *testing.T) {
+	eventingClient := clienteventingv1beta1.NewMockKnEventingClient(t)
+	eventingRecorder := eventingClient.Recorder()
+
+	eventingRecorder.ListBrokers(&v1beta1.BrokerList{}, nil)
+	output, err := executeBrokerCommand(eventingClient, "list")
+	assert.NilError(t, err)
+	assert.Assert(t, util.ContainsAll(output, "No", "brokers", "found"))
+
+	eventingRecorder.Validate()
+}
+
+func TestTriggerListAllNamespace(t *testing.T) {
+	eventingClient := clienteventingv1beta1.NewMockKnEventingClient(t)
+	eventingRecorder := eventingClient.Recorder()
+
+	broker1 := createBrokerWithNamespace("foo1", "default1")
+	broker2 := createBrokerWithNamespace("foo2", "default2")
+	broker3 := createBrokerWithNamespace("foo3", "default3")
+	brokerList := &v1beta1.BrokerList{Items: []v1beta1.Broker{*broker1, *broker2, *broker3}}
+	eventingRecorder.ListBrokers(brokerList, nil)
+
+	output, err := executeBrokerCommand(eventingClient, "list", "--all-namespaces")
+	assert.NilError(t, err)
+
+	outputLines := strings.Split(output, "\n")
+	assert.Check(t, util.ContainsAll(outputLines[0], "NAMESPACE", "NAME", "AGE", "CONDITIONS", "READY", "REASON"))
+	assert.Check(t, util.ContainsAll(outputLines[1], "default1", "foo1"))
+	assert.Check(t, util.ContainsAll(outputLines[2], "default2", "foo2"))
+	assert.Check(t, util.ContainsAll(outputLines[3], "default3", "foo3"))
+
+	eventingRecorder.Validate()
+}

--- a/pkg/kn/commands/broker/list_test.go
+++ b/pkg/kn/commands/broker/list_test.go
@@ -1,16 +1,18 @@
-// Copyright © 2020 The Knative Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package broker
 

--- a/pkg/kn/root/root.go
+++ b/pkg/kn/root/root.go
@@ -25,6 +25,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
 	"knative.dev/client/pkg/kn/commands"
+	"knative.dev/client/pkg/kn/commands/broker"
 	"knative.dev/client/pkg/kn/commands/completion"
 	"knative.dev/client/pkg/kn/commands/options"
 	"knative.dev/client/pkg/kn/commands/plugin"
@@ -88,6 +89,7 @@ func NewRootCommand() (*cobra.Command, error) {
 		{
 			Header: "Eventing Commands:",
 			Commands: []*cobra.Command{
+				broker.NewBrokerCommand(p),
 				source.NewSourceCommand(p),
 				trigger.NewTriggerCommand(p),
 			},

--- a/pkg/kn/root/root.go
+++ b/pkg/kn/root/root.go
@@ -89,8 +89,8 @@ func NewRootCommand() (*cobra.Command, error) {
 		{
 			Header: "Eventing Commands:",
 			Commands: []*cobra.Command{
-				broker.NewBrokerCommand(p),
 				source.NewSourceCommand(p),
+				broker.NewBrokerCommand(p),
 				trigger.NewTriggerCommand(p),
 			},
 		},

--- a/test/e2e/broker_test.go
+++ b/test/e2e/broker_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+// +build e2e
+// +build !serving
+
+package e2e
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+
+	"knative.dev/client/lib/test"
+	"knative.dev/client/pkg/util"
+)
+
+func TestBroker(t *testing.T) {
+	t.Parallel()
+	it, err := test.NewKnTest()
+	assert.NilError(t, err)
+	defer func() {
+		assert.NilError(t, it.Teardown())
+	}()
+
+	r := test.NewKnRunResultCollector(t, it)
+	defer r.DumpIfFailed()
+
+	t.Log("create broker, list and describe it")
+	brokerCreate(r, "foo1")
+	verifyBrokerList(r, "foo1")
+	verifyBrokerListOutputName(r, "foo1")
+	verifyBrokerDescribe(r, "foo1")
+	brokerDelete(r, "foo1")
+
+	t.Log("create broker and delete it")
+	brokerCreate(r, "foo2")
+	verifyBrokerList(r, "foo2")
+	brokerDelete(r, "foo2")
+	verifyBrokerNotfound(r, "foo2")
+
+	t.Log("create multiple brokers and list them")
+	brokerCreate(r, "foo3")
+	brokerCreate(r, "foo4")
+	verifyBrokerList(r, "foo3", "foo4")
+	verifyBrokerListOutputName(r, "foo3", "foo4")
+	brokerDelete(r, "foo3")
+	verifyBrokerNotfound(r, "foo3")
+	brokerDelete(r, "foo4")
+	verifyBrokerNotfound(r, "foo4")
+}
+
+// Private functions
+
+func brokerCreate(r *test.KnRunResultCollector, name string) {
+	out := r.KnTest().Kn().Run("broker", "create", name)
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "Broker", name, "created", "namespace", r.KnTest().Kn().Namespace()))
+}
+
+func brokerDelete(r *test.KnRunResultCollector, name string) {
+	out := r.KnTest().Kn().Run("broker", "delete", name)
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "Broker", name, "deleted", "namespace", r.KnTest().Kn().Namespace()))
+}
+
+func verifyBrokerList(r *test.KnRunResultCollector, brokers ...string) {
+	out := r.KnTest().Kn().Run("broker", "list")
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, brokers...))
+}
+
+func verifyBrokerListOutputName(r *test.KnRunResultCollector, broker ...string) {
+	out := r.KnTest().Kn().Run("broker", "list", "--output", "name")
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, broker...))
+}
+
+func verifyBrokerDescribe(r *test.KnRunResultCollector, name string) {
+	out := r.KnTest().Kn().Run("broker", "describe", name)
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, name, "Address:", "URL:", "Conditions:"))
+}
+
+func verifyBrokerNotfound(r *test.KnRunResultCollector, name string) {
+	out := r.KnTest().Kn().Run("broker", "describe", name)
+	r.AssertError(out)
+	assert.Check(r.T(), util.ContainsAll(out.Stderr, name, "not found"))
+}

--- a/test/e2e/broker_test.go
+++ b/test/e2e/broker_test.go
@@ -56,8 +56,8 @@ func TestBroker(t *testing.T) {
 	verifyBrokerList(r, "foo3", "foo4")
 	verifyBrokerListOutputName(r, "foo3", "foo4")
 	brokerDelete(r, "foo3")
-	verifyBrokerNotfound(r, "foo3")
 	brokerDelete(r, "foo4")
+	verifyBrokerNotfound(r, "foo3")
 	verifyBrokerNotfound(r, "foo4")
 }
 

--- a/test/e2e/broker_test.go
+++ b/test/e2e/broker_test.go
@@ -42,12 +42,12 @@ func TestBroker(t *testing.T) {
 	verifyBrokerList(r, "foo1")
 	verifyBrokerListOutputName(r, "foo1")
 	verifyBrokerDescribe(r, "foo1")
-	brokerDelete(r, "foo1")
+	brokerDelete(r, "foo1", false)
 
 	t.Log("create broker and delete it")
 	brokerCreate(r, "foo2")
 	verifyBrokerList(r, "foo2")
-	brokerDelete(r, "foo2")
+	brokerDelete(r, "foo2", true)
 	verifyBrokerNotfound(r, "foo2")
 
 	t.Log("create multiple brokers and list them")
@@ -55,8 +55,8 @@ func TestBroker(t *testing.T) {
 	brokerCreate(r, "foo4")
 	verifyBrokerList(r, "foo3", "foo4")
 	verifyBrokerListOutputName(r, "foo3", "foo4")
-	brokerDelete(r, "foo3")
-	brokerDelete(r, "foo4")
+	brokerDelete(r, "foo3", true)
+	brokerDelete(r, "foo4", true)
 	verifyBrokerNotfound(r, "foo3")
 	verifyBrokerNotfound(r, "foo4")
 }
@@ -69,8 +69,12 @@ func brokerCreate(r *test.KnRunResultCollector, name string) {
 	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "Broker", name, "created", "namespace", r.KnTest().Kn().Namespace()))
 }
 
-func brokerDelete(r *test.KnRunResultCollector, name string) {
-	out := r.KnTest().Kn().Run("broker", "delete", name)
+func brokerDelete(r *test.KnRunResultCollector, name string, wait bool) {
+	args := []string{"broker", "delete", name}
+	if wait {
+		args = append(args, "--wait")
+	}
+	out := r.KnTest().Kn().Run(args...)
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "Broker", name, "deleted", "namespace", r.KnTest().Kn().Namespace()))
 }

--- a/test/e2e/broker_test.go
+++ b/test/e2e/broker_test.go
@@ -1,18 +1,17 @@
-/*
-Copyright 2020 The Knative Authors
+// Copyright 2020 The Knative Authors
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build e2e
 // +build !serving
 


### PR DESCRIPTION
## Description

Since the Eventing `0.15` multitenant broker is the new default. MT Broker is easier to manage from user's namespace because there're no more requirements for additional permission as majority of broker deployment is installed in `knative-eventing` namespace. This PR adds commands to manage broker CR. 

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Add `broker create`, `broker delete`, `broker list` commands


Note 1: E2E are missing right now, I'm currently working on them.

Note 2: I haven't added `update` operation since the current impl only creates Broker CR with a name without additional specs.

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #

<!--
Please add an entrty to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
