### PR TITLE
Revisit sink prefixes: Support only 'ksvc' prefix and drop 'svc', 'service' support for knative service

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,16 +18,20 @@
 |===
 | | Description | PR
 
+| ✨
+| New sink prefix "ksvc" and drop support for "svc", "service" prefixes for knative service
+| https://github.com/knative/client/pull/896[#896]
+
 | 🎁
 | Add "url" output format to return service url in service describe
 | https://github.com/knative/client/pull/916[#916]
 
 | 🐛
-| Fix panic for `kn source apiserver` and `kn source binding` describe with Sink URI
+| Fix panic for `kn source apiserver` and `kn source binding` describe with sink URI
 | https://github.com/knative/client/pull/901[#901]
 
 | 🐛
-| Fix Panic for `kn trigger describe` with Sink URI
+| Fix panic for `kn trigger describe` with sink URI
 | https://github.com/knative/client/pull/900[#900]
 
 | 🎁
@@ -35,7 +39,7 @@
 | https://github.com/knative/client/pull/887[#887]
 
 | 🎁
-| Add commands to manage Broker resource
+| Add commands to manage broker resource
 | https://github.com/knative/client/pull/894[#894]
 
 | 🐣

--- a/conventions/cli.md
+++ b/conventions/cli.md
@@ -114,7 +114,7 @@ string or a number. Such an option is allowed to be given only once. If given
 multiple times, an error should be thrown.
 
 A scalar flag's value can have an inner structure, too. For example
-`--sink svc:myservice` uses a prefix `svc:` to indicate the targeted sink is a
+`--sink ksvc:myservice` uses a prefix `ksvc:` to indicate the targeted sink is a
 Knative Service. A colon (`:`) should be used as separators if values have a
 structure.
 
@@ -160,10 +160,10 @@ Example:
 
 ```
 # Create an ApiServer source for listening on Pod and Job resource events
-kn source apiserver create mysrc --resource pod:v1 --resource job:batch/v1 --sink svc:mysvc
+kn source apiserver create mysrc --resource pod:v1 --resource job:batch/v1 --sink ksvc:mysvc
 
 # Same as above, but crammed into a single option
-kn source apiserver create mysrc --resource pod:v1,job:batch/v1 --sink svc:mysvc
+kn source apiserver create mysrc --resource pod:v1,job:batch/v1 --sink ksvc:mysvc
 ```
 
 #### Maps

--- a/docs/cmd/kn_source_apiserver_create.md
+++ b/docs/cmd/kn_source_apiserver_create.md
@@ -30,7 +30,7 @@ kn source apiserver create NAME --resource RESOURCE --sink SINK
       --resource stringArray      Specification for which events to listen, in the format Kind:APIVersion:LabelSelector, e.g. "Event:v1:key=value".
                                   "LabelSelector" is a list of comma separated key value pairs. "LabelSelector" can be omitted, e.g. "Event:v1".
       --service-account string    Name of the service account to use to run this source
-  -s, --sink string               Addressable sink for events. You can specify broker, service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink service:receiver' for 'receiver' knative service, you can also use prefix alias 'svc' for 'service'. If do not specify a prefix, it is considered as knative service, i.e. '--sink receiver' is same as '--sink svc:receiver'.
+  -s, --sink string               Addressable sink for events. You can specify broker, knative service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink ksvc:receiver' or '--sink receiver' for 'receiver' knative service. If prefix is not provided, it is considered as knative service.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/kn_source_apiserver_create.md
+++ b/docs/cmd/kn_source_apiserver_create.md
@@ -15,7 +15,7 @@ kn source apiserver create NAME --resource RESOURCE --sink SINK
 ```
 
   # Create an ApiServerSource 'k8sevents' which consumes Kubernetes events and sends message to service 'mysvc' as a cloudevent
-  kn source apiserver create k8sevents --resource Event:v1 --service-account myaccountname --sink svc:mysvc
+  kn source apiserver create k8sevents --resource Event:v1 --service-account myaccountname --sink ksvc:mysvc
 ```
 
 ### Options

--- a/docs/cmd/kn_source_apiserver_create.md
+++ b/docs/cmd/kn_source_apiserver_create.md
@@ -30,7 +30,7 @@ kn source apiserver create NAME --resource RESOURCE --sink SINK
       --resource stringArray      Specification for which events to listen, in the format Kind:APIVersion:LabelSelector, e.g. "Event:v1:key=value".
                                   "LabelSelector" is a list of comma separated key value pairs. "LabelSelector" can be omitted, e.g. "Event:v1".
       --service-account string    Name of the service account to use to run this source
-  -s, --sink string               Addressable sink for events. You can specify broker, knative service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink ksvc:receiver' or '--sink receiver' for 'receiver' knative service. If prefix is not provided, it is considered as knative service.
+  -s, --sink string               Addressable sink for events. You can specify a broker, Knative service or URI. Examples: '--sink broker:nest' for a broker 'nest', '--sink https://event.receiver.uri' for an URI with an 'http://' or 'https://' schema, '--sink 'ksvc:receiver' or simply '--sink receiver' for a Knative service 'receiver'. If prefix is not provided, it is considered as a Knative service.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/kn_source_apiserver_create.md
+++ b/docs/cmd/kn_source_apiserver_create.md
@@ -30,7 +30,7 @@ kn source apiserver create NAME --resource RESOURCE --sink SINK
       --resource stringArray      Specification for which events to listen, in the format Kind:APIVersion:LabelSelector, e.g. "Event:v1:key=value".
                                   "LabelSelector" is a list of comma separated key value pairs. "LabelSelector" can be omitted, e.g. "Event:v1".
       --service-account string    Name of the service account to use to run this source
-  -s, --sink string               Addressable sink for events
+  -s, --sink string               Addressable sink for events. You can specify broker, service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink service:receiver' for 'receiver' knative service, you can also use prefix alias 'svc' for 'service'. If do not specify a prefix, it is considered as knative service, i.e. '--sink receiver' is same as '--sink svc:receiver'.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/kn_source_apiserver_update.md
+++ b/docs/cmd/kn_source_apiserver_update.md
@@ -30,7 +30,7 @@ kn source apiserver update NAME
       --resource stringArray      Specification for which events to listen, in the format Kind:APIVersion:LabelSelector, e.g. "Event:v1:key=value".
                                   "LabelSelector" is a list of comma separated key value pairs. "LabelSelector" can be omitted, e.g. "Event:v1".
       --service-account string    Name of the service account to use to run this source
-  -s, --sink string               Addressable sink for events
+  -s, --sink string               Addressable sink for events. You can specify broker, service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink service:receiver' for 'receiver' knative service, you can also use prefix alias 'svc' for 'service'. If do not specify a prefix, it is considered as knative service, i.e. '--sink receiver' is same as '--sink svc:receiver'.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/kn_source_apiserver_update.md
+++ b/docs/cmd/kn_source_apiserver_update.md
@@ -30,7 +30,7 @@ kn source apiserver update NAME
       --resource stringArray      Specification for which events to listen, in the format Kind:APIVersion:LabelSelector, e.g. "Event:v1:key=value".
                                   "LabelSelector" is a list of comma separated key value pairs. "LabelSelector" can be omitted, e.g. "Event:v1".
       --service-account string    Name of the service account to use to run this source
-  -s, --sink string               Addressable sink for events. You can specify broker, service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink service:receiver' for 'receiver' knative service, you can also use prefix alias 'svc' for 'service'. If do not specify a prefix, it is considered as knative service, i.e. '--sink receiver' is same as '--sink svc:receiver'.
+  -s, --sink string               Addressable sink for events. You can specify broker, knative service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink ksvc:receiver' or '--sink receiver' for 'receiver' knative service. If prefix is not provided, it is considered as knative service.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/kn_source_apiserver_update.md
+++ b/docs/cmd/kn_source_apiserver_update.md
@@ -30,7 +30,7 @@ kn source apiserver update NAME
       --resource stringArray      Specification for which events to listen, in the format Kind:APIVersion:LabelSelector, e.g. "Event:v1:key=value".
                                   "LabelSelector" is a list of comma separated key value pairs. "LabelSelector" can be omitted, e.g. "Event:v1".
       --service-account string    Name of the service account to use to run this source
-  -s, --sink string               Addressable sink for events. You can specify broker, knative service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink ksvc:receiver' or '--sink receiver' for 'receiver' knative service. If prefix is not provided, it is considered as knative service.
+  -s, --sink string               Addressable sink for events. You can specify a broker, Knative service or URI. Examples: '--sink broker:nest' for a broker 'nest', '--sink https://event.receiver.uri' for an URI with an 'http://' or 'https://' schema, '--sink 'ksvc:receiver' or simply '--sink receiver' for a Knative service 'receiver'. If prefix is not provided, it is considered as a Knative service.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/kn_source_apiserver_update.md
+++ b/docs/cmd/kn_source_apiserver_update.md
@@ -15,7 +15,7 @@ kn source apiserver update NAME
 ```
 
   # Update an ApiServerSource 'k8sevents' with different service account and sink service
-  kn source apiserver update k8sevents --service-account newsa --sink svc:newsvc
+  kn source apiserver update k8sevents --service-account newsa --sink ksvc:newsvc
 ```
 
 ### Options

