### PR TITLE
Added the option to use --scale for setting MinScale and MaxScale to the same value

### DIFF
--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -84,7 +84,7 @@ kn service create NAME --image IMAGE
       --requests-cpu string           DEPRECATED: please use --request instead. The requested CPU (e.g., 250m).
       --requests-memory string        DEPRECATED: please use --request instead. The requested memory (e.g., 64Mi).
       --revision-name string          The revision name to set. Must start with the service name and a dash as a prefix. Empty revision name will result in the server generating a name for the revision. Accepts golang templates, allowing {{.Service}} for the service name, {{.Generation}} for the generation, and {{.Random [n]}} for n random consonants. (default "{{.Service}}-{{.Random 5}}-{{.Generation}}")
-      --scale int                     Minimal and Maximal number of replicas.
+      --scale int                     Minimum and maximum number of replicas.
       --service-account string        Service account name to set. An empty argument ("") clears the service account. The referenced service account must exist in the service's namespace.
       --user int                      The user ID to run the container (e.g., 1001).
       --volume stringArray            Add a volume from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret: or sc:). Example: --volume myvolume=cm:myconfigmap or --volume myvolume=secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --volume myvolume-.

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -84,7 +84,7 @@ kn service create NAME --image IMAGE
       --requests-cpu string           DEPRECATED: please use --request instead. The requested CPU (e.g., 250m).
       --requests-memory string        DEPRECATED: please use --request instead. The requested memory (e.g., 64Mi).
       --revision-name string          The revision name to set. Must start with the service name and a dash as a prefix. Empty revision name will result in the server generating a name for the revision. Accepts golang templates, allowing {{.Service}} for the service name, {{.Generation}} for the generation, and {{.Random [n]}} for n random consonants. (default "{{.Service}}-{{.Random 5}}-{{.Generation}}")
-      --scale                         Set min and max scale as the same value
+      --scale int                     Minimal and Maximal number of replicas.
       --service-account string        Service account name to set. An empty argument ("") clears the service account. The referenced service account must exist in the service's namespace.
       --user int                      The user ID to run the container (e.g., 1001).
       --volume stringArray            Add a volume from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret: or sc:). Example: --volume myvolume=cm:myconfigmap or --volume myvolume=secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --volume myvolume-.

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -84,6 +84,7 @@ kn service create NAME --image IMAGE
       --requests-cpu string           DEPRECATED: please use --request instead. The requested CPU (e.g., 250m).
       --requests-memory string        DEPRECATED: please use --request instead. The requested memory (e.g., 64Mi).
       --revision-name string          The revision name to set. Must start with the service name and a dash as a prefix. Empty revision name will result in the server generating a name for the revision. Accepts golang templates, allowing {{.Service}} for the service name, {{.Generation}} for the generation, and {{.Random [n]}} for n random consonants. (default "{{.Service}}-{{.Random 5}}-{{.Generation}}")
+      --scale                         Set min and max scale as the same value
       --service-account string        Service account name to set. An empty argument ("") clears the service account. The referenced service account must exist in the service's namespace.
       --user int                      The user ID to run the container (e.g., 1001).
       --volume stringArray            Add a volume from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret: or sc:). Example: --volume myvolume=cm:myconfigmap or --volume myvolume=secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --volume myvolume-.

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -71,7 +71,7 @@ kn service update NAME
       --requests-cpu string           DEPRECATED: please use --request instead. The requested CPU (e.g., 250m).
       --requests-memory string        DEPRECATED: please use --request instead. The requested memory (e.g., 64Mi).
       --revision-name string          The revision name to set. Must start with the service name and a dash as a prefix. Empty revision name will result in the server generating a name for the revision. Accepts golang templates, allowing {{.Service}} for the service name, {{.Generation}} for the generation, and {{.Random [n]}} for n random consonants. (default "{{.Service}}-{{.Random 5}}-{{.Generation}}")
