### PR TITLE
Add E2E test cases for "kn source list".

### DIFF
--- a/test/e2e/source_list_test.go
+++ b/test/e2e/source_list_test.go
@@ -52,37 +52,40 @@ func TestSourceList(t *testing.T) {
 	it, err := test.NewKnTest()
 	assert.NilError(t, err)
 	defer func() {
+		assert.NilError(t, tearDownForSourceAPIServer(t, it))
 		assert.NilError(t, it.Teardown())
 	}()
 
 	r := test.NewKnRunResultCollector(t, it)
+
 	defer r.DumpIfFailed()
+	setupForSourceAPIServer(t, it)
+	test.ServiceCreate(r, "testsvc0")
 
 	t.Log("List sources empty case")
 	output := sourceList(r)
 	assert.Check(t, util.ContainsAll(output, "No", "sources", "found", "namespace"))
 	assert.Check(t, util.ContainsNone(output, "NAME", "TYPE", "RESOURCE", "SINK", "READY"))
 
-	setupForSourceAPIServer(t, it)
-	test.ServiceCreate(r, "testsvc0")
+	t.Log("Create API Server")
 	apiServerSourceCreate(r, "testapisource0", "Event:v1:key1=value1", "testsa", "svc:testsvc0")
 	apiServerSourceListOutputName(r, "testapisource0")
-	t.Log("list sources")
-	output = sourceList(r, "--type", "testapisource0")
-	assert.Check(t, util.ContainsAll(output, "No", "sources", "found", "namespace"))
-	output := sourceList(r)
-	assert.Check(t, util.ContainsAll(output, "NAME", "TYPE", "RESOURCE", "SINK", "READY"))
-	assert.Check(t, util.ContainsAll(output, "testapisource0", "ApiServerSource", "apiserversources.sources.knative.dev", "svc:testsvc0"))
 
 	t.Log("create source binding")
 	sourceBindingCreate(r, "my-binding0", "Deployment:apps/v1:myapp", "svc:testsvc0")
 	sourceBindingListOutputName(r, "my-binding0")
-	output = sourceList(r, "--type", "my-binding0")
-	assert.Check(t, util.ContainsAll(output, "No", "sources", "found", "namespace"))
 
+	t.Log("create Ping Source")
 	pingSourceCreate(r, "testpingsource0", "* * * * */1", "ping", "svc:testsvc0")
 	pingSourceListOutputName(r, "testpingsource0")
-	output = sourceList(r, "--type", "testpingsource0")
+
+	t.Log("List sources Valid case")
+	output = sourceList(r, "--type", "PingSource")
+	assert.Check(t, util.ContainsAll(output, "NAME", "TYPE", "RESOURCE", "SINK", "READY"))
+	assert.Check(t, util.ContainsAll(output, "testpingsource0", "PingSource", "pingsources.sources.knative.dev", "svc:testsvc0"))
+
+	t.Log("List sources Invalid case")
+	output = sourceList(r, "--type", "testapisource0")
 	assert.Check(t, util.ContainsAll(output, "No", "sources", "found", "namespace"))
 
 	t.Log("delete apiserver sources")

--- a/test/e2e/source_list_test.go
+++ b/test/e2e/source_list_test.go
@@ -63,6 +63,34 @@ func TestSourceList(t *testing.T) {
 	assert.Check(t, util.ContainsAll(output, "No", "sources", "found", "namespace"))
 	assert.Check(t, util.ContainsNone(output, "NAME", "TYPE", "RESOURCE", "SINK", "READY"))
 
+	setupForSourceAPIServer(t, it)
+	test.ServiceCreate(r, "testsvc0")
+	apiServerSourceCreate(r, "testapisource0", "Event:v1:key1=value1", "testsa", "svc:testsvc0")
+	apiServerSourceListOutputName(r, "testapisource0")
+	t.Log("list sources")
+	output = sourceList(r, "--type", "testapisource0")
+	assert.Check(t, util.ContainsAll(output, "No", "sources", "found", "namespace"))
+	output := sourceList(r)
+	assert.Check(t, util.ContainsAll(output, "NAME", "TYPE", "RESOURCE", "SINK", "READY"))
+	assert.Check(t, util.ContainsAll(output, "testapisource0", "ApiServerSource", "apiserversources.sources.knative.dev", "svc:testsvc0"))
+
+	t.Log("create source binding")
+	sourceBindingCreate(r, "my-binding0", "Deployment:apps/v1:myapp", "svc:testsvc0")
+	sourceBindingListOutputName(r, "my-binding0")
+	output = sourceList(r, "--type", "my-binding0")
+	assert.Check(t, util.ContainsAll(output, "No", "sources", "found", "namespace"))
+
+	pingSourceCreate(r, "testpingsource0", "* * * * */1", "ping", "svc:testsvc0")
+	pingSourceListOutputName(r, "testpingsource0")
+	output = sourceList(r, "--type", "testpingsource0")
+	assert.Check(t, util.ContainsAll(output, "No", "sources", "found", "namespace"))
+
+	t.Log("delete apiserver sources")
+	apiServerSourceDelete(r, "testapisource0")
+	t.Log("delete source binding")
+	sourceBindingDelete(r, "my-binding0")
+	t.Log("delete Ping sources")
+	pingSourceDelete(r, "testpingsource0")
 	// non empty list case is tested in test/e2e/source_apiserver_it.go where source setup is present
 }
 

--- a/test/e2e/source_list_test.go
+++ b/test/e2e/source_list_test.go
@@ -71,28 +71,35 @@ func TestSourceList(t *testing.T) {
 	apiServerSourceCreate(r, "testapisource0", "Event:v1:key1=value1", "testsa", "svc:testsvc0")
 	apiServerSourceListOutputName(r, "testapisource0")
 
-	t.Log("create source binding")
+	t.Log("Create source binding")
 	sourceBindingCreate(r, "my-binding0", "Deployment:apps/v1:myapp", "svc:testsvc0")
 	sourceBindingListOutputName(r, "my-binding0")
 
-	t.Log("create Ping Source")
+	t.Log("Create ping source")
 	pingSourceCreate(r, "testpingsource0", "* * * * */1", "ping", "svc:testsvc0")
 	pingSourceListOutputName(r, "testpingsource0")
 
-	t.Log("List sources Valid case")
+	t.Log("List sources filter valid case")
 	output = sourceList(r, "--type", "PingSource")
 	assert.Check(t, util.ContainsAll(output, "NAME", "TYPE", "RESOURCE", "SINK", "READY"))
 	assert.Check(t, util.ContainsAll(output, "testpingsource0", "PingSource", "pingsources.sources.knative.dev", "svc:testsvc0"))
 
-	t.Log("List sources Invalid case")
+	t.Log("List sources filter invalid case")
 	output = sourceList(r, "--type", "testapisource0")
 	assert.Check(t, util.ContainsAll(output, "No", "sources", "found", "namespace"))
+	output = sourceList(r, "--type", "TestSource", "-oyaml")
+	assert.Check(t, util.ContainsAll(output, "No", "sources", "found", "namespace"))
 
-	t.Log("delete apiserver sources")
+	t.Log("List available source in YAML format")
+	output = sourceList(r, "--type", "PingSource,ApiServerSource", "-oyaml")
+	assert.Check(t, util.ContainsAll(output, "testpingsource0", "PingSource", "Service", "testsvc0"))
+	assert.Check(t, util.ContainsAll(output, "testapisource1", "ApiServerSource", "Service", "testsvc0"))
+
+	t.Log("Delete apiserver sources")
 	apiServerSourceDelete(r, "testapisource0")
-	t.Log("delete source binding")
+	t.Log("Delete source binding")
 	sourceBindingDelete(r, "my-binding0")
-	t.Log("delete Ping sources")
+	t.Log("Delete Ping sources")
 	pingSourceDelete(r, "testpingsource0")
 	// non empty list case is tested in test/e2e/source_apiserver_it.go where source setup is present
 }

--- a/test/e2e/source_list_test.go
+++ b/test/e2e/source_list_test.go
@@ -93,7 +93,7 @@ func TestSourceList(t *testing.T) {
 	t.Log("List available source in YAML format")
 	output = sourceList(r, "--type", "PingSource,ApiServerSource", "-oyaml")
 	assert.Check(t, util.ContainsAll(output, "testpingsource0", "PingSource", "Service", "testsvc0"))
-	assert.Check(t, util.ContainsAll(output, "testapisource1", "ApiServerSource", "Service", "testsvc0"))
+	assert.Check(t, util.ContainsAll(output, "testapisource0", "ApiServerSource", "Service", "testsvc0"))
 
 	t.Log("Delete apiserver sources")
 	apiServerSourceDelete(r, "testapisource0")


### PR DESCRIPTION
## Description

Add E2E test cases for "kn source list"

- Test cases for valid & Invalid filter option.
- Source list output in YAML format.

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #722 


