### PR TITLE
feat: Add support to combine service create --filename with other options

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,7 +19,7 @@
 | | Description | PR
 
 | 🎁
-|  Add support to combine service create --filename with other options
+| Add support to combine service create --filename with other options
 | https://github.com/knative/client/pull/937[#937]
 
 |===

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,18 @@
 | https://github.com/knative/client/pull/[#]
 ////
 
+## Unreleased
+
+[cols="1,10,3", options="header", width="100%"]
+|===
+| | Description | PR
+
+| 🎁
+|  Add support to combine service create --filename with other options
+| https://github.com/knative/client/pull/937[#937]
+
+|===
+
 ## v0.16.0 (2020-07-14)
 
 [cols="1,10,3", options="header", width="100%"]

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -64,7 +64,7 @@ kn service create NAME --image IMAGE
       --concurrency-utilization int   Percentage of concurrent requests utilization before scaling up. (default 70)
   -e, --env stringArray               Environment variable to set. NAME=value; you may provide this flag any number of times to set multiple environment variables. To unset, specify the environment variable name followed by a "-" (e.g., NAME-).
       --env-from stringArray          Add environment variables from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret:). Example: --env-from cm:myconfigmap or --env-from secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --env-from cm:myconfigmap-.
-  -f, --filename string               Create a service from file.
+  -f, --filename string               Create a service from file. The created service can be futher modified by combining with other options.Example: -f /path/to/file --env NAME=value will also add environment variable.
       --force                         Create service forcefully, replaces existing service if any.
   -h, --help                          help for create
       --image string                  Image to run.

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -64,7 +64,7 @@ kn service create NAME --image IMAGE
       --concurrency-utilization int   Percentage of concurrent requests utilization before scaling up. (default 70)
   -e, --env stringArray               Environment variable to set. NAME=value; you may provide this flag any number of times to set multiple environment variables. To unset, specify the environment variable name followed by a "-" (e.g., NAME-).
       --env-from stringArray          Add environment variables from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret:). Example: --env-from cm:myconfigmap or --env-from secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --env-from cm:myconfigmap-.
-  -f, --filename string               Create a service from file. The created service can be further modified by combining with other options.Example: -f /path/to/file --env NAME=value will also add environment variable.
+  -f, --filename string               Create a service from file. The created service can be further modified by combining with other options. For example -f /path/to/file --env NAME=value will also add environment variable.
       --force                         Create service forcefully, replaces existing service if any.
   -h, --help                          help for create
       --image string                  Image to run.

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -64,7 +64,7 @@ kn service create NAME --image IMAGE
       --concurrency-utilization int   Percentage of concurrent requests utilization before scaling up. (default 70)
   -e, --env stringArray               Environment variable to set. NAME=value; you may provide this flag any number of times to set multiple environment variables. To unset, specify the environment variable name followed by a "-" (e.g., NAME-).
       --env-from stringArray          Add environment variables from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret:). Example: --env-from cm:myconfigmap or --env-from secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --env-from cm:myconfigmap-.
-  -f, --filename string               Create a service from file. The created service can be futher modified by combining with other options.Example: -f /path/to/file --env NAME=value will also add environment variable.
+  -f, --filename string               Create a service from file. The created service can be further modified by combining with other options.Example: -f /path/to/file --env NAME=value will also add environment variable.
       --force                         Create service forcefully, replaces existing service if any.
   -h, --help                          help for create
       --image string                  Image to run.

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -64,7 +64,7 @@ kn service create NAME --image IMAGE
       --concurrency-utilization int   Percentage of concurrent requests utilization before scaling up. (default 70)
   -e, --env stringArray               Environment variable to set. NAME=value; you may provide this flag any number of times to set multiple environment variables. To unset, specify the environment variable name followed by a "-" (e.g., NAME-).
       --env-from stringArray          Add environment variables from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret:). Example: --env-from cm:myconfigmap or --env-from secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --env-from cm:myconfigmap-.