--- a/docs/cmd/kn_source_binding_create.md
+++ b/docs/cmd/kn_source_binding_create.md
@@ -24,7 +24,7 @@ kn source binding create NAME --subject SUBJECT --sink SINK
       --ce-override stringArray   Cloud Event overrides to apply before sending event to sink. Example: '--ce-override key=value' You may be provide this flag multiple times. To unset, append "-" to the key (e.g. --ce-override key-).
   -h, --help                      help for create
   -n, --namespace string          Specify the namespace to operate in.
-  -s, --sink string               Addressable sink for events
+  -s, --sink string               Addressable sink for events. You can specify broker, service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink service:receiver' for 'receiver' knative service, you can also use prefix alias 'svc' for 'service'. If do not specify a prefix, it is considered as knative service, i.e. '--sink receiver' is same as '--sink svc:receiver'.
       --subject string            Subject which emits cloud events. This argument takes format kind:apiVersion:name for named resources or kind:apiVersion:labelKey1=value1,labelKey2=value2 for matching via a label selector
 ```
 

--- a/docs/cmd/kn_source_binding_create.md
+++ b/docs/cmd/kn_source_binding_create.md
@@ -24,7 +24,7 @@ kn source binding create NAME --subject SUBJECT --sink SINK
       --ce-override stringArray   Cloud Event overrides to apply before sending event to sink. Example: '--ce-override key=value' You may be provide this flag multiple times. To unset, append "-" to the key (e.g. --ce-override key-).
   -h, --help                      help for create
   -n, --namespace string          Specify the namespace to operate in.
-  -s, --sink string               Addressable sink for events. You can specify broker, service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink service:receiver' for 'receiver' knative service, you can also use prefix alias 'svc' for 'service'. If do not specify a prefix, it is considered as knative service, i.e. '--sink receiver' is same as '--sink svc:receiver'.
+  -s, --sink string               Addressable sink for events. You can specify broker, knative service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink ksvc:receiver' or '--sink receiver' for 'receiver' knative service. If prefix is not provided, it is considered as knative service.
       --subject string            Subject which emits cloud events. This argument takes format kind:apiVersion:name for named resources or kind:apiVersion:labelKey1=value1,labelKey2=value2 for matching via a label selector
 ```
 

--- a/docs/cmd/kn_source_binding_create.md
+++ b/docs/cmd/kn_source_binding_create.md
@@ -24,7 +24,7 @@ kn source binding create NAME --subject SUBJECT --sink SINK
       --ce-override stringArray   Cloud Event overrides to apply before sending event to sink. Example: '--ce-override key=value' You may be provide this flag multiple times. To unset, append "-" to the key (e.g. --ce-override key-).
   -h, --help                      help for create
   -n, --namespace string          Specify the namespace to operate in.
-  -s, --sink string               Addressable sink for events. You can specify broker, knative service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink ksvc:receiver' or '--sink receiver' for 'receiver' knative service. If prefix is not provided, it is considered as knative service.
+  -s, --sink string               Addressable sink for events. You can specify a broker, Knative service or URI. Examples: '--sink broker:nest' for a broker 'nest', '--sink https://event.receiver.uri' for an URI with an 'http://' or 'https://' schema, '--sink 'ksvc:receiver' or simply '--sink receiver' for a Knative service 'receiver'. If prefix is not provided, it is considered as a Knative service.
       --subject string            Subject which emits cloud events. This argument takes format kind:apiVersion:name for named resources or kind:apiVersion:labelKey1=value1,labelKey2=value2 for matching via a label selector
 ```
 

--- a/docs/cmd/kn_source_binding_create.md
+++ b/docs/cmd/kn_source_binding_create.md
@@ -15,7 +15,7 @@ kn source binding create NAME --subject SUBJECT --sink SINK
 ```
 
   # Create a sink binding which connects a deployment 'myapp' with a Knative service 'mysvc'
-  kn source binding create my-binding --subject Deployment:apps/v1:myapp --sink svc:mysvc
+  kn source binding create my-binding --subject Deployment:apps/v1:myapp --sink ksvc:mysvc
 ```
 
 ### Options

--- a/docs/cmd/kn_source_binding_update.md
+++ b/docs/cmd/kn_source_binding_update.md
@@ -24,7 +24,7 @@ kn source binding update NAME
       --ce-override stringArray   Cloud Event overrides to apply before sending event to sink. Example: '--ce-override key=value' You may be provide this flag multiple times. To unset, append "-" to the key (e.g. --ce-override key-).
   -h, --help                      help for update
   -n, --namespace string          Specify the namespace to operate in.
-  -s, --sink string               Addressable sink for events. You can specify broker, service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink service:receiver' for 'receiver' knative service, you can also use prefix alias 'svc' for 'service'. If do not specify a prefix, it is considered as knative service, i.e. '--sink receiver' is same as '--sink svc:receiver'.
+  -s, --sink string               Addressable sink for events. You can specify broker, knative service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink ksvc:receiver' or '--sink receiver' for 'receiver' knative service. If prefix is not provided, it is considered as knative service.
       --subject string            Subject which emits cloud events. This argument takes format kind:apiVersion:name for named resources or kind:apiVersion:labelKey1=value1,labelKey2=value2 for matching via a label selector
 ```
 

--- a/docs/cmd/kn_source_binding_update.md
+++ b/docs/cmd/kn_source_binding_update.md
@@ -24,7 +24,7 @@ kn source binding update NAME
       --ce-override stringArray   Cloud Event overrides to apply before sending event to sink. Example: '--ce-override key=value' You may be provide this flag multiple times. To unset, append "-" to the key (e.g. --ce-override key-).
   -h, --help                      help for update
   -n, --namespace string          Specify the namespace to operate in.
-  -s, --sink string               Addressable sink for events. You can specify broker, knative service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink ksvc:receiver' or '--sink receiver' for 'receiver' knative service. If prefix is not provided, it is considered as knative service.
+  -s, --sink string               Addressable sink for events. You can specify a broker, Knative service or URI. Examples: '--sink broker:nest' for a broker 'nest', '--sink https://event.receiver.uri' for an URI with an 'http://' or 'https://' schema, '--sink 'ksvc:receiver' or simply '--sink receiver' for a Knative service 'receiver'. If prefix is not provided, it is considered as a Knative service.
       --subject string            Subject which emits cloud events. This argument takes format kind:apiVersion:name for named resources or kind:apiVersion:labelKey1=value1,labelKey2=value2 for matching via a label selector
 ```
 

--- a/docs/cmd/kn_source_binding_update.md
+++ b/docs/cmd/kn_source_binding_update.md
@@ -24,7 +24,7 @@ kn source binding update NAME
       --ce-override stringArray   Cloud Event overrides to apply before sending event to sink. Example: '--ce-override key=value' You may be provide this flag multiple times. To unset, append "-" to the key (e.g. --ce-override key-).
   -h, --help                      help for update
   -n, --namespace string          Specify the namespace to operate in.
-  -s, --sink string               Addressable sink for events
+  -s, --sink string               Addressable sink for events. You can specify broker, service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink service:receiver' for 'receiver' knative service, you can also use prefix alias 'svc' for 'service'. If do not specify a prefix, it is considered as knative service, i.e. '--sink receiver' is same as '--sink svc:receiver'.
       --subject string            Subject which emits cloud events. This argument takes format kind:apiVersion:name for named resources or kind:apiVersion:labelKey1=value1,labelKey2=value2 for matching via a label selector
 ```
 

--- a/docs/cmd/kn_source_ping_create.md
+++ b/docs/cmd/kn_source_ping_create.md
@@ -15,7 +15,7 @@ kn source ping create NAME --sink SINK
 ```
 
   # Create a Ping source 'my-ping' which fires every two minutes and sends '{ value: "hello" }' to service 'mysvc' as a cloudevent
-  kn source ping create my-ping --schedule "*/2 * * * *" --data '{ value: "hello" }' --sink svc:mysvc
+  kn source ping create my-ping --schedule "*/2 * * * *" --data '{ value: "hello" }' --sink ksvc:mysvc
 ```
 
 ### Options

