### PR TITLE
feat: Add --filename flag to service create command

### DIFF
--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -61,6 +61,7 @@ kn service create NAME --image IMAGE
       --concurrency-utilization int   Percentage of concurrent requests utilization before scaling up. (default 70)
   -e, --env stringArray               Environment variable to set. NAME=value; you may provide this flag any number of times to set multiple environment variables. To unset, specify the environment variable name followed by a "-" (e.g., NAME-).
       --env-from stringArray          Add environment variables from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret:). Example: --env-from cm:myconfigmap or --env-from secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --env-from cm:myconfigmap-.
+      --file string                   Create service from file.
       --force                         Create service forcefully, replaces existing service if any.
   -h, --help                          help for create
       --image string                  Image to run.

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -61,7 +61,7 @@ kn service create NAME --image IMAGE
       --concurrency-utilization int   Percentage of concurrent requests utilization before scaling up. (default 70)
   -e, --env stringArray               Environment variable to set. NAME=value; you may provide this flag any number of times to set multiple environment variables. To unset, specify the environment variable name followed by a "-" (e.g., NAME-).
       --env-from stringArray          Add environment variables from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret:). Example: --env-from cm:myconfigmap or --env-from secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --env-from cm:myconfigmap-.
-  -f, --filename string               Create service from file.
+  -f, --filename string               Create a service from file.
       --force                         Create service forcefully, replaces existing service if any.
   -h, --help                          help for create
       --image string                  Image to run.

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -61,7 +61,7 @@ kn service create NAME --image IMAGE
       --concurrency-utilization int   Percentage of concurrent requests utilization before scaling up. (default 70)
   -e, --env stringArray               Environment variable to set. NAME=value; you may provide this flag any number of times to set multiple environment variables. To unset, specify the environment variable name followed by a "-" (e.g., NAME-).
       --env-from stringArray          Add environment variables from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret:). Example: --env-from cm:myconfigmap or --env-from secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --env-from cm:myconfigmap-.
-      --file string                   Create service from file.
+  -f, --filename string               Create service from file.
       --force                         Create service forcefully, replaces existing service if any.
   -h, --help                          help for create
       --image string                  Image to run.

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -275,7 +275,7 @@ func (p *ConfigurationEditFlags) AddCreateFlags(command *cobra.Command) {
 	command.Flags().BoolVar(&p.ForceCreate, "force", false,
 		"Create service forcefully, replaces existing service if any.")
 	command.Flags().StringVarP(&p.Filename, "filename", "f", "", "Create a service from file.")
-	command.MarkFlagFilename("file")
+	command.MarkFlagFilename("filename")
 }
 
 // Apply mutates the given service according to the flags in the command.

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -274,8 +274,7 @@ func (p *ConfigurationEditFlags) AddCreateFlags(command *cobra.Command) {
 	p.addSharedFlags(command)
 	command.Flags().BoolVar(&p.ForceCreate, "force", false,
 		"Create service forcefully, replaces existing service if any.")
-	//command.MarkFlagRequired("image")
-	command.Flags().StringVarP(&p.File, "file", "", "", "Create service from file.")
+	command.Flags().StringVarP(&p.File, "filename", "f", "", "Create service from file.")
 	command.MarkFlagFilename("file")
 }
 

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -68,6 +68,8 @@ type ConfigurationEditFlags struct {
 	GenerateRevisionName bool
 	ForceCreate          bool
 
+	File string
+
 	// Bookkeeping
 	flags []string
 }
