### PR TITLE
Add Missing Assertions for Command Unit Tests

### DIFF
--- a/pkg/kn/commands/broker/create_test.go
+++ b/pkg/kn/commands/broker/create_test.go
@@ -37,7 +37,7 @@ func TestBrokerCreate(t *testing.T) {
 
 	out, err := executeBrokerCommand(eventingClient, "create", brokerName)
 	assert.NilError(t, err, "Broker should be created")
-	util.ContainsAll(out, "Broker", brokerName, "created", "namespace", "default")
+	assert.Assert(t, util.ContainsAll(out, "Broker", brokerName, "created", "namespace", "default"))
 
 	eventingRecorder.Validate()
 }
@@ -47,5 +47,5 @@ func TestBrokerCreateWithError(t *testing.T) {
 
 	_, err := executeBrokerCommand(eventingClient, "create")
 	assert.ErrorContains(t, err, "broker create")
-	util.ContainsAll(err.Error(), "broker create", "requires", "name", "argument")
+	assert.Assert(t, util.ContainsAll(err.Error(), "broker create", "requires", "name", "argument"))
 }

--- a/pkg/kn/commands/broker/delete_test.go
+++ b/pkg/kn/commands/broker/delete_test.go
@@ -36,7 +36,7 @@ func TestBrokerDelete(t *testing.T) {
 
 	out, err := executeBrokerCommand(eventingClient, "delete", brokerName)
 	assert.NilError(t, err, "Broker should be deleted")
-	util.ContainsAll(out, "Broker", brokerName, "deleted", "namespace", "default")
+	assert.Assert(t, util.ContainsAll(out, "Broker", brokerName, "deleted", "namespace", "default"))
 
 	eventingRecorder.Validate()
 }
@@ -50,7 +50,7 @@ func TestBrokerWithDelete(t *testing.T) {
 
 	out, err := executeBrokerCommand(eventingClient, "delete", brokerName)
 	assert.ErrorContains(t, err, brokerName)
-	util.ContainsAll(out, "broker", brokerName, "not found")
+	assert.Assert(t, util.ContainsAll(out, "broker", brokerName, "not found"))
 
 	eventingRecorder.Validate()
 }

--- a/pkg/kn/commands/source/ping/create_test.go
+++ b/pkg/kn/commands/source/ping/create_test.go
@@ -41,7 +41,7 @@ func TestSimpleCreatePingSource(t *testing.T) {
 
 	out, err := executePingSourceCommand(pingClient, dynamicClient, "create", "--sink", "svc:mysvc", "--schedule", "* * * * */2", "--data", "maxwell", "testsource", "--ce-override", "bla=blub", "--ce-override", "foo=bar")
 	assert.NilError(t, err, "Source should have been created")
-	util.ContainsAll(out, "created", "default", "testsource")
+	assert.Assert(t, util.ContainsAll(out, "created", "default", "testsource"))
 
 	pingRecorder.Validate()
 }

--- a/pkg/kn/commands/source/ping/delete_test.go
+++ b/pkg/kn/commands/source/ping/delete_test.go
@@ -33,7 +33,7 @@ func TestSimpleDelete(t *testing.T) {
 
 	out, err := executePingSourceCommand(pingClient, nil, "delete", "testsource")
 	assert.NilError(t, err)
-	util.ContainsAll(out, "deleted", "mynamespace", "testsource", "ping")
+	assert.Assert(t, util.ContainsAll(out, "deleted", "mynamespace", "testsource", "Ping"))
 
 	pingRecorder.Validate()
 }

--- a/pkg/kn/commands/source/ping/list_test.go
+++ b/pkg/kn/commands/source/ping/list_test.go
@@ -37,8 +37,8 @@ func TestListPingSource(t *testing.T) {
 
 	out, err := executePingSourceCommand(pingClient, nil, "list")
 	assert.NilError(t, err, "Sources should be listed")
-	util.ContainsAll(out, "NAME", "SCHEDULE", "SINK", "AGE", "CONDITIONS", "READY", "REASON")
-	util.ContainsAll(out, "testsource", "* * * * */2", "mysvc")
+	assert.Assert(t, util.ContainsAll(out, "NAME", "SCHEDULE", "SINK", "AGE", "CONDITIONS", "READY", "REASON"))
+	assert.Assert(t, util.ContainsAll(out, "testsource", "* * * * */2", "mysvc"))
 
 	pingRecorder.Validate()
 }