--- a/docs/cmd/kn_source_ping_create.md
+++ b/docs/cmd/kn_source_ping_create.md
@@ -26,7 +26,7 @@ kn source ping create NAME --sink SINK
   -h, --help                      help for create
   -n, --namespace string          Specify the namespace to operate in.
       --schedule string           Optional schedule specification in crontab format (e.g. '*/2 * * * *' for every two minutes. By default fire every minute.
-  -s, --sink string               Addressable sink for events. You can specify broker, service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink service:receiver' for 'receiver' knative service, you can also use prefix alias 'svc' for 'service'. If do not specify a prefix, it is considered as knative service, i.e. '--sink receiver' is same as '--sink svc:receiver'.
+  -s, --sink string               Addressable sink for events. You can specify broker, knative service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink ksvc:receiver' or '--sink receiver' for 'receiver' knative service. If prefix is not provided, it is considered as knative service.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/kn_source_ping_create.md
+++ b/docs/cmd/kn_source_ping_create.md
@@ -26,7 +26,7 @@ kn source ping create NAME --sink SINK
   -h, --help                      help for create
   -n, --namespace string          Specify the namespace to operate in.
       --schedule string           Optional schedule specification in crontab format (e.g. '*/2 * * * *' for every two minutes. By default fire every minute.
-  -s, --sink string               Addressable sink for events. You can specify broker, knative service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink ksvc:receiver' or '--sink receiver' for 'receiver' knative service. If prefix is not provided, it is considered as knative service.
+  -s, --sink string               Addressable sink for events. You can specify a broker, Knative service or URI. Examples: '--sink broker:nest' for a broker 'nest', '--sink https://event.receiver.uri' for an URI with an 'http://' or 'https://' schema, '--sink 'ksvc:receiver' or simply '--sink receiver' for a Knative service 'receiver'. If prefix is not provided, it is considered as a Knative service.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/kn_source_ping_create.md
+++ b/docs/cmd/kn_source_ping_create.md
@@ -26,7 +26,7 @@ kn source ping create NAME --sink SINK
   -h, --help                      help for create
   -n, --namespace string          Specify the namespace to operate in.
       --schedule string           Optional schedule specification in crontab format (e.g. '*/2 * * * *' for every two minutes. By default fire every minute.
-  -s, --sink string               Addressable sink for events
+  -s, --sink string               Addressable sink for events. You can specify broker, service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink service:receiver' for 'receiver' knative service, you can also use prefix alias 'svc' for 'service'. If do not specify a prefix, it is considered as knative service, i.e. '--sink receiver' is same as '--sink svc:receiver'.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/kn_source_ping_update.md
+++ b/docs/cmd/kn_source_ping_update.md
@@ -26,7 +26,7 @@ kn source ping update NAME
   -h, --help                      help for update
   -n, --namespace string          Specify the namespace to operate in.
       --schedule string           Optional schedule specification in crontab format (e.g. '*/2 * * * *' for every two minutes. By default fire every minute.
-  -s, --sink string               Addressable sink for events. You can specify broker, knative service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink ksvc:receiver' or '--sink receiver' for 'receiver' knative service. If prefix is not provided, it is considered as knative service.
+  -s, --sink string               Addressable sink for events. You can specify a broker, Knative service or URI. Examples: '--sink broker:nest' for a broker 'nest', '--sink https://event.receiver.uri' for an URI with an 'http://' or 'https://' schema, '--sink 'ksvc:receiver' or simply '--sink receiver' for a Knative service 'receiver'. If prefix is not provided, it is considered as a Knative service.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/kn_source_ping_update.md
+++ b/docs/cmd/kn_source_ping_update.md
@@ -26,7 +26,7 @@ kn source ping update NAME
   -h, --help                      help for update
   -n, --namespace string          Specify the namespace to operate in.
       --schedule string           Optional schedule specification in crontab format (e.g. '*/2 * * * *' for every two minutes. By default fire every minute.
-  -s, --sink string               Addressable sink for events
+  -s, --sink string               Addressable sink for events. You can specify broker, service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink service:receiver' for 'receiver' knative service, you can also use prefix alias 'svc' for 'service'. If do not specify a prefix, it is considered as knative service, i.e. '--sink receiver' is same as '--sink svc:receiver'.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/kn_source_ping_update.md
+++ b/docs/cmd/kn_source_ping_update.md
@@ -26,7 +26,7 @@ kn source ping update NAME
   -h, --help                      help for update
   -n, --namespace string          Specify the namespace to operate in.
       --schedule string           Optional schedule specification in crontab format (e.g. '*/2 * * * *' for every two minutes. By default fire every minute.
-  -s, --sink string               Addressable sink for events. You can specify broker, service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink service:receiver' for 'receiver' knative service, you can also use prefix alias 'svc' for 'service'. If do not specify a prefix, it is considered as knative service, i.e. '--sink receiver' is same as '--sink svc:receiver'.
+  -s, --sink string               Addressable sink for events. You can specify broker, knative service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink ksvc:receiver' or '--sink receiver' for 'receiver' knative service. If prefix is not provided, it is considered as knative service.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/kn_trigger_create.md
+++ b/docs/cmd/kn_trigger_create.md
@@ -29,7 +29,7 @@ kn trigger create NAME --sink SINK
   -h, --help               help for create
       --inject-broker      Create new broker with name default through common annotation
   -n, --namespace string   Specify the namespace to operate in.
-  -s, --sink string        Addressable sink for events
+  -s, --sink string        Addressable sink for events. You can specify broker, service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink service:receiver' for 'receiver' knative service, you can also use prefix alias 'svc' for 'service'. If do not specify a prefix, it is considered as knative service, i.e. '--sink receiver' is same as '--sink svc:receiver'.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/kn_trigger_create.md
+++ b/docs/cmd/kn_trigger_create.md
@@ -29,7 +29,7 @@ kn trigger create NAME --sink SINK
   -h, --help               help for create
       --inject-broker      Create new broker with name default through common annotation
   -n, --namespace string   Specify the namespace to operate in.
-  -s, --sink string        Addressable sink for events. You can specify broker, service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink service:receiver' for 'receiver' knative service, you can also use prefix alias 'svc' for 'service'. If do not specify a prefix, it is considered as knative service, i.e. '--sink receiver' is same as '--sink svc:receiver'.
+  -s, --sink string        Addressable sink for events. You can specify broker, knative service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink ksvc:receiver' or '--sink receiver' for 'receiver' knative service. If prefix is not provided, it is considered as knative service.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/kn_trigger_create.md
+++ b/docs/cmd/kn_trigger_create.md
@@ -15,10 +15,10 @@ kn trigger create NAME --sink SINK
 ```
 
   # Create a trigger 'mytrigger' to declare a subscription to events from default broker. The subscriber is service 'mysvc'
-  kn trigger create mytrigger --broker default --sink svc:mysvc
+  kn trigger create mytrigger --broker default --sink ksvc:mysvc
 
   # Create a trigger to filter events with attribute 'type=dev.knative.foo'
-  kn trigger create mytrigger --broker default --filter type=dev.knative.foo --sink svc:mysvc
+  kn trigger create mytrigger --broker default --filter type=dev.knative.foo --sink ksvc:mysvc
 ```
 
 ### Options

--- a/docs/cmd/kn_trigger_create.md
+++ b/docs/cmd/kn_trigger_create.md
@@ -29,7 +29,7 @@ kn trigger create NAME --sink SINK
   -h, --help               help for create
       --inject-broker      Create new broker with name default through common annotation
   -n, --namespace string   Specify the namespace to operate in.
-  -s, --sink string        Addressable sink for events. You can specify broker, knative service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink ksvc:receiver' or '--sink receiver' for 'receiver' knative service. If prefix is not provided, it is considered as knative service.
+  -s, --sink string        Addressable sink for events. You can specify a broker, Knative service or URI. Examples: '--sink broker:nest' for a broker 'nest', '--sink https://event.receiver.uri' for an URI with an 'http://' or 'https://' schema, '--sink 'ksvc:receiver' or simply '--sink receiver' for a Knative service 'receiver'. If prefix is not provided, it is considered as a Knative service.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/kn_trigger_update.md
+++ b/docs/cmd/kn_trigger_update.md
@@ -33,7 +33,7 @@ kn trigger update NAME
   -h, --help               help for update
       --inject-broker      Create new broker with name default through common annotation
   -n, --namespace string   Specify the namespace to operate in.
-  -s, --sink string        Addressable sink for events. You can specify broker, knative service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink ksvc:receiver' or '--sink receiver' for 'receiver' knative service. If prefix is not provided, it is considered as knative service.
+  -s, --sink string        Addressable sink for events. You can specify a broker, Knative service or URI. Examples: '--sink broker:nest' for a broker 'nest', '--sink https://event.receiver.uri' for an URI with an 'http://' or 'https://' schema, '--sink 'ksvc:receiver' or simply '--sink receiver' for a Knative service 'receiver'. If prefix is not provided, it is considered as a Knative service.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/kn_trigger_update.md
+++ b/docs/cmd/kn_trigger_update.md
@@ -17,11 +17,11 @@ kn trigger update NAME
   # Update the filter which key is 'type' to value 'knative.dev.bar' in a trigger 'mytrigger'
   kn trigger update mytrigger --filter type=knative.dev.bar
 
-  # Remove the filter which key is 'type' from a trigger 'mytrigger' 
+  # Remove the filter which key is 'type' from a trigger 'mytrigger'
   kn trigger update mytrigger --filter type-
 
-  # Update the sink of a trigger 'mytrigger' to 'svc:new-service'
-  kn trigger update mytrigger --sink svc:new-service
+  # Update the sink of a trigger 'mytrigger' to 'ksvc:new-service'
+  kn trigger update mytrigger --sink ksvc:new-service
   
 ```
 

--- a/docs/cmd/kn_trigger_update.md
+++ b/docs/cmd/kn_trigger_update.md
@@ -33,7 +33,7 @@ kn trigger update NAME
   -h, --help               help for update
       --inject-broker      Create new broker with name default through common annotation
   -n, --namespace string   Specify the namespace to operate in.
-  -s, --sink string        Addressable sink for events
+  -s, --sink string        Addressable sink for events. You can specify broker, service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink service:receiver' for 'receiver' knative service, you can also use prefix alias 'svc' for 'service'. If do not specify a prefix, it is considered as knative service, i.e. '--sink receiver' is same as '--sink svc:receiver'.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/kn_trigger_update.md
+++ b/docs/cmd/kn_trigger_update.md
@@ -33,7 +33,7 @@ kn trigger update NAME
   -h, --help               help for update
       --inject-broker      Create new broker with name default through common annotation
   -n, --namespace string   Specify the namespace to operate in.
-  -s, --sink string        Addressable sink for events. You can specify broker, service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink service:receiver' for 'receiver' knative service, you can also use prefix alias 'svc' for 'service'. If do not specify a prefix, it is considered as knative service, i.e. '--sink receiver' is same as '--sink svc:receiver'.
+  -s, --sink string        Addressable sink for events. You can specify broker, knative service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink ksvc:receiver' or '--sink receiver' for 'receiver' knative service. If prefix is not provided, it is considered as knative service.
 ```
 
 ### Options inherited from parent commands

--- a/pkg/kn/commands/flags/sink.go
+++ b/pkg/kn/commands/flags/sink.go
@@ -38,11 +38,11 @@ func (i *SinkFlags) Add(cmd *cobra.Command) {
 		"s",
 		"",
 		"Addressable sink for events. "+
-			"You can specify broker, knative service or URI. "+
-			"Examples: '--sink broker:nest' for 'nest' broker, "+
-			"'--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), "+
-			"'--sink ksvc:receiver' or '--sink receiver' for 'receiver' knative service. "+
-			"If prefix is not provided, it is considered as knative service.")
+			"You can specify a broker, Knative service or URI. "+
+			"Examples: '--sink broker:nest' for a broker 'nest', "+
+			"'--sink https://event.receiver.uri' for an URI with an 'http://' or 'https://' schema, "+
+			"'--sink 'ksvc:receiver' or simply '--sink receiver' for a Knative service 'receiver'. "+
+			"If prefix is not provided, it is considered as a Knative service.")
 
 	for _, p := range config.GlobalConfig.SinkMappings() {
 		//user configration might override the default configuration

--- a/pkg/kn/commands/flags/sink.go
+++ b/pkg/kn/commands/flags/sink.go
@@ -38,13 +38,11 @@ func (i *SinkFlags) Add(cmd *cobra.Command) {
 		"s",
 		"",
 		"Addressable sink for events. "+
-			"You can specify broker, service or URI. "+
+			"You can specify broker, knative service or URI. "+
 			"Examples: '--sink broker:nest' for 'nest' broker, "+
 			"'--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), "+
-			"'--sink service:receiver' for 'receiver' knative service, "+
-			"you can also use prefix alias 'svc' for 'service'. "+
-			"If do not specify a prefix, it is considered as knative service, "+
-			"i.e. '--sink receiver' is same as '--sink svc:receiver'.")
+			"'--sink ksvc:receiver' or '--sink receiver' for 'receiver' knative service. "+
+			"If prefix is not provided, it is considered as knative service.")
 
 	for _, p := range config.GlobalConfig.SinkMappings() {
 		//user configration might override the default configuration

--- a/pkg/kn/commands/flags/sink.go
+++ b/pkg/kn/commands/flags/sink.go
@@ -33,7 +33,18 @@ type SinkFlags struct {
 }
 
 func (i *SinkFlags) Add(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&i.sink, "sink", "s", "", "Addressable sink for events")
+	cmd.Flags().StringVarP(&i.sink,
+		"sink",
+		"s",
+		"",
+		"Addressable sink for events. "+
+			"You can specify broker, service or URI. "+
+			"Examples: '--sink broker:nest' for 'nest' broker, "+
+			"'--sink https://event.receiver.uri' for an URI (identified by 'http' or 'https'), "+
+			"'--sink service:receiver' for 'receiver' knative service, "+
+			"you can also use prefix alias 'svc' for 'service'. "+
+			"If do not specify a prefix, it is considered as knative service, "+
+			"i.e. '--sink receiver' is same as '--sink svc:receiver'.")
 
 	for _, p := range config.GlobalConfig.SinkMappings() {
 		//user configration might override the default configuration

--- a/pkg/kn/commands/flags/sink.go
+++ b/pkg/kn/commands/flags/sink.go
@@ -61,13 +61,8 @@ var sinkMappings = map[string]schema.GroupVersionResource{
 		Group:    "eventing.knative.dev",
 		Version:  "v1beta1",
 	},
-	"service": {
-		Resource: "services",
-		Group:    "serving.knative.dev",
-		Version:  "v1",
-	},
 	// Shorthand alias for service
-	"svc": {
+	"ksvc": {
 		Resource: "services",
 		Group:    "serving.knative.dev",
 		Version:  "v1",
@@ -117,7 +112,7 @@ func (i *SinkFlags) ResolveSink(knclient clientdynamic.KnDynamicClient, namespac
 func parseSink(sink string) (string, string) {
 	parts := strings.SplitN(sink, ":", 2)
 	if len(parts) == 1 {
-		return "svc", parts[0]
+		return "ksvc", parts[0]
 	} else if parts[0] == "http" || parts[0] == "https" {
 		return "", sink
 	} else {
@@ -129,7 +124,7 @@ func parseSink(sink string) (string, string) {
 func SinkToString(sink duckv1.Destination) string {
 	if sink.Ref != nil {
 		if sink.Ref.Kind == "Service" {
-			return fmt.Sprintf("svc:%s", sink.Ref.Name)
+			return fmt.Sprintf("ksvc:%s", sink.Ref.Name)
 		} else {
 			return fmt.Sprintf("%s:%s", strings.ToLower(sink.Ref.Kind), sink.Ref.Name)
 		}

--- a/pkg/kn/commands/flags/sink.go
+++ b/pkg/kn/commands/flags/sink.go
@@ -88,7 +88,10 @@ func (i *SinkFlags) ResolveSink(knclient clientdynamic.KnDynamicClient, namespac
 	}
 	typ, ok := sinkMappings[prefix]
 	if !ok {
-		return nil, fmt.Errorf("unsupported sink type: %s", i.sink)
+		if prefix == "svc" || prefix == "service" {
+			return nil, fmt.Errorf("unsupported sink prefix: '%s', please use prefix 'ksvc' for knative service", prefix)
+		}
+		return nil, fmt.Errorf("unsupported sink prefix: '%s'", prefix)
 	}
 	obj, err := client.Resource(typ).Namespace(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/kn/commands/flags/sink_test.go
+++ b/pkg/kn/commands/flags/sink_test.go
@@ -65,6 +65,9 @@ func TestResolve(t *testing.T) {
 		{"http://target.example.com", &duckv1.Destination{
 			URI: targetExampleCom,
 		}, ""},
+		{"k8ssvc:foo", nil, "unsupported sink prefix: 'k8ssvc'"},
+		{"svc:foo", nil, "please use prefix 'ksvc' for knative service"},
+		{"service:foo", nil, "please use prefix 'ksvc' for knative service"},
 	}
 	dynamicClient := dynamicfake.CreateFakeKnDynamicClient("default", mysvc, defaultBroker)
 	for _, c := range cases {

--- a/pkg/kn/commands/flags/sink_test.go
+++ b/pkg/kn/commands/flags/sink_test.go
@@ -46,17 +46,17 @@ func TestResolve(t *testing.T) {
 
 	assert.NilError(t, err)
 	cases := []resolveCase{
-		{"svc:mysvc", &duckv1.Destination{
+		{"ksvc:mysvc", &duckv1.Destination{
 			Ref: &duckv1.KReference{Kind: "Service",
 				APIVersion: "serving.knative.dev/v1",
 				Namespace:  "default",
 				Name:       "mysvc"}}, ""},
-		{"service:mysvc", &duckv1.Destination{
+		{"mysvc", &duckv1.Destination{
 			Ref: &duckv1.KReference{Kind: "Service",
 				APIVersion: "serving.knative.dev/v1",
 				Namespace:  "default",
 				Name:       "mysvc"}}, ""},
-		{"svc:absent", nil, "\"absent\" not found"},
+		{"ksvc:absent", nil, "\"absent\" not found"},
 		{"broker:default", &duckv1.Destination{
 			Ref: &duckv1.KReference{Kind: "Broker",
 				APIVersion: "eventing.knative.dev/v1beta1",

--- a/pkg/kn/commands/source/apiserver/create.go
+++ b/pkg/kn/commands/source/apiserver/create.go
@@ -36,7 +36,7 @@ func NewAPIServerCreateCommand(p *commands.KnParams) *cobra.Command {
 		Short: "Create an api-server source",
 		Example: `
   # Create an ApiServerSource 'k8sevents' which consumes Kubernetes events and sends message to service 'mysvc' as a cloudevent
-  kn source apiserver create k8sevents --resource Event:v1 --service-account myaccountname --sink svc:mysvc`,
+  kn source apiserver create k8sevents --resource Event:v1 --service-account myaccountname --sink ksvc:mysvc`,
 
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {

--- a/pkg/kn/commands/source/apiserver/create_test.go
+++ b/pkg/kn/commands/source/apiserver/create_test.go
@@ -37,7 +37,7 @@ func TestCreateApiServerSource(t *testing.T) {
 	apiServerRecorder := apiServerClient.Recorder()
 	apiServerRecorder.CreateAPIServerSource(createAPIServerSource("testsource", "Event", "v1", "testsa", "Reference", map[string]string{"bla": "blub", "foo": "bar"}, createSinkv1("testsvc", "default")), nil)
 
-	out, err := executeAPIServerSourceCommand(apiServerClient, dynamicClient, "create", "testsource", "--resource", "Event:v1", "--service-account", "testsa", "--sink", "svc:testsvc", "--mode", "Reference", "--ce-override", "bla=blub", "--ce-override", "foo=bar")
+	out, err := executeAPIServerSourceCommand(apiServerClient, dynamicClient, "create", "testsource", "--resource", "Event:v1", "--service-account", "testsa", "--sink", "ksvc:testsvc", "--mode", "Reference", "--ce-override", "bla=blub", "--ce-override", "foo=bar")
 	assert.NilError(t, err, "ApiServer source should be created")
 	assert.Assert(t, util.ContainsAll(out, "created", "default", "testsource"))
 
@@ -48,7 +48,7 @@ func TestSinkNotFoundError(t *testing.T) {
 	dynamicClient := dynamicfake.CreateFakeKnDynamicClient("default")
 	apiServerClient := v1alpha2.NewMockKnAPIServerSourceClient(t)
 	errorMsg := "cannot create ApiServerSource 'testsource' in namespace 'default' because: services.serving.knative.dev \"testsvc\" not found"
-	out, err := executeAPIServerSourceCommand(apiServerClient, dynamicClient, "create", "testsource", "--resource", "Event:v1:key1=value1", "--service-account", "testsa", "--sink", "svc:testsvc", "--mode", "Reference")
+	out, err := executeAPIServerSourceCommand(apiServerClient, dynamicClient, "create", "testsource", "--resource", "Event:v1:key1=value1", "--service-account", "testsa", "--sink", "ksvc:testsvc", "--mode", "Reference")
 	assert.Error(t, err, errorMsg)
 	assert.Assert(t, util.ContainsAll(out, errorMsg, "Usage"))
 }

--- a/pkg/kn/commands/source/apiserver/list_test.go
+++ b/pkg/kn/commands/source/apiserver/list_test.go
@@ -38,7 +38,7 @@ func TestListAPIServerSource(t *testing.T) {
 	out, err := executeAPIServerSourceCommand(apiServerClient, nil, "list")
 	assert.NilError(t, err, "sources should be listed")
 	assert.Assert(t, util.ContainsAll(out, "NAME", "RESOURCES", "SINK", "AGE", "CONDITIONS", "READY", "REASON"))
-	assert.Assert(t, util.ContainsAll(out, "testsource", "Event:v1", "svc:testsvc"))
+	assert.Assert(t, util.ContainsAll(out, "testsource", "Event:v1", "ksvc:testsvc"))
 
 	apiServerRecorder.Validate()
 }

--- a/pkg/kn/commands/source/apiserver/update.go
+++ b/pkg/kn/commands/source/apiserver/update.go
@@ -36,7 +36,7 @@ func NewAPIServerUpdateCommand(p *commands.KnParams) *cobra.Command {
 		Short: "Update an api-server source",
 		Example: `
   # Update an ApiServerSource 'k8sevents' with different service account and sink service
-  kn source apiserver update k8sevents --service-account newsa --sink svc:newsvc`,
+  kn source apiserver update k8sevents --service-account newsa --sink ksvc:newsvc`,
 
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {

--- a/pkg/kn/commands/source/apiserver/update_test.go
+++ b/pkg/kn/commands/source/apiserver/update_test.go
@@ -43,7 +43,7 @@ func TestApiServerSourceUpdate(t *testing.T) {
 	updated := createAPIServerSource("testsource", "Event", "v1", "testsa2", "Reference", map[string]string{"foo": "baz"}, createSinkv1("svc2", "default"))
 	apiServerRecorder.UpdateAPIServerSource(updated, nil)
 
-	output, err := executeAPIServerSourceCommand(apiServerClient, dynamicClient, "update", "testsource", "--service-account", "testsa2", "--sink", "svc:svc2", "--ce-override", "bla-", "--ce-override", "foo=baz")
+	output, err := executeAPIServerSourceCommand(apiServerClient, dynamicClient, "update", "testsource", "--service-account", "testsa2", "--sink", "ksvc:svc2", "--ce-override", "bla-", "--ce-override", "foo=baz")
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(output, "testsource", "updated", "default"))
 
@@ -58,7 +58,7 @@ func TestApiServerSourceUpdateDeletionTimestampNotNil(t *testing.T) {
 	present.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 	apiServerRecorder.GetAPIServerSource("testsource", present, nil)
 
-	_, err := executeAPIServerSourceCommand(apiServerClient, nil, "update", "testsource", "--service-account", "testsa2", "--sink", "svc:svc2")
+	_, err := executeAPIServerSourceCommand(apiServerClient, nil, "update", "testsource", "--service-account", "testsa2", "--sink", "ksvc:svc2")
 	assert.ErrorContains(t, err, present.Name)
 	assert.ErrorContains(t, err, "deletion")
 	assert.ErrorContains(t, err, "apiserver")

--- a/pkg/kn/commands/source/binding/create.go
+++ b/pkg/kn/commands/source/binding/create.go
@@ -36,7 +36,7 @@ func NewBindingCreateCommand(p *commands.KnParams) *cobra.Command {
 		Short: "Create a sink binding",
 		Example: `
   # Create a sink binding which connects a deployment 'myapp' with a Knative service 'mysvc'
-  kn source binding create my-binding --subject Deployment:apps/v1:myapp --sink svc:mysvc`,
+  kn source binding create my-binding --subject Deployment:apps/v1:myapp --sink ksvc:mysvc`,
 
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {

--- a/pkg/kn/commands/source/binding/create_test.go
+++ b/pkg/kn/commands/source/binding/create_test.go
@@ -33,7 +33,7 @@ func TestSimpleCreateBinding(t *testing.T) {
 	bindingRecorder := bindingClient.Recorder()
 	bindingRecorder.CreateSinkBinding(createSinkBinding("testbinding", "mysvc", deploymentGvk, "mydeploy", "default", map[string]string{"bla": "blub", "foo": "bar"}), nil)
 
-	out, err := executeSinkBindingCommand(bindingClient, dynamicClient, "create", "testbinding", "--sink", "svc:mysvc", "--subject", "deployment:apps/v1:mydeploy", "--ce-override", "bla=blub", "--ce-override", "foo=bar")
+	out, err := executeSinkBindingCommand(bindingClient, dynamicClient, "create", "testbinding", "--sink", "ksvc:mysvc", "--subject", "deployment:apps/v1:mydeploy", "--ce-override", "bla=blub", "--ce-override", "foo=bar")
 	assert.NilError(t, err, "Source should have been created")
 	assert.Assert(t, util.ContainsAll(out, "created", "default", "testbinding"))
 
@@ -44,7 +44,7 @@ func TestNoSinkError(t *testing.T) {
 	bindingClient := v1alpha2.NewMockKnSinkBindingClient(t)
 	dynamicClient := dynamicfake.CreateFakeKnDynamicClient("default")
 
-	_, err := executeSinkBindingCommand(bindingClient, dynamicClient, "create", "testbinding", "--sink", "svc:mysvc", "--subject", "deployment:apps/v1:app=myapp")
+	_, err := executeSinkBindingCommand(bindingClient, dynamicClient, "create", "testbinding", "--sink", "ksvc:mysvc", "--subject", "deployment:apps/v1:app=myapp")
 	assert.ErrorContains(t, err, "mysvc")
 	assert.ErrorContains(t, err, "not found")
 }

--- a/pkg/kn/commands/source/binding/update_test.go
+++ b/pkg/kn/commands/source/binding/update_test.go
@@ -42,7 +42,7 @@ func TestSimpleBindingUpdate(t *testing.T) {
 	bindingRecorder.GetSinkBinding("testbinding", createSinkBinding("testbinding", "mysvc", deploymentGvk, "mydeploy", "default", ceOverrideMap), nil)
 	bindingRecorder.UpdateSinkBinding(createSinkBinding("testbinding", "othersvc", deploymentGvk, "mydeploy", "default", ceOverrideMapUpdated), nil)
 
-	out, err := executeSinkBindingCommand(sinkBindingClient, dynamicClient, "update", "testbinding", "--sink", "svc:othersvc", "--ce-override", "bla-", "--ce-override", "foo=baz", "--ce-override", "new=ceoverride")
+	out, err := executeSinkBindingCommand(sinkBindingClient, dynamicClient, "update", "testbinding", "--sink", "ksvc:othersvc", "--ce-override", "bla-", "--ce-override", "foo=baz", "--ce-override", "new=ceoverride")
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(out, "updated", "default", "testbinding"))
 

--- a/pkg/kn/commands/source/duck/multisourcelist_test.go
+++ b/pkg/kn/commands/source/duck/multisourcelist_test.go
@@ -33,10 +33,10 @@ func TestToSource(t *testing.T) {
 	assert.Check(t, s.SourceKind == "SinkBinding")
 	s = toSource(newSourceUnstructuredObjWithSink("p1",
 		"sources.knative.dev/v1alpha1", "PingSource"))
-	assert.Check(t, s.Sink == "svc:foo")
+	assert.Check(t, s.Sink == "ksvc:foo")
 	s = toSource(newSourceUnstructuredObjWithSink("k1",
 		"sources.knative.dev/v1alpha1", "KafkaSource"))
-	assert.Check(t, s.Sink == "svc:foo")
+	assert.Check(t, s.Sink == "ksvc:foo")
 	s = toSource(newSourceUnstructuredObjWithoutSink("k1",
 		"sources.knative.dev/v1alpha1", "KafkaSource"))
 	assert.Check(t, s.Sink == "")

--- a/pkg/kn/commands/source/list_test.go
+++ b/pkg/kn/commands/source/list_test.go
@@ -82,9 +82,9 @@ func TestSourceList(t *testing.T) {
 	)
 	assert.NilError(t, err)
 	assert.Check(t, util.ContainsAll(output[0], "NAME", "TYPE", "RESOURCE", "SINK", "READY"))
-	assert.Check(t, util.ContainsAll(output[1], "a1", "ApiServerSource", "apiserversources.sources.knative.dev", "svc:foo", "True"))
-	assert.Check(t, util.ContainsAll(output[2], "p1", "PingSource", "pingsources.sources.knative.dev", "svc:foo", "True"))
-	assert.Check(t, util.ContainsAll(output[3], "s1", "SinkBinding", "sinkbindings.sources.knative.dev", "svc:foo", "True"))
+	assert.Check(t, util.ContainsAll(output[1], "a1", "ApiServerSource", "apiserversources.sources.knative.dev", "ksvc:foo", "True"))
+	assert.Check(t, util.ContainsAll(output[2], "p1", "PingSource", "pingsources.sources.knative.dev", "ksvc:foo", "True"))
+	assert.Check(t, util.ContainsAll(output[3], "s1", "SinkBinding", "sinkbindings.sources.knative.dev", "ksvc:foo", "True"))
 }
 
 func TestSourceListUntyped(t *testing.T) {
@@ -95,8 +95,8 @@ func TestSourceListUntyped(t *testing.T) {
 	)
 	assert.NilError(t, err)
 	assert.Check(t, util.ContainsAll(output[0], "NAME", "TYPE", "RESOURCE", "SINK", "READY"))
-	assert.Check(t, util.ContainsAll(output[1], "k1", "KafkaSource", "kafkasources.sources.knative.dev", "svc:foo", "True"))
-	assert.Check(t, util.ContainsAll(output[2], "k2", "KafkaSource", "kafkasources.sources.knative.dev", "svc:foo", "True"))
+	assert.Check(t, util.ContainsAll(output[1], "k1", "KafkaSource", "kafkasources.sources.knative.dev", "ksvc:foo", "True"))
+	assert.Check(t, util.ContainsAll(output[2], "k2", "KafkaSource", "kafkasources.sources.knative.dev", "ksvc:foo", "True"))
 }
 
 func TestSourceListNoHeaders(t *testing.T) {

--- a/pkg/kn/commands/source/ping/create.go
+++ b/pkg/kn/commands/source/ping/create.go
@@ -36,7 +36,7 @@ func NewPingCreateCommand(p *commands.KnParams) *cobra.Command {
 		Short: "Create a ping source",
 		Example: `
   # Create a Ping source 'my-ping' which fires every two minutes and sends '{ value: "hello" }' to service 'mysvc' as a cloudevent
-  kn source ping create my-ping --schedule "*/2 * * * *" --data '{ value: "hello" }' --sink svc:mysvc`,
+  kn source ping create my-ping --schedule "*/2 * * * *" --data '{ value: "hello" }' --sink ksvc:mysvc`,
 
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {

--- a/pkg/kn/commands/source/ping/create_test.go
+++ b/pkg/kn/commands/source/ping/create_test.go
@@ -39,7 +39,7 @@ func TestSimpleCreatePingSource(t *testing.T) {
 	pingRecorder := pingClient.Recorder()
 	pingRecorder.CreatePingSource(createPingSource("testsource", "* * * * */2", "maxwell", "mysvc", map[string]string{"bla": "blub", "foo": "bar"}), nil)
 
-	out, err := executePingSourceCommand(pingClient, dynamicClient, "create", "--sink", "svc:mysvc", "--schedule", "* * * * */2", "--data", "maxwell", "testsource", "--ce-override", "bla=blub", "--ce-override", "foo=bar")
+	out, err := executePingSourceCommand(pingClient, dynamicClient, "create", "--sink", "ksvc:mysvc", "--schedule", "* * * * */2", "--data", "maxwell", "testsource", "--ce-override", "bla=blub", "--ce-override", "foo=bar")
 	assert.NilError(t, err, "Source should have been created")
 	assert.Assert(t, util.ContainsAll(out, "created", "default", "testsource"))
 
@@ -51,7 +51,7 @@ func TestNoSinkError(t *testing.T) {
 
 	dynamicClient := dynamicfake.CreateFakeKnDynamicClient("default")
 
-	out, err := executePingSourceCommand(pingClient, dynamicClient, "create", "--sink", "svc:mysvc", "--schedule", "* * * * */2", "--data", "maxwell", "testsource")
+	out, err := executePingSourceCommand(pingClient, dynamicClient, "create", "--sink", "ksvc:mysvc", "--schedule", "* * * * */2", "--data", "maxwell", "testsource")
 	assert.Error(t, err, "services.serving.knative.dev \"mysvc\" not found")
 	assert.Assert(t, util.ContainsAll(out, "Usage"))
 }
@@ -64,7 +64,7 @@ func TestNoSinkGivenError(t *testing.T) {
 }
 
 func TestNoNameGivenError(t *testing.T) {
-	out, err := executePingSourceCommand(nil, nil, "create", "--sink", "svc:mysvc", "--schedule", "* * * * */2")
+	out, err := executePingSourceCommand(nil, nil, "create", "--sink", "ksvc:mysvc", "--schedule", "* * * * */2")
 	assert.ErrorContains(t, err, "name")
 	assert.ErrorContains(t, err, "require")
 	assert.Assert(t, util.ContainsAll(out, "Usage", "require", "name"))

--- a/pkg/kn/commands/source/ping/flags.go
+++ b/pkg/kn/commands/source/ping/flags.go
@@ -86,7 +86,7 @@ func printSource(source *v1alpha2.PingSource, options hprinters.PrintOptions) ([
 	var sink string
 	if source.Spec.Sink.Ref != nil {
 		if source.Spec.Sink.Ref.Kind == "Service" {
-			sink = fmt.Sprintf("svc:%s", source.Spec.Sink.Ref.Name)
+			sink = fmt.Sprintf("ksvc:%s", source.Spec.Sink.Ref.Name)
 		} else {
 			sink = fmt.Sprintf("%s:%s", source.Spec.Sink.Ref.Kind, source.Spec.Sink.Ref.Name)
 		}

--- a/pkg/kn/commands/trigger/create.go
+++ b/pkg/kn/commands/trigger/create.go
@@ -37,10 +37,10 @@ func NewTriggerCreateCommand(p *commands.KnParams) *cobra.Command {
 		Short: "Create a trigger",
 		Example: `
   # Create a trigger 'mytrigger' to declare a subscription to events from default broker. The subscriber is service 'mysvc'
-  kn trigger create mytrigger --broker default --sink svc:mysvc
+  kn trigger create mytrigger --broker default --sink ksvc:mysvc
 
   # Create a trigger to filter events with attribute 'type=dev.knative.foo'
-  kn trigger create mytrigger --broker default --filter type=dev.knative.foo --sink svc:mysvc`,
+  kn trigger create mytrigger --broker default --filter type=dev.knative.foo --sink ksvc:mysvc`,
 
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {

--- a/pkg/kn/commands/trigger/create_test.go
+++ b/pkg/kn/commands/trigger/create_test.go
@@ -42,7 +42,7 @@ func TestTriggerCreate(t *testing.T) {
 	eventingRecorder.CreateTrigger(createTrigger("default", triggerName, map[string]string{"type": "dev.knative.foo"}, "mybroker", "mysvc"), nil)
 
 	out, err := executeTriggerCommand(eventingClient, dynamicClient, "create", triggerName, "--broker", "mybroker",
-		"--filter", "type=dev.knative.foo", "--sink", "svc:mysvc")
+		"--filter", "type=dev.knative.foo", "--sink", "ksvc:mysvc")
 	assert.NilError(t, err, "Trigger should be created")
 	assert.Assert(t, util.ContainsAll(out, "Trigger", triggerName, "created", "namespace", "default"))
 
@@ -60,7 +60,7 @@ func TestTriggerWithInjectCreate(t *testing.T) {
 	eventingRecorder.CreateTrigger(createTriggerWithInject("default", triggerName, map[string]string{"type": "dev.knative.foo"}, "default", "mysvc"), nil)
 
 	out, err := executeTriggerCommand(eventingClient, dynamicClient, "create", triggerName, "--broker", "default", "--inject-broker",
-		"--filter", "type=dev.knative.foo", "--sink", "svc:mysvc")
+		"--filter", "type=dev.knative.foo", "--sink", "ksvc:mysvc")
 	assert.NilError(t, err, "Trigger should be created")
 	assert.Assert(t, util.ContainsAll(out, "Trigger", triggerName, "created", "namespace", "default"))
 
@@ -75,7 +75,7 @@ func TestTriggetWithInjecError(t *testing.T) {
 	})
 
 	_, err := executeTriggerCommand(eventingClient, dynamicClient, "create", triggerName, "--broker", "mybroker", "--inject-broker",
-		"--filter", "type=dev.knative.foo", "--sink", "svc:mysvc")
+		"--filter", "type=dev.knative.foo", "--sink", "ksvc:mysvc")
 	assert.ErrorContains(t, err, "broker", "name", "'default'", "--inject-broker", "flag")
 }
 
@@ -86,7 +86,7 @@ func TestSinkNotFoundError(t *testing.T) {
 	errorMsg := fmt.Sprintf("cannot create trigger '%s' in namespace 'default' because: services.serving.knative.dev \"mysvc\" not found", triggerName)
 
 	out, err := executeTriggerCommand(eventingClient, dynamicClient, "create", triggerName, "--broker", "mybroker",
-		"--filter", "type=dev.knative.foo", "--sink", "svc:mysvc")
+		"--filter", "type=dev.knative.foo", "--sink", "ksvc:mysvc")
 	assert.Error(t, err, errorMsg)
 	assert.Assert(t, util.ContainsAll(out, errorMsg, "Usage"))
 }
@@ -109,7 +109,7 @@ func TestTriggerCreateMultipleFilter(t *testing.T) {
 	eventingRecorder.CreateTrigger(createTrigger("default", triggerName, map[string]string{"type": "dev.knative.foo", "source": "event.host"}, "mybroker", "mysvc"), nil)
 
 	out, err := executeTriggerCommand(eventingClient, dynamicClient, "create", triggerName, "--broker", "mybroker",
-		"--filter", "type=dev.knative.foo", "--filter", "source=event.host", "--sink", "svc:mysvc")
+		"--filter", "type=dev.knative.foo", "--filter", "source=event.host", "--sink", "ksvc:mysvc")
 	assert.NilError(t, err, "Trigger should be created")
 	assert.Assert(t, util.ContainsAll(out, "Trigger", triggerName, "created", "namespace", "default"))
 
@@ -126,7 +126,7 @@ func TestTriggerCreateWithoutFilter(t *testing.T) {
 	eventingRecorder := eventingClient.Recorder()
 	eventingRecorder.CreateTrigger(createTrigger("default", triggerName, nil, "mybroker", "mysvc"), nil)
 
-	out, err := executeTriggerCommand(eventingClient, dynamicClient, "create", triggerName, "--broker", "mybroker", "--sink", "svc:mysvc")
+	out, err := executeTriggerCommand(eventingClient, dynamicClient, "create", triggerName, "--broker", "mybroker", "--sink", "ksvc:mysvc")
 	assert.NilError(t, err, "Trigger should be created")
 	assert.Assert(t, util.ContainsAll(out, "Trigger", triggerName, "created", "namespace", "default"))
 

--- a/pkg/kn/commands/trigger/update.go
+++ b/pkg/kn/commands/trigger/update.go
@@ -42,11 +42,11 @@ func NewTriggerUpdateCommand(p *commands.KnParams) *cobra.Command {
   # Update the filter which key is 'type' to value 'knative.dev.bar' in a trigger 'mytrigger'
   kn trigger update mytrigger --filter type=knative.dev.bar
 
-  # Remove the filter which key is 'type' from a trigger 'mytrigger' 
+  # Remove the filter which key is 'type' from a trigger 'mytrigger'
   kn trigger update mytrigger --filter type-
 
-  # Update the sink of a trigger 'mytrigger' to 'svc:new-service'
-  kn trigger update mytrigger --sink svc:new-service
+  # Update the sink of a trigger 'mytrigger' to 'ksvc:new-service'
+  kn trigger update mytrigger --sink ksvc:new-service
   `,
 
 		RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/pkg/kn/commands/trigger/update_test.go
+++ b/pkg/kn/commands/trigger/update_test.go
@@ -42,7 +42,7 @@ func TestTriggerUpdate(t *testing.T) {
 	eventingRecorder.UpdateTrigger(updated, nil)
 
 	out, err := executeTriggerCommand(eventingClient, dynamicClient, "update", triggerName,
-		"--filter", "type=dev.knative.new", "--sink", "svc:mysvc")
+		"--filter", "type=dev.knative.new", "--sink", "ksvc:mysvc")
 	assert.NilError(t, err, "Trigger should be updated")
 	assert.Assert(t, util.ContainsAll(out, "Trigger", triggerName, "updated", "namespace", "default"))
 
@@ -55,7 +55,7 @@ func TestTriggerUpdateWithError(t *testing.T) {
 	eventingRecorder.GetTrigger(triggerName, nil, fmt.Errorf("trigger not found"))
 
 	out, err := executeTriggerCommand(eventingClient, nil, "update", triggerName,
-		"--filter", "type=dev.knative.new", "--sink", "svc:newsvc")
+		"--filter", "type=dev.knative.new", "--sink", "ksvc:newsvc")
 	assert.ErrorContains(t, err, "trigger not found")
 	assert.Assert(t, util.ContainsAll(out, "Usage", triggerName))
 
@@ -85,7 +85,7 @@ func TestTriggerUpdateDeletionTimestampNotNil(t *testing.T) {
 	eventingRecorder.GetTrigger(triggerName, present, nil)
 
 	_, err := executeTriggerCommand(eventingClient, nil, "update", triggerName,
-		"--filter", "type=dev.knative.new", "--sink", "svc:mysvc")
+		"--filter", "type=dev.knative.new", "--sink", "ksvc:mysvc")
 	assert.ErrorContains(t, err, present.Name)
 	assert.ErrorContains(t, err, "deletion")
 	assert.ErrorContains(t, err, "trigger")

--- a/test/e2e/ping_test.go
+++ b/test/e2e/ping_test.go
@@ -42,19 +42,19 @@ func TestSourcePing(t *testing.T) {
 
 	t.Log("create Ping sources with a sink to a service")
 
-	pingSourceCreate(r, "testpingsource0", "* * * * */1", "ping", "svc:testsvc0")
+	pingSourceCreate(r, "testpingsource0", "* * * * */1", "ping", "ksvc:testsvc0")
 	pingSourceListOutputName(r, "testpingsource0")
 
 	t.Log("delete Ping sources")
 	pingSourceDelete(r, "testpingsource0")
 
 	t.Log("create Ping source with a missing sink service")
-	pingSourceCreateMissingSink(r, "testpingsource1", "* * * * */1", "ping", "svc:unknown")
+	pingSourceCreateMissingSink(r, "testpingsource1", "* * * * */1", "ping", "ksvc:unknown")
 
 	t.Log("update Ping source sink service")
-	pingSourceCreate(r, "testpingsource2", "* * * * */1", "ping", "svc:testsvc0")
+	pingSourceCreate(r, "testpingsource2", "* * * * */1", "ping", "ksvc:testsvc0")
 	test.ServiceCreate(r, "testsvc1")
-	pingSourceUpdateSink(r, "testpingsource2", "svc:testsvc1")
+	pingSourceUpdateSink(r, "testpingsource2", "ksvc:testsvc1")
 	jpSinkRefNameInSpec := "jsonpath={.spec.sink.ref.name}"
 	out, err := test.GetResourceFieldsWithJSONPath(t, it, "pingsource", "testpingsource2", jpSinkRefNameInSpec)
 	assert.NilError(t, err)
@@ -62,7 +62,7 @@ func TestSourcePing(t *testing.T) {
 
 	t.Log("verify Ping source description")
 	mymsg := "This is a message from Ping."
-	pingSourceCreate(r, "testpingsource3", "*/1 * * * *", mymsg, "svc:testsvc1")
+	pingSourceCreate(r, "testpingsource3", "*/1 * * * *", mymsg, "ksvc:testsvc1")
 	verifyPingSourceDescribe(r, "testpingsource3", "*/1 * * * *", mymsg, "testsvc1")
 }
 

--- a/test/e2e/source_apiserver_test.go
+++ b/test/e2e/source_apiserver_test.go
@@ -53,15 +53,15 @@ func TestSourceApiServer(t *testing.T) {
 	test.ServiceCreate(r, "testsvc0")
 
 	t.Log("create apiserver sources with a sink to a service")
-	apiServerSourceCreate(r, "testapisource0", "Event:v1:key1=value1", "testsa", "svc:testsvc0")
-	apiServerSourceCreate(r, "testapisource1", "Event:v1", "testsa", "svc:testsvc0")
+	apiServerSourceCreate(r, "testapisource0", "Event:v1:key1=value1", "testsa", "ksvc:testsvc0")
+	apiServerSourceCreate(r, "testapisource1", "Event:v1", "testsa", "ksvc:testsvc0")
 	apiServerSourceListOutputName(r, "testapisource0", "testapisource1")
 
 	t.Log("list sources")
 	output := sourceList(r)
 	assert.Check(t, util.ContainsAll(output, "NAME", "TYPE", "RESOURCE", "SINK", "READY"))
-	assert.Check(t, util.ContainsAll(output, "testapisource0", "ApiServerSource", "apiserversources.sources.knative.dev", "svc:testsvc0"))
-	assert.Check(t, util.ContainsAll(output, "testapisource1", "ApiServerSource", "apiserversources.sources.knative.dev", "svc:testsvc0"))
+	assert.Check(t, util.ContainsAll(output, "testapisource0", "ApiServerSource", "apiserversources.sources.knative.dev", "ksvc:testsvc0"))
+	assert.Check(t, util.ContainsAll(output, "testapisource1", "ApiServerSource", "apiserversources.sources.knative.dev", "ksvc:testsvc0"))
 
 	t.Log("list sources in YAML format")
 	output = sourceList(r, "-oyaml")
@@ -72,12 +72,12 @@ func TestSourceApiServer(t *testing.T) {
 	apiServerSourceDelete(r, "testapisource1")
 
 	t.Log("create apiserver source with a missing sink service")
-	apiServerSourceCreateMissingSink(r, "testapisource2", "Event:v1", "testsa", "svc:unknown")
+	apiServerSourceCreateMissingSink(r, "testapisource2", "Event:v1", "testsa", "ksvc:unknown")
 
 	t.Log("update apiserver source sink service")
-	apiServerSourceCreate(r, "testapisource3", "Event:v1", "testsa", "svc:testsvc0")
+	apiServerSourceCreate(r, "testapisource3", "Event:v1", "testsa", "ksvc:testsvc0")
 	test.ServiceCreate(r, "testsvc1")
-	apiServerSourceUpdateSink(r, "testapisource3", "svc:testsvc1")
+	apiServerSourceUpdateSink(r, "testapisource3", "ksvc:testsvc1")
 	jpSinkRefNameInSpec := "jsonpath={.spec.sink.ref.name}"
 	out, err := test.GetResourceFieldsWithJSONPath(t, it, "apiserversource.sources.knative.dev", "testapisource3", jpSinkRefNameInSpec)
 	assert.NilError(t, err)

--- a/test/e2e/source_binding_test.go
+++ b/test/e2e/source_binding_test.go
@@ -40,16 +40,16 @@ func TestSourceBinding(t *testing.T) {
 	test.ServiceCreate(r, "testsvc0")
 
 	t.Log("create source binding")
-	sourceBindingCreate(r, "my-binding0", "Deployment:apps/v1:myapp", "svc:testsvc0")
+	sourceBindingCreate(r, "my-binding0", "Deployment:apps/v1:myapp", "ksvc:testsvc0")
 	sourceBindingListOutputName(r, "my-binding0")
 
 	t.Log("delete source binding")
 	sourceBindingDelete(r, "my-binding0")
 
 	t.Log("update source binding")
-	sourceBindingCreate(r, "my-binding1", "Deployment:apps/v1:myapp", "svc:testsvc0")
+	sourceBindingCreate(r, "my-binding1", "Deployment:apps/v1:myapp", "ksvc:testsvc0")
 	test.ServiceCreate(r, "testsvc1")
-	sourceBindingUpdate(r, "my-binding1", "Deployment:apps/v1:myapp", "svc:testsvc1")
+	sourceBindingUpdate(r, "my-binding1", "Deployment:apps/v1:myapp", "ksvc:testsvc1")
 	jpSinkRefNameInSpec := "jsonpath={.spec.sink.ref.name}"
 	out, err := test.GetResourceFieldsWithJSONPath(t, it, "sinkbindings.sources.knative.dev", "my-binding1", jpSinkRefNameInSpec)
 	assert.NilError(t, err)

--- a/test/e2e/source_list_test.go
+++ b/test/e2e/source_list_test.go
@@ -68,21 +68,21 @@ func TestSourceList(t *testing.T) {
 	assert.Check(t, util.ContainsNone(output, "NAME", "TYPE", "RESOURCE", "SINK", "READY"))
 
 	t.Log("Create API Server")
-	apiServerSourceCreate(r, "testapisource0", "Event:v1:key1=value1", "testsa", "svc:testsvc0")
+	apiServerSourceCreate(r, "testapisource0", "Event:v1:key1=value1", "testsa", "ksvc:testsvc0")
 	apiServerSourceListOutputName(r, "testapisource0")
 
 	t.Log("Create source binding")
-	sourceBindingCreate(r, "my-binding0", "Deployment:apps/v1:myapp", "svc:testsvc0")
+	sourceBindingCreate(r, "my-binding0", "Deployment:apps/v1:myapp", "ksvc:testsvc0")
 	sourceBindingListOutputName(r, "my-binding0")
 
 	t.Log("Create ping source")
-	pingSourceCreate(r, "testpingsource0", "* * * * */1", "ping", "svc:testsvc0")
+	pingSourceCreate(r, "testpingsource0", "* * * * */1", "ping", "ksvc:testsvc0")
 	pingSourceListOutputName(r, "testpingsource0")
 
 	t.Log("List sources filter valid case")
 	output = sourceList(r, "--type", "PingSource")
 	assert.Check(t, util.ContainsAll(output, "NAME", "TYPE", "RESOURCE", "SINK", "READY"))
-	assert.Check(t, util.ContainsAll(output, "testpingsource0", "PingSource", "pingsources.sources.knative.dev", "svc:testsvc0"))
+	assert.Check(t, util.ContainsAll(output, "testpingsource0", "PingSource", "pingsources.sources.knative.dev", "ksvc:testsvc0"))
 
 	t.Log("List sources filter invalid case")
 	output = sourceList(r, "--type", "testapisource0")

--- a/test/e2e/trigger_inject_broker_test.go
+++ b/test/e2e/trigger_inject_broker_test.go
@@ -51,13 +51,13 @@ func TestInjectBrokerTrigger(t *testing.T) {
 
 	t.Log("create trigger with error")
 	out := it.Kn().Run("trigger", "create", "errorTrigger", "--broker", "mybroker", "--inject-broker",
-		"--sink", "svc:sinksvc0", "--filter", "a=b")
+		"--sink", "ksvc:sinksvc0", "--filter", "a=b")
 	r.AssertError(out)
 	assert.Check(t, util.ContainsAllIgnoreCase(out.Stderr, "broker", "name", "'default'", "--inject-broker", "flag"))
 }
 
 func triggerCreateWithInject(r *test.KnRunResultCollector, name string, sinksvc string, filters []string) {
-	args := []string{"trigger", "create", name, "--broker", "default", "--inject-broker", "--sink", "svc:" + sinksvc}
+	args := []string{"trigger", "create", name, "--broker", "default", "--inject-broker", "--sink", "ksvc:" + sinksvc}
 	for _, v := range filters {
 		args = append(args, "--filter", v)
 	}

--- a/test/e2e/trigger_test.go
+++ b/test/e2e/trigger_test.go
@@ -80,7 +80,7 @@ func TestBrokerTrigger(t *testing.T) {
 // Private functions
 
 func triggerCreate(r *test.KnRunResultCollector, name string, sinksvc string, filters []string) {
-	args := []string{"trigger", "create", name, "--broker", "default", "--sink", "svc:" + sinksvc}
+	args := []string{"trigger", "create", name, "--broker", "default", "--sink", "ksvc:" + sinksvc}
 	if len(filters) > 0 {
 		for _, v := range filters {
 			args = append(args, "--filter", v)
@@ -92,7 +92,7 @@ func triggerCreate(r *test.KnRunResultCollector, name string, sinksvc string, fi
 }
 
 func triggerCreateMissingSink(r *test.KnRunResultCollector, name string, sinksvc string) {
-	out := r.KnTest().Kn().Run("trigger", "create", name, "--broker", "default", "--sink", "svc:"+sinksvc)
+	out := r.KnTest().Kn().Run("trigger", "create", name, "--broker", "default", "--sink", "ksvc:"+sinksvc)
 	r.AssertError(out)
 	assert.Check(r.T(), util.ContainsAll(out.Stderr, "services.serving.knative.dev", "not found"))
 }
@@ -104,7 +104,7 @@ func triggerDelete(r *test.KnRunResultCollector, name string) {
 }
 
 func triggerUpdate(r *test.KnRunResultCollector, name string, filter string, sinksvc string) {
-	out := r.KnTest().Kn().Run("trigger", "update", name, "--filter", filter, "--sink", "svc:"+sinksvc)
+	out := r.KnTest().Kn().Run("trigger", "update", name, "--filter", filter, "--sink", "ksvc:"+sinksvc)
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "Trigger", name, "updated", "namespace", r.KnTest().Kn().Namespace()))
 }


### PR DESCRIPTION
Fixes #898 

- 'ksvc' prefix --> Knative Service (or no prefix means knative service)
- Update all the examples and tests
- Add examples for broker, service and URI in flag help message
- Drop support for 'svc' and 'service' prefixes for knative service, hint in err msg if these prefixes are given

help message:
```
  -s, --sink string               Addressable sink for events. You can specify broker, knative service or URI. Examples: '--sink broker:nest' for 'nest' broker, '--sink
                                  https://event.receiver.uri' for an URI (identified by 'http' or 'https'), '--sink ksvc:receiver' or '--sink receiver' for 'receiver' knative service.
                                  If prefix is not provided, it is considered as knative service.
```