### PR TITLE
Refer broker from v1beta1 APIs and add missing e2e tests

### DIFF
--- a/lib/test/broker.go
+++ b/lib/test/broker.go
@@ -1,0 +1,49 @@
+// Copyright 2020 The Knative Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or im
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// LabelNamespaceForDefaultBroker adds label 'knative-eventing-injection=enabled' to the configured namespace
+func LabelNamespaceForDefaultBroker(r *KnRunResultCollector) error {
+	_, err := Kubectl{}.Run("label", "namespace", r.KnTest().Kn().Namespace(), "knative-eventing-injection=enabled")
+	r
+
+	if err != nil {
+		r.T().Fatalf("Error executing 'kubectl label namespace %s knative-eventing-injection=enabled'. Error: %s", r.KnTest().Kn().Namespace(), err.Error())
+	}
+
+	return wait.PollImmediate(10*time.Second, 5*time.Minute, func() (bool, error) {
+		out, err := NewKubectl(r.KnTest().Kn().Namespace()).Run("get", "broker", "-o=jsonpath='{.items[0].status.conditions[?(@.type==\"Ready\")].status}'")
+		if err != nil {
+			return false, nil
+		}
+
+		return strings.Contains(out, "True"), nil
+	})
+}
+
+// UnlabelNamespaceForDefaultBroker removes label 'knative-eventing-injection=enabled' from the configured namespace
+func UnlabelNamespaceForDefaultBroker(r *KnRunResultCollector) {
+	_, err := Kubectl{}.Run("label", "namespace", r.KnTest().Kn().Namespace(), "knative-eventing-injection-")
+	if err != nil {
+		t.Fatalf("Error executing 'kubectl label namespace %s knative-eventing-injection-'. Error: %s", r.KnTest().Kn().Namespace(), err.Error())
+	}
+}

--- a/lib/test/broker.go
+++ b/lib/test/broker.go
@@ -24,7 +24,6 @@ import (
 // LabelNamespaceForDefaultBroker adds label 'knative-eventing-injection=enabled' to the configured namespace
 func LabelNamespaceForDefaultBroker(r *KnRunResultCollector) error {
 	_, err := Kubectl{}.Run("label", "namespace", r.KnTest().Kn().Namespace(), "knative-eventing-injection=enabled")
-	r
 
 	if err != nil {
 		r.T().Fatalf("Error executing 'kubectl label namespace %s knative-eventing-injection=enabled'. Error: %s", r.KnTest().Kn().Namespace(), err.Error())
@@ -44,6 +43,6 @@ func LabelNamespaceForDefaultBroker(r *KnRunResultCollector) error {
 func UnlabelNamespaceForDefaultBroker(r *KnRunResultCollector) {
 	_, err := Kubectl{}.Run("label", "namespace", r.KnTest().Kn().Namespace(), "knative-eventing-injection-")
 	if err != nil {
-		t.Fatalf("Error executing 'kubectl label namespace %s knative-eventing-injection-'. Error: %s", r.KnTest().Kn().Namespace(), err.Error())
+		r.T().Fatalf("Error executing 'kubectl label namespace %s knative-eventing-injection-'. Error: %s", r.KnTest().Kn().Namespace(), err.Error())
 	}
 }

--- a/pkg/dynamic/fake/fake.go
+++ b/pkg/dynamic/fake/fake.go
@@ -29,7 +29,7 @@ import (
 func CreateFakeKnDynamicClient(testNamespace string, objects ...runtime.Object) dynamic.KnDynamicClient {
 	scheme := runtime.NewScheme()
 	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "serving.knative.dev", Version: "v1", Kind: "Service"}, &servingv1.Service{})
-	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "eventing.knative.dev", Version: "v1alpha1", Kind: "Broker"}, &eventingv1beta1.Broker{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "eventing.knative.dev", Version: "v1beta1", Kind: "Broker"}, &eventingv1beta1.Broker{})
 	client := dynamicfake.NewSimpleDynamicClient(scheme, objects...)
 	return dynamic.NewKnDynamicClient(client, testNamespace)
 }

--- a/pkg/kn/commands/flags/sink.go
+++ b/pkg/kn/commands/flags/sink.go
@@ -50,7 +50,7 @@ var sinkMappings = map[string]schema.GroupVersionResource{
 	"broker": {
 		Resource: "brokers",
 		Group:    "eventing.knative.dev",
-		Version:  "v1alpha1",
+		Version:  "v1beta1",
 	},
 	"service": {
 		Resource: "services",

--- a/pkg/kn/commands/flags/sink_test.go
+++ b/pkg/kn/commands/flags/sink_test.go
@@ -40,7 +40,7 @@ func TestResolve(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "mysvc", Namespace: "default"},
 	}
 	defaultBroker := &eventingv1beta1.Broker{
-		TypeMeta:   metav1.TypeMeta{Kind: "Broker", APIVersion: "eventing.knative.dev/v1alpha1"},
+		TypeMeta:   metav1.TypeMeta{Kind: "Broker", APIVersion: "eventing.knative.dev/v1beta1"},
 		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "default"},
 	}
 
@@ -59,7 +59,7 @@ func TestResolve(t *testing.T) {
 		{"svc:absent", nil, "\"absent\" not found"},
 		{"broker:default", &duckv1.Destination{
 			Ref: &duckv1.KReference{Kind: "Broker",
-				APIVersion: "eventing.knative.dev/v1alpha1",
+				APIVersion: "eventing.knative.dev/v1beta1",
 				Namespace:  "default",
 				Name:       "default"}}, ""},
 		{"http://target.example.com", &duckv1.Destination{

--- a/test/e2e/sink_test.go
+++ b/test/e2e/sink_test.go
@@ -1,0 +1,54 @@
+// Copyright 2020 The Knative Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or im
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build e2e
+// +build !serving
+
+package e2e
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+
+	"knative.dev/client/lib/test"
+)
+
+func TestSink(t *testing.T) {
+	t.Parallel()
+	it, err := test.NewKnTest()
+	assert.NilError(t, err)
+	defer func() {
+		assert.NilError(t, it.Teardown())
+	}()
+
+	r := test.NewKnRunResultCollector(t, it)
+	defer r.DumpIfFailed()
+
+	// create broker
+	err = test.LabelNamespaceForDefaultBroker(r)
+	assert.NilError(t, err)
+	defer test.UnlabelNamespaceForDefaultBroker(r)
+
+	t.Log("Create Ping source with a sink to the default broker")
+	pingSourceCreate(r, "testpingsource0", "* * * * */1", "ping", "broker:default")
+
+	jpSinkRefNameInSpec := "jsonpath={.spec.sink.ref.name}"
+	out, err := test.GetResourceFieldsWithJSONPath(t, it, "pingsource", "testpingsource0", jpSinkRefNameInSpec)
+	assert.NilError(t, err)
+	assert.Equal(t, out, "default")
+
+	t.Log("delete Ping sources")
+	pingSourceDelete(r, "testpingsource0")
+}


### PR DESCRIPTION
## Description
- Broker is now moved to v1beta1 APIs, while we were referring it from `v1alpha1`
https://github.com/knative/client/blob/10b23b8802d59f0c0cecbe2d7f4ae8af944cbf68/pkg/kn/commands/flags/sink.go#L53
 this wasnt caught in e2e because we dont have an e2e for referring broker using `--sink`.
- This PR refers broker from v1beta1 and add respective e2e tests to verify.

## Changes
- Move broker injection namespace label, unlabel utilities to lib
- Refer broker from eventing v1beta1 APIs
- Add e2e test for refering default broker as sink

/lint