@@ -272,7 +274,9 @@ func (p *ConfigurationEditFlags) AddCreateFlags(command *cobra.Command) {
 	p.addSharedFlags(command)
 	command.Flags().BoolVar(&p.ForceCreate, "force", false,
 		"Create service forcefully, replaces existing service if any.")
-	command.MarkFlagRequired("image")
+	//command.MarkFlagRequired("image")
+	command.Flags().StringVarP(&p.File, "file", "", "", "Create service from file.")
+	command.MarkFlagFilename("file")
 }
 
 // Apply mutates the given service according to the flags in the command.

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -68,7 +68,7 @@ type ConfigurationEditFlags struct {
 	GenerateRevisionName bool
 	ForceCreate          bool
 
-	File string
+	Filename string
 
 	// Bookkeeping
 	flags []string
@@ -274,7 +274,7 @@ func (p *ConfigurationEditFlags) AddCreateFlags(command *cobra.Command) {
 	p.addSharedFlags(command)
 	command.Flags().BoolVar(&p.ForceCreate, "force", false,
 		"Create service forcefully, replaces existing service if any.")
-	command.Flags().StringVarP(&p.File, "filename", "f", "", "Create service from file.")
+	command.Flags().StringVarP(&p.Filename, "filename", "f", "", "Create a service from file.")
 	command.MarkFlagFilename("file")
 }
 

--- a/pkg/kn/commands/service/create.go
+++ b/pkg/kn/commands/service/create.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 
 	"knative.dev/client/pkg/kn/commands"
 	servinglib "knative.dev/client/pkg/serving"
@@ -28,6 +29,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	clientservingv1 "knative.dev/client/pkg/serving/v1"
@@ -79,7 +82,7 @@ func NewServiceCreateCommand(p *commands.KnParams) *cobra.Command {
 				return errors.New("'service create' requires the service name given as single argument")
 			}
 			name := args[0]
-			if editFlags.Image == "" {
+			if editFlags.Image == "" && editFlags.File == "" {
 				return errors.New("'service create' requires the image name to run provided with the --image option")
 			}
 
@@ -88,7 +91,12 @@ func NewServiceCreateCommand(p *commands.KnParams) *cobra.Command {
 				return err
 			}
 
-			service, err := constructService(cmd, editFlags, name, namespace)
+			var service *servingv1.Service
+			if editFlags.File == "" {
+				service, err = constructService(cmd, editFlags, name, namespace)
+			} else {
+				service, err = constructServiceFromFile(cmd, editFlags, name, namespace)
+			}
 			if err != nil {
 				return err
 			}
@@ -97,8 +105,7 @@ func NewServiceCreateCommand(p *commands.KnParams) *cobra.Command {
 			if err != nil {
 				return err
 			}
-
-			serviceExists, err := serviceExists(client, name)
+			serviceExists, err := serviceExists(client, service.Name)
 			if err != nil {
 				return err
 			}
@@ -108,7 +115,7 @@ func NewServiceCreateCommand(p *commands.KnParams) *cobra.Command {
 				if !editFlags.ForceCreate {
 					return fmt.Errorf(
 						"cannot create service '%s' in namespace '%s' "+
-							"because the service already exists and no --force option was given", name, namespace)
+							"because the service already exists and no --force option was given", service.Name, namespace)
 				}
 				err = replaceService(client, service, waitFlags, out)
 			} else {
@@ -258,5 +265,34 @@ func constructService(cmd *cobra.Command, editFlags ConfigurationEditFlags, name
 	if err != nil {
 		return nil, err
 	}
+	return &service, nil
+}
+
+// constructServiceFromFile creates struct from provided file
+func constructServiceFromFile(cmd *cobra.Command, editFlags ConfigurationEditFlags, name, namespace string) (*servingv1.Service, error) {
+	var service servingv1.Service
+	file, err := os.Open(editFlags.File)
+	if err != nil {
+		return nil, err
+	}
+	decoder := yaml.NewYAMLOrJSONDecoder(file, 512)
+
+	err = decoder.Decode(&service)
+	if err != nil {
+		return nil, err
+	}
+	if service.Name != name {
+		return nil, fmt.Errorf("Provided service name '%s' doesn't match name from file '%s'.", name, service.Name)
+	}
+	// Set namespace in case it's specified as --namespace
+	service.ObjectMeta.Namespace = namespace
+
+	// We need to generate revision to have --force replace working
+	revName, err := servinglib.GenerateRevisionName(editFlags.RevisionName, &service)
+	if err != nil {
+		return nil, err
+	}
+	service.Spec.Template.Name = revName
+
 	return &service, nil
 }

--- a/pkg/kn/commands/service/create.go
+++ b/pkg/kn/commands/service/create.go
@@ -82,7 +82,7 @@ func NewServiceCreateCommand(p *commands.KnParams) *cobra.Command {
 				return errors.New("'service create' requires the service name given as single argument")
 			}
 			name := args[0]
-			if editFlags.Image == "" && editFlags.File == "" {
+			if editFlags.Image == "" && editFlags.Filename == "" {
 				return errors.New("'service create' requires the image name to run provided with the --image option")
 			}
 
@@ -92,7 +92,7 @@ func NewServiceCreateCommand(p *commands.KnParams) *cobra.Command {
 			}
 
 			var service *servingv1.Service
-			if editFlags.File == "" {
+			if editFlags.Filename == "" {
 				service, err = constructService(cmd, editFlags, name, namespace)
 			} else {
 				service, err = constructServiceFromFile(cmd, editFlags, name, namespace)
@@ -271,7 +271,7 @@ func constructService(cmd *cobra.Command, editFlags ConfigurationEditFlags, name
 // constructServiceFromFile creates struct from provided file
 func constructServiceFromFile(cmd *cobra.Command, editFlags ConfigurationEditFlags, name, namespace string) (*servingv1.Service, error) {
 	var service servingv1.Service
-	file, err := os.Open(editFlags.File)
+	file, err := os.Open(editFlags.Filename)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kn/commands/service/create.go
+++ b/pkg/kn/commands/service/create.go
@@ -288,11 +288,11 @@ func constructServiceFromFile(cmd *cobra.Command, editFlags ConfigurationEditFla
 	service.ObjectMeta.Namespace = namespace
 
 	// We need to generate revision to have --force replace working
-	revName, err := servinglib.GenerateRevisionName(editFlags.RevisionName, &service)
-	if err != nil {
-		return nil, err
-	}
-	service.Spec.Template.Name = revName
+	// revName, err := servinglib.GenerateRevisionName(editFlags.RevisionName, &service)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	service.Spec.Template.Name = ""
 
 	return &service, nil
 }

--- a/pkg/kn/commands/service/create.go
+++ b/pkg/kn/commands/service/create.go
@@ -105,7 +105,7 @@ func NewServiceCreateCommand(p *commands.KnParams) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			serviceExists, err := serviceExists(client, service.Name)
+			serviceExists, err := serviceExists(client, name)
 			if err != nil {
 				return err
 			}
@@ -115,7 +115,7 @@ func NewServiceCreateCommand(p *commands.KnParams) *cobra.Command {
 				if !editFlags.ForceCreate {
 					return fmt.Errorf(
 						"cannot create service '%s' in namespace '%s' "+
-							"because the service already exists and no --force option was given", service.Name, namespace)
+							"because the service already exists and no --force option was given", name, namespace)
 				}
 				err = replaceService(client, service, waitFlags, out)
 			} else {

--- a/pkg/kn/commands/service/create.go
+++ b/pkg/kn/commands/service/create.go
@@ -282,7 +282,7 @@ func constructServiceFromFile(cmd *cobra.Command, editFlags ConfigurationEditFla
 		return nil, err
 	}
 	if service.Name != name {
-		return nil, fmt.Errorf("Provided service name '%s' doesn't match name from file '%s'.", name, service.Name)
+		return nil, fmt.Errorf("provided service name '%s' doesn't match name from file '%s'", name, service.Name)
 	}
 	// Set namespace in case it's specified as --namespace
 	service.ObjectMeta.Namespace = namespace

--- a/pkg/kn/commands/service/create_test.go
+++ b/pkg/kn/commands/service/create_test.go
@@ -788,6 +788,36 @@ func TestServiceCreateFromJSON(t *testing.T) {
 	assert.Equal(t, created.Spec.Template.Spec.GetContainer().Image, "gcr.io/foo/bar:baz")
 }
 
+func TestServiceCreateFromFileWithName(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "kn-file")
+	defer os.RemoveAll(tempDir)
+	assert.NilError(t, err)
+
+	tempFile := filepath.Join(tempDir, "service.yaml")
+	err = ioutil.WriteFile(tempFile, []byte(serviceYAML), os.FileMode(0666))
+	assert.NilError(t, err)
+
+	t.Log("no NAME param provided")
+	action, created, _, err := fakeServiceCreate([]string{
+		"service", "create", "--filename", tempFile}, false)
+	assert.NilError(t, err)
+	assert.Assert(t, action.Matches("create", "services"))
+
+	assert.Equal(t, created.Name, "foo")
+	assert.Equal(t, created.Spec.Template.Spec.GetContainer().Image, "gcr.io/foo/bar:baz")
+
+	t.Log("no service.Name provided in file")
+	err = ioutil.WriteFile(tempFile, []byte(strings.ReplaceAll(serviceYAML, "name: foo", "")), os.FileMode(0666))
+	assert.NilError(t, err)
+	action, created, _, err = fakeServiceCreate([]string{
+		"service", "create", "cli-foo", "--filename", tempFile}, false)
+	assert.NilError(t, err)
+	assert.Assert(t, action.Matches("create", "services"))
+
+	assert.Equal(t, created.Name, "cli-foo")
+	assert.Equal(t, created.Spec.Template.Spec.GetContainer().Image, "gcr.io/foo/bar:baz")
+}
+
 func TestServiceCreateFileNameMismatch(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", "kn-file")
 	assert.NilError(t, err)
@@ -796,10 +826,19 @@ func TestServiceCreateFileNameMismatch(t *testing.T) {
 	err = ioutil.WriteFile(tempFile, []byte(serviceJSON), os.FileMode(0666))
 	assert.NilError(t, err)
 
+	t.Log("NAME param nad service.Name differ")
 	_, _, _, err = fakeServiceCreate([]string{
 		"service", "create", "anotherFoo", "--filename", tempFile}, false)
-
+	assert.Assert(t, err != nil)
 	assert.Assert(t, util.ContainsAllIgnoreCase(err.Error(), "provided", "'anotherFoo'", "name", "match", "from", "file", "'foo'"))
+
+	t.Log("no NAME param & no service.Name provided in file")
+	err = ioutil.WriteFile(tempFile, []byte(strings.ReplaceAll(serviceYAML, "name: foo", "")), os.FileMode(0666))
+	assert.NilError(t, err)
+	_, _, _, err = fakeServiceCreate([]string{
+		"service", "create", "--filename", tempFile}, false)
+	assert.Assert(t, err != nil)
+	assert.Assert(t, util.ContainsAllIgnoreCase(err.Error(), "no", "service", "name", "provided", "parameter", "file"))
 }
 
 func TestServiceCreateFileError(t *testing.T) {
@@ -862,5 +901,5 @@ func TestServiceCreateInvalidDataYAML(t *testing.T) {
 	err = ioutil.WriteFile(tempFile, []byte(invalidData), os.FileMode(0666))
 	assert.NilError(t, err)
 	_, _, _, err = fakeServiceCreate([]string{"service", "create", "foo", "--filename", tempFile}, false)
-	assert.Assert(t, util.ContainsAll(err.Error(), "found", "found", "found", "violates", "violates"))
+	assert.Assert(t, util.ContainsAll(err.Error(), "found", "tab", "violates", "indentation"))
 }

--- a/pkg/kn/commands/service/create_test.go
+++ b/pkg/kn/commands/service/create_test.go
@@ -737,7 +737,7 @@ var serviceJSON = `
     "template": {
 		"spec": {
 		"containers": [
-			{ 
+			{
 			"image": "gcr.io/foo/bar:baz",
 			"env": [
 				{

--- a/pkg/kn/commands/service/create_test.go
+++ b/pkg/kn/commands/service/create_test.go
@@ -754,8 +754,8 @@ var serviceJSON = `
 
 func TestServiceCreateFromYAML(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", "kn-file")
-	assert.NilError(t, err)
 	defer os.RemoveAll(tempDir)
+	assert.NilError(t, err)
 
 	tempFile := filepath.Join(tempDir, "service.yaml")
 	err = ioutil.WriteFile(tempFile, []byte(serviceYAML), os.FileMode(0666))
@@ -772,8 +772,8 @@ func TestServiceCreateFromYAML(t *testing.T) {
 
 func TestServiceCreateFromJSON(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", "kn-file")
-	assert.NilError(t, err)
 	defer os.RemoveAll(tempDir)
+	assert.NilError(t, err)
 
 	tempFile := filepath.Join(tempDir, "service.json")
 	err = ioutil.WriteFile(tempFile, []byte(serviceJSON), os.FileMode(0666))
@@ -811,8 +811,8 @@ func TestServiceCreateFileError(t *testing.T) {
 
 func TestServiceCreateInvalidDataJSON(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", "kn-file")
-	assert.NilError(t, err)
 	defer os.RemoveAll(tempDir)
+	assert.NilError(t, err)
 	tempFile := filepath.Join(tempDir, "invalid.json")
 
 	// Double curly bracket at the beginning of file
@@ -839,8 +839,8 @@ func TestServiceCreateInvalidDataJSON(t *testing.T) {
 
 func TestServiceCreateInvalidDataYAML(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", "kn-file")
-	assert.NilError(t, err)
 	defer os.RemoveAll(tempDir)
+	assert.NilError(t, err)
 	tempFile := filepath.Join(tempDir, "invalid.yaml")
 
 	// Remove dash

--- a/pkg/kn/commands/service/create_test.go
+++ b/pkg/kn/commands/service/create_test.go
@@ -762,7 +762,7 @@ func TestServiceCreateFromYAML(t *testing.T) {
 	assert.NilError(t, err)
 
 	action, created, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--file", tempFile}, false)
+		"service", "create", "foo", "--filename", tempFile}, false)
 	assert.NilError(t, err)
 	assert.Assert(t, action.Matches("create", "services"))
 
@@ -780,7 +780,7 @@ func TestServiceCreateFromJSON(t *testing.T) {
 	assert.NilError(t, err)
 
 	action, created, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--file", tempFile}, false)
+		"service", "create", "foo", "--filename", tempFile}, false)
 	assert.NilError(t, err)
 	assert.Assert(t, action.Matches("create", "services"))
 
@@ -797,14 +797,14 @@ func TestServiceCreateFileNameMismatch(t *testing.T) {
 	assert.NilError(t, err)
 
 	_, _, _, err = fakeServiceCreate([]string{
-		"service", "create", "anotherFoo", "--file", tempFile}, false)
+		"service", "create", "anotherFoo", "--filename", tempFile}, false)
 
 	assert.Assert(t, util.ContainsAllIgnoreCase(err.Error(), "provided", "'anotherFoo'", "name", "match", "from", "file", "'foo'"))
 }
 
 func TestServiceCreateFileError(t *testing.T) {
 	_, _, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--file", "filepath"}, false)
+		"service", "create", "foo", "--filename", "filepath"}, false)
 
 	assert.Assert(t, util.ContainsAll(err.Error(), "no", "such", "file", "directory", "filepath"))
 }
@@ -819,21 +819,21 @@ func TestServiceCreateInvalidDataJSON(t *testing.T) {
 	invalidData := strings.Replace(serviceJSON, "{\n", "{{\n", 1)
 	err = ioutil.WriteFile(tempFile, []byte(invalidData), os.FileMode(0666))
 	assert.NilError(t, err)
-	_, _, _, err = fakeServiceCreate([]string{"service", "create", "foo", "--file", tempFile}, false)
+	_, _, _, err = fakeServiceCreate([]string{"service", "create", "foo", "--filename", tempFile}, false)
 	assert.Assert(t, util.ContainsAll(err.Error(), "invalid", "character", "'{'", "beginning"))
 
 	// Remove closing quote on key
 	invalidData = strings.Replace(serviceJSON, "metadata\"", "metadata", 1)
 	err = ioutil.WriteFile(tempFile, []byte(invalidData), os.FileMode(0666))
 	assert.NilError(t, err)
-	_, _, _, err = fakeServiceCreate([]string{"service", "create", "foo", "--file", tempFile}, false)
+	_, _, _, err = fakeServiceCreate([]string{"service", "create", "foo", "--filename", tempFile}, false)
 	assert.Assert(t, util.ContainsAll(err.Error(), "invalid", "character", "'\\n'", "string", "literal"))
 
 	// Remove opening square bracket
 	invalidData = strings.Replace(serviceJSON, " [", "", 1)
 	err = ioutil.WriteFile(tempFile, []byte(invalidData), os.FileMode(0666))
 	assert.NilError(t, err)
-	_, _, _, err = fakeServiceCreate([]string{"service", "create", "foo", "--file", tempFile}, false)
+	_, _, _, err = fakeServiceCreate([]string{"service", "create", "foo", "--filename", tempFile}, false)
 	assert.Assert(t, util.ContainsAll(err.Error(), "invalid", "character", "']'", "after", "key:value"))
 }
 
@@ -847,20 +847,20 @@ func TestServiceCreateInvalidDataYAML(t *testing.T) {
 	invalidData := strings.Replace(serviceYAML, "- image", "image", 1)
 	err = ioutil.WriteFile(tempFile, []byte(invalidData), os.FileMode(0666))
 	assert.NilError(t, err)
-	_, _, _, err = fakeServiceCreate([]string{"service", "create", "foo", "--file", tempFile}, false)
+	_, _, _, err = fakeServiceCreate([]string{"service", "create", "foo", "--filename", tempFile}, false)
 	assert.Assert(t, util.ContainsAll(err.Error(), "mapping", "values", "not", "allowed"))
 
 	// Remove name key
 	invalidData = strings.Replace(serviceYAML, "name:", "", 1)
 	err = ioutil.WriteFile(tempFile, []byte(invalidData), os.FileMode(0666))
 	assert.NilError(t, err)
-	_, _, _, err = fakeServiceCreate([]string{"service", "create", "foo", "--file", tempFile}, false)
+	_, _, _, err = fakeServiceCreate([]string{"service", "create", "foo", "--filename", tempFile}, false)
 	assert.Assert(t, util.ContainsAll(err.Error(), "cannot", "unmarshal", "Go", "struct", "Service.metadata"))
 
 	// Remove opening square bracket
 	invalidData = strings.Replace(serviceYAML, "env", "\tenv", 1)
 	err = ioutil.WriteFile(tempFile, []byte(invalidData), os.FileMode(0666))
 	assert.NilError(t, err)
-	_, _, _, err = fakeServiceCreate([]string{"service", "create", "foo", "--file", tempFile}, false)
+	_, _, _, err = fakeServiceCreate([]string{"service", "create", "foo", "--filename", tempFile}, false)
 	assert.Assert(t, util.ContainsAll(err.Error(), "found", "found", "found", "violates", "violates"))
 }

--- a/test/e2e/service_file_test.go
+++ b/test/e2e/service_file_test.go
@@ -102,7 +102,7 @@ func TestServiceCreateFromFile(t *testing.T) {
 }
 
 func serviceCreateFromFile(r *test.KnRunResultCollector, serviceName, filePath string) {
-	out := r.KnTest().Kn().Run("service", "create", serviceName, "--file", filePath)
+	out := r.KnTest().Kn().Run("service", "create", serviceName, "-f", filePath)
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "service", serviceName, "creating", "namespace", r.KnTest().Kn().Namespace(), "ready"))
 
@@ -112,13 +112,13 @@ func serviceCreateFromFile(r *test.KnRunResultCollector, serviceName, filePath s
 }
 
 func serviceCreateFromFileError(r *test.KnRunResultCollector, serviceName, filePath string) {
-	out := r.KnTest().Kn().Run("service", "create", serviceName, "--file", filePath)
+	out := r.KnTest().Kn().Run("service", "create", serviceName, "--filename", filePath)
 	r.AssertError(out)
 	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stderr, "no", "such", "file", "directory", filePath))
 }
 
 func serviceCreateFromFileNameMismatch(r *test.KnRunResultCollector, serviceName, filePath string) {
-	out := r.KnTest().Kn().Run("service", "create", serviceName, "--file", filePath)
+	out := r.KnTest().Kn().Run("service", "create", serviceName, "--filename", filePath)
 	r.AssertError(out)
 	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stderr, "provided", "'"+serviceName+"'", "name", "match", "from", "file"))
 }

--- a/test/e2e/service_file_test.go
+++ b/test/e2e/service_file_test.go
@@ -20,6 +20,7 @@ package e2e
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -84,6 +85,7 @@ func TestServiceCreateFromFile(t *testing.T) {
 
 	tempDir, err := ioutil.TempDir("", "kn-file")
 	assert.NilError(t, err)
+	defer os.RemoveAll(tempDir)
 
 	test.CreateFile("foo.json", fmt.Sprintf(ServiceJSON, test.KnDefaultTestImage), tempDir, test.FileModeReadWrite)
 	test.CreateFile("foo.yaml", fmt.Sprintf(ServiceYAML, test.KnDefaultTestImage), tempDir, test.FileModeReadWrite)

--- a/test/e2e/service_file_test.go
+++ b/test/e2e/service_file_test.go
@@ -84,8 +84,8 @@ func TestServiceCreateFromFile(t *testing.T) {
 	defer r.DumpIfFailed()
 
 	tempDir, err := ioutil.TempDir("", "kn-file")
-	assert.NilError(t, err)
 	defer os.RemoveAll(tempDir)
+	assert.NilError(t, err)
 
 	test.CreateFile("foo.json", fmt.Sprintf(ServiceJSON, test.KnDefaultTestImage), tempDir, test.FileModeReadWrite)
 	test.CreateFile("foo.yaml", fmt.Sprintf(ServiceYAML, test.KnDefaultTestImage), tempDir, test.FileModeReadWrite)

--- a/test/e2e/service_file_test.go
+++ b/test/e2e/service_file_test.go
@@ -1,0 +1,122 @@
+// Copyright 2020 The Knative Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build e2e
+// +build !eventing
+
+package e2e
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/assert"
+
+	"knative.dev/client/lib/test"
+	"knative.dev/client/pkg/util"
+)
+
+const (
+	ServiceYAML string = `
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: foo-yaml
+spec:
+  template:
+    spec:
+      containers:
+        - image: %s
+          env:
+            - name: TARGET
+              value: "Go Sample v1"`
+
+	ServiceJSON string = `
+{
+  "apiVersion": "serving.knative.dev/v1",
+  "kind": "Service",
+  "metadata": {
+    "name": "foo-json"
+  },
+  "spec": {
+    "template": {
+		"spec": {
+		"containers": [
+			{ 
+			"image": "%s",
+			"env": [
+				{
+				"name": "TARGET",
+				"value": "Go Sample v1"
+				}
+			]
+		  }
+		]
+	  }
+	}
+  }
+}`
+)
+
+func TestServiceCreateFromFile(t *testing.T) {
+	t.Parallel()
+	it, err := test.NewKnTest()
+	assert.NilError(t, err)
+	defer func() {
+		assert.NilError(t, it.Teardown())
+	}()
+
+	r := test.NewKnRunResultCollector(t, it)
+	defer r.DumpIfFailed()
+
+	tempDir, err := ioutil.TempDir("", "kn-file")
+	assert.NilError(t, err)
+
+	test.CreateFile("foo.json", fmt.Sprintf(ServiceJSON, test.KnDefaultTestImage), tempDir, test.FileModeReadWrite)
+	test.CreateFile("foo.yaml", fmt.Sprintf(ServiceYAML, test.KnDefaultTestImage), tempDir, test.FileModeReadWrite)
+
+	t.Log("create foo-json service from JSON file")
+	serviceCreateFromFile(r, "foo-json", filepath.Join(tempDir, "foo.json"))
+
+	t.Log("create foo-yaml service from YAML file")
+	serviceCreateFromFile(r, "foo-yaml", filepath.Join(tempDir, "foo.yaml"))
+
+	t.Log("error message for non-existing file")
+	serviceCreateFromFileNameMismatch(r, "foo", filepath.Join(tempDir, "foo.yaml"))
+	serviceCreateFromFileNameMismatch(r, "foo", filepath.Join(tempDir, "foo.json"))
+}
+
+func serviceCreateFromFile(r *test.KnRunResultCollector, serviceName, filePath string) {
+	out := r.KnTest().Kn().Run("service", "create", serviceName, "--file", filePath)
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "service", serviceName, "creating", "namespace", r.KnTest().Kn().Namespace(), "ready"))
+
+	out = r.KnTest().Kn().Run("service", "describe", serviceName, "--verbose")
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, serviceName))
+}
+
+func serviceCreateFromFileError(r *test.KnRunResultCollector, serviceName, filePath string) {
+	out := r.KnTest().Kn().Run("service", "create", serviceName, "--file", filePath)
+	r.AssertError(out)
+	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stderr, "no", "such", "file", "directory", filePath))
+}
+
+func serviceCreateFromFileNameMismatch(r *test.KnRunResultCollector, serviceName, filePath string) {
+	out := r.KnTest().Kn().Run("service", "create", serviceName, "--file", filePath)
+	r.AssertError(out)
+	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stderr, "provided", "'"+serviceName+"'", "name", "match", "from", "file"))
+}