@@ -53,8 +53,8 @@ func TestListPingJobSourceEmpty(t *testing.T) {
 
 	out, err := executePingSourceCommand(pingClient, nil, "list")
 	assert.NilError(t, err, "Sources should be listed")
-	util.ContainsNone(out, "NAME", "SCHEDULE", "SINK", "AGE", "CONDITIONS", "READY", "REASON")
-	util.ContainsAll(out, "No", "ping", "source", "found")
+	assert.Assert(t, util.ContainsNone(out, "NAME", "SCHEDULE", "SINK", "AGE", "CONDITIONS", "READY", "REASON"))
+	assert.Assert(t, util.ContainsAll(out, "No", "Ping", "source", "found"))
 
 	pingRecorder.Validate()
 }

--- a/pkg/kn/commands/source/ping/update_test.go
+++ b/pkg/kn/commands/source/ping/update_test.go
@@ -34,7 +34,7 @@ func TestSimplePingUpdate(t *testing.T) {
 
 	out, err := executePingSourceCommand(pingSourceClient, nil, "update", "--schedule", "* * * * */3", "testsource")
 	assert.NilError(t, err)
-	util.ContainsAll(out, "updated", "default", "testsource")
+	assert.Assert(t, util.ContainsAll(out, "updated", "default", "testsource"))
 
 	pingRecorder.Validate()
 }
@@ -49,7 +49,7 @@ func TestSimplePingUpdateCEOverrides(t *testing.T) {
 
 	out, err := executePingSourceCommand(pingSourceClient, nil, "update", "--schedule", "* * * * */3", "testsource", "--ce-override", "bla-", "--ce-override", "foo=baz", "--ce-override", "new=ceoverride")
 	assert.NilError(t, err)
-	util.ContainsAll(out, "updated", "default", "testsource")
+	assert.Assert(t, util.ContainsAll(out, "updated", "default", "testsource"))
 
 	pingRecorder.Validate()
 }
@@ -62,7 +62,7 @@ func TestUpdateError(t *testing.T) {
 
 	out, err := executePingSourceCommand(pingClient, nil, "update", "testsource")
 	assert.ErrorContains(t, err, "testsource")
-	util.ContainsAll(out, "Usage", "testsource")
+	assert.Assert(t, util.ContainsAll(out, "Usage", "testsource"))
 
 	pingRecorder.Validate()
 }

--- a/pkg/kn/commands/trigger/create_test.go
+++ b/pkg/kn/commands/trigger/create_test.go
@@ -44,7 +44,7 @@ func TestTriggerCreate(t *testing.T) {
 	out, err := executeTriggerCommand(eventingClient, dynamicClient, "create", triggerName, "--broker", "mybroker",
 		"--filter", "type=dev.knative.foo", "--sink", "svc:mysvc")
 	assert.NilError(t, err, "Trigger should be created")
-	util.ContainsAll(out, "Trigger", triggerName, "created", "namespace", "default")
+	assert.Assert(t, util.ContainsAll(out, "Trigger", triggerName, "created", "namespace", "default"))
 
 	eventingRecorder.Validate()
 }
@@ -62,7 +62,7 @@ func TestTriggerWithInjectCreate(t *testing.T) {
 	out, err := executeTriggerCommand(eventingClient, dynamicClient, "create", triggerName, "--broker", "default", "--inject-broker",
 		"--filter", "type=dev.knative.foo", "--sink", "svc:mysvc")
 	assert.NilError(t, err, "Trigger should be created")
-	util.ContainsAll(out, "Trigger", triggerName, "created", "namespace", "default")
+	assert.Assert(t, util.ContainsAll(out, "Trigger", triggerName, "created", "namespace", "default"))
 
 	eventingRecorder.Validate()
 }