-      --scale int                     Minimal and Maximal number of replicas.
+      --scale int                     Minimum and maximum number of replicas.
       --service-account string        Service account name to set. An empty argument ("") clears the service account. The referenced service account must exist in the service's namespace.
       --tag strings                   Set tag (format: --tag revisionRef=tagName) where revisionRef can be a revision or '@latest' string representing latest ready revision. This flag can be specified multiple times.
       --traffic strings               Set traffic distribution (format: --traffic revisionRef=percent) where revisionRef can be a revision or a tag or '@latest' string representing latest ready revision. This flag can be given multiple times with percent summing up to 100%.

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -71,7 +71,7 @@ kn service update NAME
       --requests-cpu string           DEPRECATED: please use --request instead. The requested CPU (e.g., 250m).
       --requests-memory string        DEPRECATED: please use --request instead. The requested memory (e.g., 64Mi).
       --revision-name string          The revision name to set. Must start with the service name and a dash as a prefix. Empty revision name will result in the server generating a name for the revision. Accepts golang templates, allowing {{.Service}} for the service name, {{.Generation}} for the generation, and {{.Random [n]}} for n random consonants. (default "{{.Service}}-{{.Random 5}}-{{.Generation}}")
-      --scale                         Set min and max scale as the same value.
+      --scale int                     Minimal and Maximal number of replicas.
       --service-account string        Service account name to set. An empty argument ("") clears the service account. The referenced service account must exist in the service's namespace.
       --tag strings                   Set tag (format: --tag revisionRef=tagName) where revisionRef can be a revision or '@latest' string representing latest ready revision. This flag can be specified multiple times.
       --traffic strings               Set traffic distribution (format: --traffic revisionRef=percent) where revisionRef can be a revision or a tag or '@latest' string representing latest ready revision. This flag can be given multiple times with percent summing up to 100%.

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -71,6 +71,7 @@ kn service update NAME
       --requests-cpu string           DEPRECATED: please use --request instead. The requested CPU (e.g., 250m).
       --requests-memory string        DEPRECATED: please use --request instead. The requested memory (e.g., 64Mi).
       --revision-name string          The revision name to set. Must start with the service name and a dash as a prefix. Empty revision name will result in the server generating a name for the revision. Accepts golang templates, allowing {{.Service}} for the service name, {{.Generation}} for the generation, and {{.Random [n]}} for n random consonants. (default "{{.Service}}-{{.Random 5}}-{{.Generation}}")
+      --scale                         Set min and max scale as the same value.
       --service-account string        Service account name to set. An empty argument ("") clears the service account. The referenced service account must exist in the service's namespace.
       --tag strings                   Set tag (format: --tag revisionRef=tagName) where revisionRef can be a revision or '@latest' string representing latest ready revision. This flag can be specified multiple times.
       --traffic strings               Set traffic distribution (format: --traffic revisionRef=percent) where revisionRef can be a revision or a tag or '@latest' string representing latest ready revision. This flag can be given multiple times with percent summing up to 100%.

--- a/docs/operations/autoscaling.md
+++ b/docs/operations/autoscaling.md
@@ -10,6 +10,9 @@ limit) and is the recommended configuration for autoscaling in Knative.
 The `minScale` and `maxScale` annotations can be used to configure the minimum
 and maximum number of pods that can serve applications.
 
+The `scale` annotation can be used to configure the minimum and maximum number
+of pods at the same time.
+
 You can access autoscaling capabilities by using `kn` to modify Knative services
 without editing YAML files directly.
 
@@ -22,3 +25,4 @@ flags to configure the autoscaling behavior.
 | `--concurrency-target int` | Recommendation for when to scale up based on the concurrent number of incoming requests. Defaults to `--concurrency-limit`. |
 | `--max-scale int`          | Maximum number of replicas.                                                                                                 |
 | `--min-scale int`          | Minimum number of replicas.                                                                                                 |
+| `--scale int`              | Set min and max scale as the same value.                                                                                    |