--- a/test/e2e/service_file_test.go
+++ b/test/e2e/service_file_test.go
@@ -91,18 +91,27 @@ func TestServiceCreateFromFile(t *testing.T) {
 	test.CreateFile("foo.yaml", fmt.Sprintf(ServiceYAML, test.KnDefaultTestImage), tempDir, test.FileModeReadWrite)
 
 	t.Log("create foo-json service from JSON file")
-	serviceCreateFromFile(r, "foo-json", filepath.Join(tempDir, "foo.json"))
+	serviceCreateFromFile(r, "foo-json", filepath.Join(tempDir, "foo.json"), true)
 
 	t.Log("create foo-yaml service from YAML file")
-	serviceCreateFromFile(r, "foo-yaml", filepath.Join(tempDir, "foo.yaml"))
+	serviceCreateFromFile(r, "foo-yaml", filepath.Join(tempDir, "foo.yaml"), false)
 
 	t.Log("error message for non-existing file")
-	serviceCreateFromFileNameMismatch(r, "foo", filepath.Join(tempDir, "foo.yaml"))
+	serviceCreateFromFileError(r, "foo", filepath.Join(tempDir, "fake-foo.json"))
+	serviceCreateFromFileError(r, "foo", filepath.Join(tempDir, "fake-foo.yaml"))
+
+	t.Log("error message for mismatch names")
 	serviceCreateFromFileNameMismatch(r, "foo", filepath.Join(tempDir, "foo.json"))
+	serviceCreateFromFileNameMismatch(r, "foo", filepath.Join(tempDir, "foo.yaml"))
 }
 