@@ -111,7 +111,7 @@ func TestTriggerCreateMultipleFilter(t *testing.T) {
 	out, err := executeTriggerCommand(eventingClient, dynamicClient, "create", triggerName, "--broker", "mybroker",
 		"--filter", "type=dev.knative.foo", "--filter", "source=event.host", "--sink", "svc:mysvc")
 	assert.NilError(t, err, "Trigger should be created")
-	util.ContainsAll(out, "Trigger", triggerName, "created", "namespace", "default")
+	assert.Assert(t, util.ContainsAll(out, "Trigger", triggerName, "created", "namespace", "default"))
 
 	eventingRecorder.Validate()
 }
@@ -128,7 +128,7 @@ func TestTriggerCreateWithoutFilter(t *testing.T) {
 
 	out, err := executeTriggerCommand(eventingClient, dynamicClient, "create", triggerName, "--broker", "mybroker", "--sink", "svc:mysvc")
 	assert.NilError(t, err, "Trigger should be created")
-	util.ContainsAll(out, "Trigger", triggerName, "created", "namespace", "default")
+	assert.Assert(t, util.ContainsAll(out, "Trigger", triggerName, "created", "namespace", "default"))
 
 	eventingRecorder.Validate()
 }

--- a/pkg/kn/commands/trigger/delete_test.go
+++ b/pkg/kn/commands/trigger/delete_test.go
@@ -33,7 +33,7 @@ func TestTriggerDelete(t *testing.T) {
 
 	out, err := executeTriggerCommand(eventingClient, nil, "delete", triggerName)
 	assert.NilError(t, err)
-	util.ContainsAll(out, "deleted", "testns", triggerName)
+	assert.Assert(t, util.ContainsAll(out, "deleted", "default", triggerName))
 
 	eventingRecorder.Validate()
 }
@@ -47,7 +47,7 @@ func TestTriggerDeleteWithError(t *testing.T) {
 
 	out, err := executeTriggerCommand(eventingClient, nil, "delete", triggerName)
 	assert.ErrorContains(t, err, triggerName)
-	util.ContainsAll(out, "trigger", triggerName, "not found")
+	assert.Assert(t, util.ContainsAll(out, "trigger", triggerName, "not found"))
 
 	eventingRecorder.Validate()
 }

--- a/pkg/kn/commands/trigger/update_test.go
+++ b/pkg/kn/commands/trigger/update_test.go
@@ -44,7 +44,7 @@ func TestTriggerUpdate(t *testing.T) {
 	out, err := executeTriggerCommand(eventingClient, dynamicClient, "update", triggerName,
 		"--filter", "type=dev.knative.new", "--sink", "svc:mysvc")
 	assert.NilError(t, err, "Trigger should be updated")
-	util.ContainsAll(out, "Trigger", triggerName, "updated", "namespace", "default")
+	assert.Assert(t, util.ContainsAll(out, "Trigger", triggerName, "updated", "namespace", "default"))
 
 	eventingRecorder.Validate()
 }
@@ -57,7 +57,7 @@ func TestTriggerUpdateWithError(t *testing.T) {
 	out, err := executeTriggerCommand(eventingClient, nil, "update", triggerName,
 		"--filter", "type=dev.knative.new", "--sink", "svc:newsvc")
 	assert.ErrorContains(t, err, "trigger not found")
-	util.ContainsAll(out, "Usage", triggerName)
+	assert.Assert(t, util.ContainsAll(out, "Usage", triggerName))
 
 	eventingRecorder.Validate()
 }
@@ -71,7 +71,7 @@ func TestTriggerUpdateInvalidBroker(t *testing.T) {
 	out, err := executeTriggerCommand(eventingClient, nil, "update", triggerName,
 		"--broker", "newbroker")
 	assert.ErrorContains(t, err, "broker is immutable")
-	util.ContainsAll(out, "Usage", triggerName)
+	assert.Assert(t, util.ContainsAll(out, "Usage", triggerName))
 
 	eventingRecorder.Validate()
 }


### PR DESCRIPTION
## Description

This pull request adds assertions for unit tests for verifying command output. The commands missing these assertions in unit tests were `source ping`, `trigger`, and `broker`. 

It also updates unit tests for `source ping` since `Ping` is capitalized in command output for `delete` and `list`.

/lint
