### PR TITLE
Setup eventing extension: sugar controller

### DIFF
--- a/test/common.sh
+++ b/test/common.sh
@@ -36,6 +36,11 @@ function knative_setup() {
 
   if [ "${eventing_version}" = "latest" ]; then
     start_latest_knative_eventing
+
+    # install the sugar controller
+    kubectl apply --filename https://storage.googleapis.com/knative-nightly/eventing/latest/eventing-sugar-controller.yaml
+    wait_until_pods_running knative-eventing || return 1
+
   else
     start_release_knative_eventing "${eventing_version}"
   fi


### PR DESCRIPTION
## Description
 We'll need sugar controller for reconciling broker for tests
 which labels namespace and annotates the triggers.

 Currently, sugar controller is not part of the eventing nightly release setup
 by test-infra libs. This changeset adds install of same for nightly
 CI setup.