-  -f, --filename string               Create a service from file. The created service can be further modified by combining with other options. For example -f /path/to/file --env NAME=value will also add environment variable.
+  -f, --filename string               Create a service from file. The created service can be further modified by combining with other options. For example, -f /path/to/file --env NAME=value adds also an environment variable.
       --force                         Create service forcefully, replaces existing service if any.
   -h, --help                          help for create
       --image string                  Image to run.

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -279,7 +279,7 @@ func (p *ConfigurationEditFlags) AddCreateFlags(command *cobra.Command) {
 	command.Flags().BoolVar(&p.ForceCreate, "force", false,
 		"Create service forcefully, replaces existing service if any.")
 	command.Flags().StringVarP(&p.Filename, "filename", "f", "", "Create a service from file. "+
-		"The created service can be futher modified by combining with other options."+
+		"The created service can be further modified by combining with other options."+
 		"Example: -f /path/to/file --env NAME=value will also add environment variable.")
 	command.MarkFlagFilename("filename")
 	p.markFlagMakesRevision("filename")

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -278,8 +278,11 @@ func (p *ConfigurationEditFlags) AddCreateFlags(command *cobra.Command) {
 	p.addSharedFlags(command)
 	command.Flags().BoolVar(&p.ForceCreate, "force", false,
 		"Create service forcefully, replaces existing service if any.")
-	command.Flags().StringVarP(&p.Filename, "filename", "f", "", "Create a service from file.")
+	command.Flags().StringVarP(&p.Filename, "filename", "f", "", "Create a service from file. "+
+		"The created service can be futher modified by combining with other options."+
+		"Example: -f /path/to/file --env NAME=value will also add environment variable.")
 	command.MarkFlagFilename("filename")
+	p.markFlagMakesRevision("filename")
 }
 
 // Apply mutates the given service according to the flags in the command.

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -280,7 +280,7 @@ func (p *ConfigurationEditFlags) AddCreateFlags(command *cobra.Command) {
 		"Create service forcefully, replaces existing service if any.")
 	command.Flags().StringVarP(&p.Filename, "filename", "f", "", "Create a service from file. "+
 		"The created service can be further modified by combining with other options. "+
-		"For example -f /path/to/file --env NAME=value will also add environment variable.")
+		"For example, -f /path/to/file --env NAME=value adds also an environment variable.")
 	command.MarkFlagFilename("filename")
 	p.markFlagMakesRevision("filename")
 }

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -279,8 +279,8 @@ func (p *ConfigurationEditFlags) AddCreateFlags(command *cobra.Command) {
 	command.Flags().BoolVar(&p.ForceCreate, "force", false,
 		"Create service forcefully, replaces existing service if any.")
 	command.Flags().StringVarP(&p.Filename, "filename", "f", "", "Create a service from file. "+
-		"The created service can be further modified by combining with other options."+
-		"Example: -f /path/to/file --env NAME=value will also add environment variable.")
+		"The created service can be further modified by combining with other options. "+
+		"For example -f /path/to/file --env NAME=value will also add environment variable.")
 	command.MarkFlagFilename("filename")
 	p.markFlagMakesRevision("filename")
 }

--- a/pkg/kn/commands/service/create.go
+++ b/pkg/kn/commands/service/create.go
@@ -303,12 +303,11 @@ func constructServiceFromFile(cmd *cobra.Command, editFlags ConfigurationEditFla
 	// Set namespace in case it's specified as --namespace
 	service.ObjectMeta.Namespace = namespace
 
-	// We need to generate revision to have --force replace working
-	revName, err := servinglib.GenerateRevisionName(editFlags.RevisionName, &service)
+	// Apply options provided from cmdline
+	err = editFlags.Apply(&service, nil, cmd)
 	if err != nil {
 		return nil, err
 	}
-	service.Spec.Template.Name = revName
 
 	return &service, nil
 }


### PR DESCRIPTION
## Description

Add enhancement to the command `kn service create -f` to accept other options to modify the created service.

Per discussion in #923 we should decide how `name` is handled:
- Provided cmdline `name` overrides the name in the file
- Keep the current implementation that if `name` is provided on cmdline it must match the name in the file.


## Changes

*  Add support to combine service create --filename with other options

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #923 

<!--
Please add an entrty to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