-func serviceCreateFromFile(r *test.KnRunResultCollector, serviceName, filePath string) {
-	out := r.KnTest().Kn().Run("service", "create", serviceName, "-f", filePath)
+func serviceCreateFromFile(r *test.KnRunResultCollector, serviceName, filePath string, useName bool) {
+	var out test.KnRunResult
+	if useName {
+		out = r.KnTest().Kn().Run("service", "create", serviceName, "-f", filePath)
+	} else {
+		out = r.KnTest().Kn().Run("service", "create", "-f", filePath)
+	}
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "service", serviceName, "creating", "namespace", r.KnTest().Kn().Namespace(), "ready"))
 

--- a/test/e2e/service_file_test.go
+++ b/test/e2e/service_file_test.go
@@ -55,7 +55,7 @@ spec:
     "template": {
 		"spec": {
 		"containers": [
-			{ 
+			{
 			"image": "%s",
 			"env": [
 				{


### PR DESCRIPTION
## Description

Allow users to create Services from provided YAML or JSON file.

There're couple of open questions:
- Is it necessary to keep `NAME` parameter for the create command?
  - Should the `NAME` parameter take priority over file provided name?
- Should the multi-item (services separated by `---`) YAML be supported as well? 


## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Add new flag `--filename` to `service create` command


## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #550

<!--
Please add an entrty to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
