### PR TITLE
Fixed the error message for min/max scale tests

### DIFF
--- a/pkg/kn/commands/service/create_test.go
+++ b/pkg/kn/commands/service/create_test.go
@@ -540,7 +540,7 @@ func TestServiceCreateMaxMinScale(t *testing.T) {
 	}
 
 	if *template.Spec.ContainerConcurrency != int64(100) {
-		t.Fatalf("container concurrency not set to given value 1000")
+		t.Fatalf("container concurrency not set to given value 100")
 	}
 }
 

--- a/pkg/kn/commands/service/update_test.go
+++ b/pkg/kn/commands/service/update_test.go
@@ -350,7 +350,7 @@ func TestServiceUpdateMaxMinScale(t *testing.T) {
 	}
 
 	if *template.Spec.ContainerConcurrency != int64(100) {
-		t.Fatalf("container concurrency not set to given value 1000")
+		t.Fatalf("container concurrency not set to given value 100")
 	}
 
 }


### PR DESCRIPTION
## Description

Fixed an error message in the create_test.go file

## Changes

* Changed 1000 to 100 to match the value used in the test. 