--- a/docs/operations/autoscaling.md
+++ b/docs/operations/autoscaling.md
@@ -10,9 +10,6 @@ limit) and is the recommended configuration for autoscaling in Knative.
 The `minScale` and `maxScale` annotations can be used to configure the minimum
 and maximum number of pods that can serve applications.
 
-The `scale` annotation can be used to configure the minimum and maximum number
-of pods at the same time.
-
 You can access autoscaling capabilities by using `kn` to modify Knative services
 without editing YAML files directly.
 
@@ -25,4 +22,3 @@ flags to configure the autoscaling behavior.
 | `--concurrency-target int` | Recommendation for when to scale up based on the concurrent number of incoming requests. Defaults to `--concurrency-limit`. |
 | `--max-scale int`          | Maximum number of replicas.                                                                                                 |
 | `--min-scale int`          | Minimum number of replicas.                                                                                                 |
-| `--scale int`              | Set min and max scale as the same value.                                                                                    |

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -186,7 +186,7 @@ func (p *ConfigurationEditFlags) addSharedFlags(command *cobra.Command) {
 	command.Flags().IntVar(&p.MaxScale, "max-scale", 0, "Maximal number of replicas.")
 	p.markFlagMakesRevision("max-scale")
 
-	command.Flags().IntVar(&p.Scale, "scale", 0, "Minimal and Maximal number of replicas.")
+	command.Flags().IntVar(&p.Scale, "scale", 0, "Minimum and maximum number of replicas.")
 	p.markFlagMakesRevision("scale")
 
 	command.Flags().StringVar(&p.AutoscaleWindow, "autoscale-window", "", "Duration to look back for making auto-scaling decisions. The service is scaled to zero if no request was received in during that time. (eg: 10s)")
@@ -439,13 +439,19 @@ func (p *ConfigurationEditFlags) Apply(
 	}
 
 	if cmd.Flags().Changed("scale") {
-		err = servinglib.UpdateMaxScale(template, p.Scale)
-		if err != nil {
-			return err
-		}
-		err = servinglib.UpdateMinScale(template, p.Scale)
-		if err != nil {
-			return err
+		if cmd.Flags().Changed("max-scale") {
+			return fmt.Errorf("only --scale or --max-scale can be specified")
+		} else if cmd.Flags().Changed("min-scale") {
+			return fmt.Errorf("only --scale or --min-scale can be specified")
+		} else {
+			err = servinglib.UpdateMaxScale(template, p.Scale)
+			if err != nil {
+				return err
+			}
+			err = servinglib.UpdateMinScale(template, p.Scale)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -45,6 +45,7 @@ type ConfigurationEditFlags struct {
 
 	RequestsFlags, LimitsFlags ResourceFlags // TODO: Flag marked deprecated in release v0.15.0, remove in release v0.18.0
 	Resources                  knflags.ResourceOptions
+	Scale                      int
 	MinScale                   int
 	MaxScale                   int
 	ConcurrencyTarget          int
@@ -184,6 +185,9 @@ func (p *ConfigurationEditFlags) addSharedFlags(command *cobra.Command) {
 
 	command.Flags().IntVar(&p.MaxScale, "max-scale", 0, "Maximal number of replicas.")
 	p.markFlagMakesRevision("max-scale")
+
+	command.Flags().IntVar(&p.Scale, "scale", 0, "Minimal and Maximal number of replicas.")
+	p.markFlagMakesRevision("scale")
 
 	command.Flags().StringVar(&p.AutoscaleWindow, "autoscale-window", "", "Duration to look back for making auto-scaling decisions. The service is scaled to zero if no request was received in during that time. (eg: 10s)")
 	p.markFlagMakesRevision("autoscale-window")
@@ -429,6 +433,17 @@ func (p *ConfigurationEditFlags) Apply(
 
 	if cmd.Flags().Changed("max-scale") {
 		err = servinglib.UpdateMaxScale(template, p.MaxScale)
+		if err != nil {
+			return err
+		}
+	}
+
+	if cmd.Flags().Changed("scale") {
+		err = servinglib.UpdateMaxScale(template, p.Scale)
+		if err != nil {
+			return err
+		}
+		err = servinglib.UpdateMinScale(template, p.Scale)
 		if err != nil {
 			return err
 		}

--- a/pkg/kn/commands/service/create_test.go
+++ b/pkg/kn/commands/service/create_test.go
@@ -547,10 +547,7 @@ func TestServiceCreateMaxMinScale(t *testing.T) {
 func TestServiceCreateScale(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
 		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
-		"--scale", "5",
-		"--concurrency-target", "10", "--concurrency-limit", "100",
-		"--concurrency-utilization", "50",
-		"--no-wait"}, false)
+		"--scale", "5"}, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -564,8 +561,6 @@ func TestServiceCreateScale(t *testing.T) {
 	expectedAnnos := []string{
 		"autoscaling.knative.dev/minScale", "5",
 		"autoscaling.knative.dev/maxScale", "5",
-		"autoscaling.knative.dev/target", "10",
-		"autoscaling.knative.dev/targetUtilizationPercentage", "50",
 	}
 
 	for i := 0; i < len(expectedAnnos); i += 2 {
@@ -574,10 +569,6 @@ func TestServiceCreateScale(t *testing.T) {
 			t.Fatalf("Unexpected annotation value for %s : %s (actual) != %s (expected)",
 				anno, actualAnnos[anno], expectedAnnos[i+1])
 		}
-	}
-
-	if *template.Spec.ContainerConcurrency != int64(100) {
-		t.Fatalf("container concurrency not set to given value 1000")
 	}
 }
 

--- a/pkg/kn/commands/service/create_test.go
+++ b/pkg/kn/commands/service/create_test.go
@@ -547,7 +547,7 @@ func TestServiceCreateMaxMinScale(t *testing.T) {
 func TestServiceCreateScale(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
 		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
-		"--scale", "5"}, false)
+		"--scale", "5", "--no-wait"}, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -570,6 +570,32 @@ func TestServiceCreateScale(t *testing.T) {
 				anno, actualAnnos[anno], expectedAnnos[i+1])
 		}
 	}
+}
+
+func TestServiceCreateScaleWithMaxScaleSet(t *testing.T) {
+	_, _, output, err := fakeServiceCreate([]string{
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
+		"--scale", "5", "--max-scale", "2", "--no-wait"}, true)
+	if err == nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output, "only --scale or --max-scale can be specified") {
+		t.Errorf("Invalid error output: '%s'", output)
+	}
+
+}
+
+func TestServiceCreateScaleWithMinScaleSet(t *testing.T) {
+	_, _, output, err := fakeServiceCreate([]string{
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
+		"--scale", "5", "--min-scale", "2", "--no-wait"}, true)
+	if err == nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output, "only --scale or --min-scale can be specified") {
+		t.Errorf("Invalid error output: '%s'", output)
+	}
+
 }
 
 func TestServiceCreateRequestsLimitsCPUMemory(t *testing.T) {

--- a/pkg/kn/commands/service/create_test.go
+++ b/pkg/kn/commands/service/create_test.go
@@ -572,28 +572,44 @@ func TestServiceCreateScale(t *testing.T) {
 	}
 }
 
+func TestServiceCreateScaleWithNegativeValue(t *testing.T) {
+	_, _, _, err := fakeServiceCreate([]string{
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
+		"--scale", "-1", "--no-wait"}, true)
+	if err == nil {
+		t.Fatal(err)
+	}
+	expectedErrMsg := "expected 0 <= -1 <= 2147483647: autoscaling.knative.dev/maxScale"
+	if !strings.Contains(err.Error(), expectedErrMsg) {
+		t.Errorf("Invalid error output, expected: %s, got : '%s'", expectedErrMsg, err)
+	}
+
+}
+
 func TestServiceCreateScaleWithMaxScaleSet(t *testing.T) {
-	_, _, output, err := fakeServiceCreate([]string{
+	_, _, _, err := fakeServiceCreate([]string{
 		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
 		"--scale", "5", "--max-scale", "2", "--no-wait"}, true)
 	if err == nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(output, "only --scale or --max-scale can be specified") {
-		t.Errorf("Invalid error output: '%s'", output)
+	expectedErrMsg := "only --scale or --max-scale can be specified"
+	if !strings.Contains(err.Error(), expectedErrMsg) {
+		t.Errorf("Invalid error output, expected: %s, got : '%s'", expectedErrMsg, err)
 	}
 
 }
 
 func TestServiceCreateScaleWithMinScaleSet(t *testing.T) {
-	_, _, output, err := fakeServiceCreate([]string{
+	_, _, _, err := fakeServiceCreate([]string{
 		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
 		"--scale", "5", "--min-scale", "2", "--no-wait"}, true)
 	if err == nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(output, "only --scale or --min-scale can be specified") {
-		t.Errorf("Invalid error output: '%s'", output)
+	expectedErrMsg := "only --scale or --min-scale can be specified"
+	if !strings.Contains(err.Error(), expectedErrMsg) {
+		t.Errorf("Invalid error output, expected: %s, got : '%s'", expectedErrMsg, err)
 	}
 
 }

--- a/pkg/kn/commands/service/create_test.go
+++ b/pkg/kn/commands/service/create_test.go
@@ -544,6 +544,43 @@ func TestServiceCreateMaxMinScale(t *testing.T) {
 	}
 }
 
+func TestServiceCreateScale(t *testing.T) {
+	action, created, _, err := fakeServiceCreate([]string{
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
+		"--scale", "5",
+		"--concurrency-target", "10", "--concurrency-limit", "100",
+		"--concurrency-utilization", "50",
+		"--no-wait"}, false)
+
+	if err != nil {
+		t.Fatal(err)
+	} else if !action.Matches("create", "services") {
+		t.Fatalf("Bad action %v", action)
+	}
+
+	template := &created.Spec.Template
+
+	actualAnnos := template.Annotations
+	expectedAnnos := []string{
+		"autoscaling.knative.dev/minScale", "5",
+		"autoscaling.knative.dev/maxScale", "5",
+		"autoscaling.knative.dev/target", "10",
+		"autoscaling.knative.dev/targetUtilizationPercentage", "50",
+	}
+
+	for i := 0; i < len(expectedAnnos); i += 2 {
+		anno := expectedAnnos[i]
+		if actualAnnos[anno] != expectedAnnos[i+1] {
+			t.Fatalf("Unexpected annotation value for %s : %s (actual) != %s (expected)",
+				anno, actualAnnos[anno], expectedAnnos[i+1])
+		}
+	}
+
+	if *template.Spec.ContainerConcurrency != int64(100) {
+		t.Fatalf("container concurrency not set to given value 1000")
+	}
+}
+
 func TestServiceCreateRequestsLimitsCPUMemory(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
 		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",

--- a/pkg/kn/commands/service/update_test.go
+++ b/pkg/kn/commands/service/update_test.go
@@ -360,7 +360,7 @@ func TestServiceUpdateScale(t *testing.T) {
 
 	action, updated, _, err := fakeServiceUpdate(original, []string{
 		"service", "update", "foo",
-		"--scale", "5", "--concurrency-target", "10", "--concurrency-limit", "100", "--concurrency-utilization", "50", "--no-wait"})
+		"--scale", "5"})
 
 	if err != nil {
 		t.Fatal(err)
@@ -377,8 +377,6 @@ func TestServiceUpdateScale(t *testing.T) {
 	expectedAnnos := []string{
 		"autoscaling.knative.dev/minScale", "5",
 		"autoscaling.knative.dev/maxScale", "5",
-		"autoscaling.knative.dev/target", "10",
-		"autoscaling.knative.dev/targetUtilizationPercentage", "50",
 	}
 
 	for i := 0; i < len(expectedAnnos); i += 2 {
@@ -387,10 +385,6 @@ func TestServiceUpdateScale(t *testing.T) {
 			t.Fatalf("Unexpected annotation value for %s : %s (actual) != %s (expected)",
 				anno, actualAnnos[anno], expectedAnnos[i+1])
 		}
-	}
-
-	if *template.Spec.ContainerConcurrency != int64(100) {
-		t.Fatalf("container concurrency not set to given value 1000")
 	}
 
 }

--- a/pkg/kn/commands/service/update_test.go
+++ b/pkg/kn/commands/service/update_test.go
@@ -389,6 +389,25 @@ func TestServiceUpdateScale(t *testing.T) {
 
 }
 
+func TestServiceUpdateScaleWithNegativeValue(t *testing.T) {
+	original := newEmptyService()
+
+	_, _, _, err := fakeServiceUpdate(original, []string{
+		"service", "update", "foo",
+		"--scale", "-1", "--no-wait"})
+
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	expectedErrMsg := "expected 0 <= -1 <= 2147483647: autoscaling.knative.dev/maxScale"
+
+	if !strings.Contains(err.Error(), expectedErrMsg) {
+		t.Errorf("Invalid error output, expected: %s, got : '%s'", expectedErrMsg, err)
+	}
+
+}
+
 func TestServiceUpdateScaleWithMaxScaleSet(t *testing.T) {
 	original := newEmptyService()
 

--- a/pkg/kn/commands/service/update_test.go
+++ b/pkg/kn/commands/service/update_test.go
@@ -397,11 +397,13 @@ func TestServiceUpdateScaleWithMaxScaleSet(t *testing.T) {
 		"--scale", "5", "--max-scale", "2", "--no-wait"})
 
 	if err == nil {
-		t.Fatal(err)
+		t.Fatal("Expected error, got nil")
 	}
 
-	if !strings.Contains(err.Error(), "only --scale or --max-scale can be specified") {
-		t.Errorf("Invalid error output: '%s'", err)
+	expectedErrMsg := "only --scale or --max-scale can be specified"
+
+	if !strings.Contains(err.Error(), expectedErrMsg) {
+		t.Errorf("Invalid error output, expected: %s, got : '%s'", expectedErrMsg, err)
 	}
 
 }
@@ -414,11 +416,13 @@ func TestServiceUpdateScaleWithMinScaleSet(t *testing.T) {
 		"--scale", "5", "--min-scale", "2", "--no-wait"})
 
 	if err == nil {
-		t.Fatal(err)
+		t.Fatal("Expected error, got nil")
 	}
 
-	if !strings.Contains(err.Error(), "only --scale or --min-scale can be specified") {
-		t.Errorf("Invalid error output: '%s'", err)
+	expectedErrMsg := "only --scale or --min-scale can be specified"
+
+	if !strings.Contains(err.Error(), expectedErrMsg) {
+		t.Errorf("Invalid error output, expected: %s, got : '%s'", expectedErrMsg, err)
 	}
 
 }

--- a/pkg/kn/commands/service/update_test.go
+++ b/pkg/kn/commands/service/update_test.go
@@ -360,7 +360,7 @@ func TestServiceUpdateScale(t *testing.T) {
 
 	action, updated, _, err := fakeServiceUpdate(original, []string{
 		"service", "update", "foo",
-		"--scale", "5"})
+		"--scale", "5", "--no-wait"})
 
 	if err != nil {
 		t.Fatal(err)
@@ -389,6 +389,39 @@ func TestServiceUpdateScale(t *testing.T) {
 
 }
 
+func TestServiceUpdateScaleWithMaxScaleSet(t *testing.T) {
+	original := newEmptyService()
+
+	_, _, _, err := fakeServiceUpdate(original, []string{
+		"service", "update", "foo",
+		"--scale", "5", "--max-scale", "2", "--no-wait"})
+
+	if err == nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(err.Error(), "only --scale or --max-scale can be specified") {
+		t.Errorf("Invalid error output: '%s'", err)
+	}
+
+}
+
+func TestServiceUpdateScaleWithMinScaleSet(t *testing.T) {
+	original := newEmptyService()
+
+	_, _, _, err := fakeServiceUpdate(original, []string{
+		"service", "update", "foo",
+		"--scale", "5", "--min-scale", "2", "--no-wait"})
+
+	if err == nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(err.Error(), "only --scale or --min-scale can be specified") {
+		t.Errorf("Invalid error output: '%s'", err)
+	}
+
+}
 func TestServiceUpdateEnv(t *testing.T) {
 	orig := newEmptyService()
 

--- a/test/e2e/service_options_test.go
+++ b/test/e2e/service_options_test.go
@@ -72,6 +72,11 @@ func TestServiceOptions(t *testing.T) {
 	validateServiceMinScale(r, "svc2", "1")
 	validateServiceMaxScale(r, "svc2", "3")
 
+	t.Log("create and validate service with scale options ")
+	serviceCreateWithOptions(r, "svc2", "--scale", "5")
+	validateServiceMinScale(r, "svc2", "5")
+	validateServiceMaxScale(r, "svc2", "5")
+
 	t.Log("update and validate service with max scale option")
 	test.ServiceUpdate(r, "svc2", "--max-scale", "2")
 	validateServiceMaxScale(r, "svc2", "2")

--- a/test/e2e/service_options_test.go
+++ b/test/e2e/service_options_test.go
@@ -73,9 +73,9 @@ func TestServiceOptions(t *testing.T) {
 	validateServiceMaxScale(r, "svc2", "3")
 
 	t.Log("create and validate service with scale options ")
-	serviceCreateWithOptions(r, "svc2", "--scale", "5")
-	validateServiceMinScale(r, "svc2", "5")
-	validateServiceMaxScale(r, "svc2", "5")
+	serviceCreateWithOptions(r, "svc2a", "--scale", "5")
+	validateServiceMinScale(r, "svc2a", "5")
+	validateServiceMaxScale(r, "svc2a", "5")
 
 	t.Log("update and validate service with max scale option")
 	test.ServiceUpdate(r, "svc2", "--max-scale", "2")

--- a/test/e2e/service_options_test.go
+++ b/test/e2e/service_options_test.go
@@ -67,19 +67,24 @@ func TestServiceOptions(t *testing.T) {
 	t.Log("delete service")
 	test.ServiceDelete(r, "svc1")
 
-	t.Log("create and validate service with min/max scale options ")
+	t.Log("create and validate service with min/max scale options")
 	serviceCreateWithOptions(r, "svc2", "--min-scale", "1", "--max-scale", "3")
 	validateServiceMinScale(r, "svc2", "1")
 	validateServiceMaxScale(r, "svc2", "3")
 
-	t.Log("create and validate service with scale options ")
+	t.Log("update and validate service with max scale option")
+	test.ServiceUpdate(r, "svc2", "--max-scale", "2")
+	validateServiceMaxScale(r, "svc2", "2")
+
+	t.Log("create and validate service with scale options")
 	serviceCreateWithOptions(r, "svc2a", "--scale", "5")
 	validateServiceMinScale(r, "svc2a", "5")
 	validateServiceMaxScale(r, "svc2a", "5")
 
-	t.Log("update and validate service with max scale option")
-	test.ServiceUpdate(r, "svc2", "--max-scale", "2")
-	validateServiceMaxScale(r, "svc2", "2")
+	t.Log("update and validate service with scale option")
+	test.ServiceUpdate(r, "svc2a", "--scale", "2")
+	validateServiceMaxScale(r, "svc2a", "2")
+	validateServiceMinScale(r, "svc2a", "2")
 
 	t.Log("delete service")
 	test.ServiceDelete(r, "svc2")


### PR DESCRIPTION
## Description

This allows a user to set --scale which will update MinScale and MaxScale to the same value. 

## Changes

* add --scale as a CLI option

## Reference

#822 
