### PR TITLE
Fix Panic for kn trigger describe with Sink URI

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,10 @@
 |===
 | | Description | PR
 
+| 🐛
+| Fix Panic for `kn trigger describe` with Sink URI
+| https://github.com/knative/client/pull/900[#900]
+
 | 🎁
 | Group commands in usage output with `kn --help`
 | https://github.com/knative/client/pull/887[#887]

--- a/pkg/kn/commands/trigger/describe.go
+++ b/pkg/kn/commands/trigger/describe.go
@@ -98,10 +98,10 @@ func NewTriggerDescribeCommand(p *commands.KnParams) *cobra.Command {
 
 func writeSink(dw printers.PrefixWriter, sink *duckv1.Destination) {
 	subWriter := dw.WriteAttribute("Sink", "")
-	subWriter.WriteAttribute("Name", sink.Ref.Name)
-	subWriter.WriteAttribute("Namespace", sink.Ref.Namespace)
 	ref := sink.Ref
 	if ref != nil {
+		subWriter.WriteAttribute("Name", sink.Ref.Name)
+		subWriter.WriteAttribute("Namespace", sink.Ref.Namespace)
 		subWriter.WriteAttribute("Resource", fmt.Sprintf("%s (%s)", sink.Ref.Kind, sink.Ref.APIVersion))
 	}
 	uri := sink.URI


### PR DESCRIPTION
## Description

This pull request moves all `Sink.Ref` properties from being referenced for `kn trigger describe` until after it has been checked if `Sink.Ref` is nil due to using a URI instead of a Ref. 

## Reference

Fixes #899

/lint
