### PR TITLE
Add support for internal plugins

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -74,6 +74,10 @@
 | https://github.com/knative/client/pull/920[#920]
 
 | 🎁
+| Add support for internal plugins
+| https://github.com/knative/client/pull/880[#880]
+
+| 🎁
 | Add "url" output format to return service url in service describe
 | https://github.com/knative/client/pull/916[#916]
 

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -21,3 +21,39 @@ Please refer to the documentation and examples for more information on how to
 write your own plugins.
 
 - [kn plugin](../cmd/kn_plugin.md) - Plugin command group
+
+
+## Plugin Inlining
+
+It is possible to inline plugins that are written in golang.
+The following steps are required:
+
+* In your plugin project, create a implementation of the `Plugin` interface and add it to the global `plugin.InternalPlugins` slice in your `init()` method, like in this example:
+
+```go
+package plugin
+
+import (
+	"knative.dev/client/pkg/kn/plugin"
+)
+
+func init() {
+	plugin.InternalPlugins = append(plugin.InternalPlugins, &myPlugin{})
+}
+```
+
+* In your fork of the kn client, add a file `plugin_register.go` to the root package directory which imports your plugin's implementation package:
+
+```go
+package root
+
+import (
+        _ "github.com/rhuss/myplugin/plugin"
+)
+
+// RegisterInlinePlugins is an empty function which however forces the
+// compiler to run all init() methods of the registered imports
+func RegisterInlinePlugins() {}
+```
+
+* Update you `go.mod` file with the new dependency and build your custom distribution of `kn`

--- a/go.sum
+++ b/go.sum
@@ -360,6 +360,7 @@ github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fortytw2/leaktest v1.2.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
@@ -809,6 +810,7 @@ github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a/go.mod h1:M1qo
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-ieproxy v0.0.0-20190610004146-91bb50d98149/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
@@ -818,6 +820,7 @@ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.11 h1:FxPOTFNqGkuDUGi3H/qkUbQO4ZiBa2brKq5r0l8TGeM=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=

