### PR TITLE
Don't Display kn --help message with Plugin Errors

### DIFF
--- a/cmd/kn/main_test.go
+++ b/cmd/kn/main_test.go
@@ -244,12 +244,35 @@ func TestRunWithError(t *testing.T) {
 	}
 	for _, d := range data {
 		capture := test.CaptureOutput(t)
-		printError(errors.New(d.given))
+		printError(errors.New(d.given), true)
 		stdOut, errOut := capture.Close()
 
 		assert.Equal(t, stdOut, "")
 		assert.Assert(t, strings.Contains(errOut, d.expected))
 		assert.Assert(t, util.ContainsAll(errOut, "Run", "--help", "usage"))
+	}
+}
+
+func TestRunWithPluginError(t *testing.T) {
+	data := []struct {
+		given    string
+		expected string
+	}{
+		{
+			"exit status 1",
+			"Error: exit status 1",
+		},
+	}
+	for _, d := range data {
+		capture := test.CaptureOutput(t)
+		// displayHelp argument is false for plugin error
+		printError(errors.New(d.given), false)
+		stdOut, errOut := capture.Close()
+
+		assert.Equal(t, stdOut, "")
+		assert.Assert(t, strings.Contains(errOut, d.expected))
+		// check that --help message isn't displayed
+		assert.Assert(t, util.ContainsNone(errOut, "Run", "--help", "usage"))
 	}
 }
 
@@ -262,9 +285,10 @@ func TestRun(t *testing.T) {
 	})()
 
 	capture := test.CaptureOutput(t)
-	err := run(os.Args[1:])
+	displayHelp, err := run(os.Args[1:])
 	out, _ := capture.Close()
 
 	assert.NilError(t, err)
+	assert.Assert(t, displayHelp == true, "plugin error occurred (but should not have)")
 	assert.Assert(t, util.ContainsAllIgnoreCase(out, "version", "build", "git"))
 }


### PR DESCRIPTION
## Description

This pull request removes the `kn --help` message with a plugin error as detailed in #904. 

## Changes

* Use a boolean `pluginErr` in `main.go` to determine whether to print an 
* Add e2e test in `plugin_test.go` to verify error message isn't present

## Reference

Fixes #904

/lint