--- a/lib/test/broker.go
+++ b/lib/test/broker.go
@@ -24,7 +24,7 @@ import (
 
 // LabelNamespaceForDefaultBroker adds label 'knative-eventing-injection=enabled' to the configured namespace
 func LabelNamespaceForDefaultBroker(r *KnRunResultCollector) error {
-	cmd := []string{"label", "namespace", r.KnTest().Kn().Namespace(), v1beta1.DeprecatedInjectionAnnotation + "=enabled"}
+	cmd := []string{"label", "namespace", r.KnTest().Kn().Namespace(), v1beta1.InjectionAnnotation + "=enabled"}
 	_, err := Kubectl{}.Run(cmd...)
 
 	if err != nil {
@@ -43,7 +43,7 @@ func LabelNamespaceForDefaultBroker(r *KnRunResultCollector) error {
 
 // UnlabelNamespaceForDefaultBroker removes label 'knative-eventing-injection=enabled' from the configured namespace
 func UnlabelNamespaceForDefaultBroker(r *KnRunResultCollector) {
-	cmd := []string{"label", "namespace", r.KnTest().Kn().Namespace(), v1beta1.DeprecatedInjectionAnnotation + "-"}
+	cmd := []string{"label", "namespace", r.KnTest().Kn().Namespace(), v1beta1.InjectionAnnotation + "-"}
 	_, err := Kubectl{}.Run(cmd...)
 	if err != nil {
 		r.T().Fatalf("error executing '%s': %s", strings.Join(cmd, " "), err.Error())

--- a/pkg/kn/config/config.go
+++ b/pkg/kn/config/config.go
@@ -129,7 +129,7 @@ func BootstrapConfig() error {
 	viper.SetConfigFile(GlobalConfig.ConfigFile())
 	viper.AutomaticEnv() // read in environment variables that match
 
-	// Defaults are taken from the parsed flags, which in turn have bootstrapDefaults
+	// Defaults are taken from the parsed flags, which in turn have bootstrap defaults
 	// TODO: Re-enable when legacy handling for plugin config has been removed
 	// For now default handling is happening directly in the getter of GlobalConfig
 	// viper.SetDefault(keyPluginsDirectory, bootstrapDefaults.pluginsDir)

--- a/pkg/kn/plugin/manager.go
+++ b/pkg/kn/plugin/manager.go
@@ -163,7 +163,7 @@ func (manager *Manager) ListPluginsForCommandGroup(commandGroupParts []string) (
 			}
 
 			// Ignore all plugins that are shadowed
-			if _, ok := hasSeen[name]; !ok {
+			if seen, ok := hasSeen[name]; !ok || !seen {
 				plugins = append(plugins, &plugin{
 					path:         filepath.Join(dir, f.Name()),
 					name:         stripWindowsExecExtensions(f.Name()),

--- a/pkg/kn/plugin/manager.go
+++ b/pkg/kn/plugin/manager.go
@@ -441,10 +441,14 @@ func findInDirOrPath(name string, dir string, lookupInPath bool) (string, error)
 }
 
 // lookupInternalPlugin looks up internally registered plugins. Return nil if none is found.
+// Start with longest argument path first to find the most specific match
 func lookupInternalPlugin(parts []string) Plugin {
-	for _, plugin := range InternalPlugins {
-		if equalsSlice(plugin.CommandParts(), parts) {
-			return plugin
+	for i := len(parts); i > 0; i-- {
+		checkParts := parts[0:i]
+		for _, plugin := range InternalPlugins {
+			if equalsSlice(plugin.CommandParts(), checkParts) {
+				return plugin
+			}
 		}
 	}
 	return nil

--- a/pkg/kn/plugin/manager_test.go
+++ b/pkg/kn/plugin/manager_test.go
@@ -157,7 +157,7 @@ func TestPluginMixed(t *testing.T) {
 	ctx := setup(t)
 	defer cleanup(t, ctx)
 
-    createTestPlugin(t, "kn-external", ctx)
+	createTestPlugin(t, "kn-external", ctx)
 	createTestPlugin(t, "kn-shadow", ctx)
 
 	// Initialize registered plugins
@@ -167,13 +167,13 @@ func TestPluginMixed(t *testing.T) {
 	))()
 
 	data := []struct {
-			path []string
-			name  string
-			isInternal bool
+		path       []string
+		name       string
+		isInternal bool
 	}{
-		{[]string{ "external" },"kn-external", false},
-		{[]string{ "internal" }, "kn-internal",  true},
-		{[]string{ "shadow" }, "kn-shadow", true},
+		{[]string{"external"}, "kn-external", false},
+		{[]string{"internal"}, "kn-internal", true},
+		{[]string{"shadow"}, "kn-shadow", true},
 	}
 	for _, d := range data {
 		plugin, err := ctx.pluginManager.FindPlugin(d.path)
@@ -188,7 +188,7 @@ func TestPluginMixed(t *testing.T) {
 func prepareInternalPlugins(plugins ...Plugin) func() {
 	oldPlugins := InternalPlugins
 	InternalPlugins = plugins
-    return 	func() {
+	return func() {
 		InternalPlugins = oldPlugins
 	}
 }

--- a/pkg/kn/plugin/manager_test.go
+++ b/pkg/kn/plugin/manager_test.go
@@ -44,11 +44,11 @@ type testPlugin struct {
 	parts []string
 }
 
-func (t testPlugin) Name() string { return strings.Join(t.parts, " ") }
-func (t testPlugin) Execute(args []string) error { return nil}
+func (t testPlugin) Name() string                 { return strings.Join(t.parts, " ") }
+func (t testPlugin) Execute(args []string) error  { return nil }
 func (t testPlugin) Description() (string, error) { return "desc: " + t.Name(), nil }
-func (t testPlugin) CommandParts() []string { return t.parts }
-func (t testPlugin) Path() string { return "" }
+func (t testPlugin) CommandParts() []string       { return t.parts }
+func (t testPlugin) Path() string                 { return "" }
 
 var _ Plugin = testPlugin{}
 
@@ -133,11 +133,11 @@ func TestFindPluginInternally(t *testing.T) {
 
 	data := []struct {
 		parts []string
-		name string
-	} {
-		{ []string{ "a", "b"}, "a b" },
-		{ []string{ "a"}, "a" },
-		{ []string{ "a", "c"}, "a" },
+		name  string
+	}{
+		{[]string{"a", "b"}, "a b"},
+		{[]string{"a"}, "a"},
+		{[]string{"a", "c"}, "a"},
 	}
 	for _, d := range data {
 		plugin, err := ctx.pluginManager.FindPlugin(d.parts)


### PR DESCRIPTION
This PR adds the possibility for internal plugins. This works by allowing code to add to a global plugin slice `plugins.InternalPlugins`. By default this slice is empty, but for a custom assembly process (outside of this project), this could be leverage to add plugins directly in the code.

The changes are minimal and well tested, but the PR was created a bit in a hurry so apologies for not having an associated issue yet (but I will create on tomorrow).