### PR TITLE
List inbuilt sources if CRD access is restricted

### DIFF
--- a/pkg/dynamic/client.go
+++ b/pkg/dynamic/client.go
@@ -15,7 +15,7 @@
 package dynamic
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -121,7 +121,7 @@ func (c *knDynamicClient) ListSources(types ...WithType) (*unstructured.Unstruct
 	}
 
 	if sourceTypes == nil || len(sourceTypes.Items) == 0 {
-		return nil, fmt.Errorf("404: no sources found on the backend, please verify the installation")
+		return nil, errors.New("no sources found on the backend, please verify the installation")
 	}
 
 	namespace := c.Namespace()

--- a/pkg/dynamic/client.go
+++ b/pkg/dynamic/client.go
@@ -15,6 +15,7 @@
 package dynamic
 
 import (
+	"fmt"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,13 +45,13 @@ type KnDynamicClient interface {
 	// ListCRDs returns list of CRDs with their type and name
 	ListCRDs(options metav1.ListOptions) (*unstructured.UnstructuredList, error)
 
-	// ListSourceCRDs returns list of eventing sources CRDs
+	// ListSourcesTypes returns list of eventing sources CRDs
 	ListSourcesTypes() (*unstructured.UnstructuredList, error)
 
 	// ListSources returns list of available source objects
 	ListSources(types ...WithType) (*unstructured.UnstructuredList, error)
 
-	// ListSources returns list of available source objects using given list of GVKs
+	// ListSourcesUsingGVKs returns list of available source objects using given list of GVKs
 	ListSourcesUsingGVKs(*[]schema.GroupVersionKind, ...WithType) (*unstructured.UnstructuredList, error)
 
 	// RawClient returns the raw dynamic client interface
@@ -118,6 +119,11 @@ func (c *knDynamicClient) ListSources(types ...WithType) (*unstructured.Unstruct
 	if err != nil {
 		return nil, err
 	}
+
+	if sourceTypes == nil || len(sourceTypes.Items) == 0 {
+		return nil, fmt.Errorf("404: no sources found on the backend, please verify the installation")
+	}
+
 	namespace := c.Namespace()
 	filters := WithTypes(types).List()
 	// For each source type available, find out each source types objects
@@ -159,7 +165,7 @@ func (c *knDynamicClient) ListSources(types ...WithType) (*unstructured.Unstruct
 	return &sourceList, nil
 }
 
-// ListSources returns list of available source objects using given list of GVKs
+// ListSourcesUsingGVKs returns list of available source objects using given list of GVKs
 func (c *knDynamicClient) ListSourcesUsingGVKs(gvks *[]schema.GroupVersionKind, types ...WithType) (*unstructured.UnstructuredList, error) {
 	if gvks == nil {
 		return nil, nil

--- a/pkg/dynamic/client_test.go
+++ b/pkg/dynamic/client_test.go
@@ -95,6 +95,13 @@ func TestListSources(t *testing.T) {
 		assert.Check(t, util.ContainsAll(err.Error(), "can't", "find", "source", "kind", "CRD"))
 	})
 
+	t.Run("sources not installed", func(t *testing.T) {
+		client := createFakeKnDynamicClient(testNamespace)
+		_, err := client.ListSources()
+		assert.Check(t, err != nil)
+		assert.Check(t, util.ContainsAll(err.Error(), "no sources", "found", "backend", "verify", "installation"))
+	})
+
 	t.Run("source list empty", func(t *testing.T) {
 		client := createFakeKnDynamicClient(testNamespace,
 			newSourceCRDObjWithSpec("pingsources", "sources.knative.dev", "v1alpha1", "PingSource"),

--- a/pkg/dynamic/lib.go
+++ b/pkg/dynamic/lib.go
@@ -125,6 +125,7 @@ func (types WithTypes) List() []string {
 	return stypes
 }
 
+// UnstructuredCRDFromGVK constructs an unstructured object using the given GVK
 func UnstructuredCRDFromGVK(gvk schema.GroupVersionKind) *unstructured.Unstructured {
 	name := fmt.Sprintf("%ss.%s", strings.ToLower(gvk.Kind), gvk.Group)
 	plural := fmt.Sprintf("%ss", strings.ToLower(gvk.Kind))

--- a/pkg/dynamic/lib.go
+++ b/pkg/dynamic/lib.go
@@ -16,6 +16,7 @@ package dynamic
 
 import (
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -122,4 +123,25 @@ func (types WithTypes) List() []string {
 		f(&stypes)
 	}
 	return stypes
+}
+
+func UnstructuredCRDFromGVK(gvk schema.GroupVersionKind) *unstructured.Unstructured {
+	name := fmt.Sprintf("%ss.%s", strings.ToLower(gvk.Kind), gvk.Group)
+	plural := fmt.Sprintf("%ss", strings.ToLower(gvk.Kind))
+	u := &unstructured.Unstructured{}
+	u.SetUnstructuredContent(map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": name,
+		},
+		"spec": map[string]interface{}{
+			"group":   gvk.Group,
+			"version": gvk.Version,
+			"names": map[string]interface{}{
+				"kind":   gvk.Kind,
+				"plural": plural,
+			},
+		},
+	})
+
+	return u
 }

--- a/pkg/dynamic/lib_test.go
+++ b/pkg/dynamic/lib_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"gotest.tools/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"knative.dev/client/pkg/util"
 )
@@ -76,4 +77,23 @@ func TestGVRFromUnstructured(t *testing.T) {
 	_, err = gvrFromUnstructured(obj)
 	assert.Check(t, err != nil)
 	assert.Check(t, util.ContainsAll(err.Error(), "can't", "find", "version"))
+}
+
+func TestUnstructuredCRDFromGVK(t *testing.T) {
+	u := UnstructuredCRDFromGVK(schema.GroupVersionKind{"sources.knative.dev", "v1alpha2", "ApiServerSource"})
+	g, err := groupFromUnstructured(u)
+	assert.NilError(t, err)
+	assert.Equal(t, g, "sources.knative.dev")
+
+	v, err := versionFromUnstructured(u)
+	assert.NilError(t, err)
+	assert.Equal(t, v, "v1alpha2")
+
+	k, err := kindFromUnstructured(u)
+	assert.NilError(t, err)
+	assert.Equal(t, k, "ApiServerSource")
+
+	r, err := resourceFromUnstructured(u)
+	assert.NilError(t, err)
+	assert.Equal(t, r, "apiserversources")
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -41,3 +41,7 @@ func newNoKubeConfig(errString string) error {
 func newForbidden(code int32, msg string) *KNError {
 	return NewKNError(fmt.Sprintf("%d: %s", code, msg))
 }
+
+func newResourceNotFoundError(code int32, msg string) *KNError {
+	return NewKNError(fmt.Sprintf("%d: %s, please verify the installation", code, msg))
+}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -22,7 +22,7 @@ import (
 func newInvalidCRD(apiGroup string) *KNError {
 	parts := strings.Split(apiGroup, ".")
 	name := parts[0]
-	msg := fmt.Sprintf("no Knative %s API found on the backend, please verify the installation", name)
+	msg := fmt.Sprintf("404: no Knative %s API found on the backend, please verify the installation", name)
 	return NewKNError(msg)
 }
 
@@ -36,4 +36,8 @@ func newNoRouteToHost(errString string) error {
 
 func newNoKubeConfig(errString string) error {
 	return NewKNError("no kubeconfig has been provided, please use a valid configuration to connect to the cluster")
+}
+
+func newForbidden(code int32, msg string) *KNError {
+	return NewKNError(fmt.Sprintf("%d: %s", code, msg))
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -22,11 +22,11 @@ import (
 func newInvalidCRD(apiGroup string) *KNError {
 	parts := strings.Split(apiGroup, ".")
 	name := parts[0]
-	msg := fmt.Sprintf("404: no Knative %s API found on the backend, please verify the installation", name)
+	msg := fmt.Sprintf("no Knative %s API found on the backend, please verify the installation", name)
 	return NewKNError(msg)
 }
 
-func newNoRouteToHost(errString string) error {
+func newNoRouteToHost(errString string) *KNError {
 	parts := strings.SplitAfter(errString, "dial tcp")
 	if len(parts) == 2 {
 		return NewKNError(fmt.Sprintf("error connecting to the cluster, please verify connection at: %s", strings.Trim(parts[1], " ")))
@@ -34,14 +34,6 @@ func newNoRouteToHost(errString string) error {
 	return NewKNError(fmt.Sprintf("error connecting to the cluster: %s", errString))
 }
 
-func newNoKubeConfig(errString string) error {
+func newNoKubeConfig(errString string) *KNError {
 	return NewKNError("no kubeconfig has been provided, please use a valid configuration to connect to the cluster")
-}
-
-func newForbidden(code int32, msg string) *KNError {
-	return NewKNError(fmt.Sprintf("%d: %s", code, msg))
-}
-
-func newResourceNotFoundError(code int32, msg string) *KNError {
-	return NewKNError(fmt.Sprintf("%d: %s, please verify the installation", code, msg))
 }

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -22,12 +22,12 @@ import (
 
 func TestNewInvalidCRD(t *testing.T) {
 	err := newInvalidCRD("serving.knative.dev")
-	assert.Error(t, err, "404: no Knative serving API found on the backend, please verify the installation")
+	assert.Error(t, err, "no Knative serving API found on the backend, please verify the installation")
 
 	err = newInvalidCRD("eventing")
-	assert.Error(t, err, "404: no Knative eventing API found on the backend, please verify the installation")
+	assert.Error(t, err, "no Knative eventing API found on the backend, please verify the installation")
 
 	err = newInvalidCRD("")
-	assert.Error(t, err, "404: no Knative  API found on the backend, please verify the installation")
+	assert.Error(t, err, "no Knative  API found on the backend, please verify the installation")
 
 }

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -22,12 +22,12 @@ import (
 
 func TestNewInvalidCRD(t *testing.T) {
 	err := newInvalidCRD("serving.knative.dev")
-	assert.Error(t, err, "no Knative serving API found on the backend, please verify the installation")
+	assert.Error(t, err, "404: no Knative serving API found on the backend, please verify the installation")
 
 	err = newInvalidCRD("eventing")
-	assert.Error(t, err, "no Knative eventing API found on the backend, please verify the installation")
+	assert.Error(t, err, "404: no Knative eventing API found on the backend, please verify the installation")
 
 	err = newInvalidCRD("")
-	assert.Error(t, err, "no Knative  API found on the backend, please verify the installation")
+	assert.Error(t, err, "404: no Knative  API found on the backend, please verify the installation")
 
 }

--- a/pkg/errors/factory.go
+++ b/pkg/errors/factory.go
@@ -48,22 +48,20 @@ func GetError(err error) error {
 	case isNoRouteToHostError(err):
 		return newNoRouteToHost(err.Error())
 	default:
-		var knerr *KNError
 		apiStatus, ok := err.(api_errors.APIStatus)
-		switch {
-		case !ok:
+		if !ok {
 			return err
-		case apiStatus.Status().Details == nil:
-			knerr = NewKNError(err.Error())
-			knerr.Status = apiStatus
-			return knerr
-		case isCRDError(apiStatus):
+		}
+		if apiStatus.Status().Details == nil {
+			return err
+		}
+		var knerr *KNError
+		if isCRDError(apiStatus) {
 			knerr = newInvalidCRD(apiStatus.Status().Details.Group)
 			knerr.Status = apiStatus
 			return knerr
-		default:
-			return err
 		}
+		return err
 	}
 }
 

--- a/pkg/errors/factory.go
+++ b/pkg/errors/factory.go
@@ -43,6 +43,10 @@ func isForbiddenError(status api_errors.APIStatus) bool {
 	return status.Status().Code == http.StatusForbidden
 }
 
+func isResourceNotFoundError(err error) bool {
+	return strings.Contains(err.Error(), "server could not find the requested resource")
+}
+
 //Retrieves a custom error struct based on the original error APIStatus struct
 //Returns the original error struct in case it can't identify the kind of APIStatus error
 func GetError(err error) error {
@@ -67,6 +71,10 @@ func GetError(err error) error {
 			return knerr
 		case isForbiddenError(apiStatus):
 			knerr = newForbidden(apiStatus.Status().Code, apiStatus.Status().Message)
+			knerr.Status = apiStatus
+			return knerr
+		case isResourceNotFoundError(err):
+			knerr = newResourceNotFoundError(apiStatus.Status().Code, apiStatus.Status().Message)
 			knerr.Status = apiStatus
 			return knerr
 		default:

--- a/pkg/errors/factory.go
+++ b/pkg/errors/factory.go
@@ -39,7 +39,7 @@ func isEmptyConfigError(err error) bool {
 	return strings.Contains(err.Error(), "no configuration has been provided")
 }
 
-func IsForbiddenError(status api_errors.APIStatus) bool {
+func isForbiddenError(status api_errors.APIStatus) bool {
 	return status.Status().Code == http.StatusForbidden
 }
 
@@ -65,7 +65,7 @@ func GetError(err error) error {
 			knerr = newInvalidCRD(apiStatus.Status().Details.Group)
 			knerr.Status = apiStatus
 			return knerr
-		case IsForbiddenError(apiStatus):
+		case isForbiddenError(apiStatus):
 			knerr = newForbidden(apiStatus.Status().Code, apiStatus.Status().Message)
 			knerr.Status = apiStatus
 			return knerr

--- a/pkg/errors/factory_test.go
+++ b/pkg/errors/factory_test.go
@@ -48,7 +48,7 @@ func TestKnErrorsStatusErrors(t *testing.T) {
 				}
 				return statusError
 			},
-			ExpectedMsg: "404: no Knative serving API found on the backend, please verify the installation",
+			ExpectedMsg: "no Knative serving API found on the backend, please verify the installation",
 			Validate: func(t *testing.T, err error, msg string) {
 				assert.Error(t, err, msg)
 			},

--- a/pkg/errors/factory_test.go
+++ b/pkg/errors/factory_test.go
@@ -48,7 +48,7 @@ func TestKnErrorsStatusErrors(t *testing.T) {
 				}
 				return statusError
 			},
-			ExpectedMsg: "no Knative serving API found on the backend, please verify the installation",
+			ExpectedMsg: "404: no Knative serving API found on the backend, please verify the installation",
 			Validate: func(t *testing.T, err error, msg string) {
 				assert.Error(t, err, msg)
 			},

--- a/pkg/kn/commands/source/list.go
+++ b/pkg/kn/commands/source/list.go
@@ -55,10 +55,12 @@ func NewListCommand(p *commands.KnParams) *cobra.Command {
 			if err != nil {
 				return err
 			}
+
 			var filters dynamic.WithTypes
 			for _, filter := range filterFlags.Filters {
 				filters = append(filters, dynamic.WithTypeFilter(filter))
 			}
+
 			sourceList, err := dynamicClient.ListSources(filters...)
 			if err != nil {
 				if strings.HasPrefix(knerrors.GetError(err).Error(), "403") {
@@ -67,10 +69,12 @@ func NewListCommand(p *commands.KnParams) *cobra.Command {
 					if err != nil {
 						return knerrors.GetError(err)
 					}
+				} else {
+					return knerrors.GetError(err)
 				}
 			}
 
-			if len(sourceList.Items) == 0 {
+			if sourceList == nil || len(sourceList.Items) == 0 {
 				fmt.Fprintf(cmd.OutOrStdout(), "No sources found in %s namespace.\n", namespace)
 				return nil
 			}

--- a/pkg/kn/commands/source/list_test.go
+++ b/pkg/kn/commands/source/list_test.go
@@ -79,7 +79,7 @@ func TestSourceListTypesNoHeaders(t *testing.T) {
 	assert.Check(t, util.ContainsAll(output[0], "PingSource"))
 }
 
-func TestListBuiltInSources(t *testing.T) {
+func TestListBuiltInSourceTypes(t *testing.T) {
 	fakeDynamic := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
 	sources, err := listBuiltInSourceTypes(clientdynamic.NewKnDynamicClient(fakeDynamic, "current"))
 	assert.NilError(t, err)

--- a/pkg/kn/commands/source/list_test.go
+++ b/pkg/kn/commands/source/list_test.go
@@ -23,6 +23,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clientdynamic "knative.dev/client/pkg/dynamic"
 	"knative.dev/client/pkg/kn/commands"
 	"knative.dev/client/pkg/util"
 )
@@ -69,6 +71,14 @@ func TestSourceListTypesNoHeaders(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Check(t, util.ContainsNone(output[0], "TYPE", "NAME", "DESCRIPTION"))
 	assert.Check(t, util.ContainsAll(output[0], "PingSource"))
+}
+
+func TestListBuiltInSources(t *testing.T) {
+	fakeDynamic := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	sources, err := listBuiltInSourceTypes(clientdynamic.NewKnDynamicClient(fakeDynamic, "current"))
+	assert.NilError(t, err)
+	assert.Check(t, sources != nil)
+	assert.Equal(t, len(sources.Items), 4)
 }
 
 func TestSourceList(t *testing.T) {

--- a/pkg/kn/commands/source/list_test.go
+++ b/pkg/kn/commands/source/list_test.go
@@ -53,6 +53,12 @@ func sourceFakeCmd(args []string, objects ...runtime.Object) (output []string, e
 	return
 }
 
+func TestSourceListTypesNoSourcesInstalled(t *testing.T) {
+	_, err := sourceFakeCmd([]string{"source", "list-types"})
+	assert.Check(t, err != nil)
+	assert.Check(t, util.ContainsAll(err.Error(), "no sources", "found", "backend", "verify", "installation"))
+}
+
 func TestSourceListTypes(t *testing.T) {
 	output, err := sourceFakeCmd([]string{"source", "list-types"},
 		newSourceCRDObjWithSpec("pingsources", "sources.knative.dev", "v1alpha1", "PingSource"),
@@ -79,6 +85,12 @@ func TestListBuiltInSources(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Check(t, sources != nil)
 	assert.Equal(t, len(sources.Items), 4)
+}
+
+func TestSourceListNoSourcesInstalled(t *testing.T) {
+	_, err := sourceFakeCmd([]string{"source", "list"})
+	assert.Check(t, err != nil)
+	assert.Check(t, util.ContainsAll(err.Error(), "no sources", "found", "backend", "verify", "installation"))
 }
 
 func TestSourceList(t *testing.T) {

--- a/pkg/sources/v1alpha2/apiserver_client.go
+++ b/pkg/sources/v1alpha2/apiserver_client.go
@@ -111,7 +111,7 @@ func (c *apiServerSourcesClient) Namespace() string {
 func (c *apiServerSourcesClient) ListAPIServerSource() (*v1alpha2.ApiServerSourceList, error) {
 	sourceList, err := c.client.List(metav1.ListOptions{})
 	if err != nil {
-		return nil, err
+		return nil, knerrors.GetError(err)
 	}
 
 	return updateAPIServerSourceListGVK(sourceList)

--- a/pkg/sources/v1alpha2/client.go
+++ b/pkg/sources/v1alpha2/client.go
@@ -15,8 +15,6 @@
 package v1alpha2
 
 import (
-	"strings"
-
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	sourcesv1alpha2 "knative.dev/eventing/pkg/apis/sources/v1alpha2"
 	clientv1alpha2 "knative.dev/eventing/pkg/client/clientset/versioned/typed/sources/v1alpha2"

--- a/pkg/sources/v1alpha2/client.go
+++ b/pkg/sources/v1alpha2/client.go
@@ -15,6 +15,10 @@
 package v1alpha2
 
 import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	sourcesv1alpha2 "knative.dev/eventing/pkg/apis/sources/v1alpha2"
 	clientv1alpha2 "knative.dev/eventing/pkg/client/clientset/versioned/typed/sources/v1alpha2"
 )
 
@@ -60,4 +64,14 @@ func (c *sourcesClient) SinkBindingClient() KnSinkBindingClient {
 // ApiServerSourcesClient for dealing with ApiServer sources
 func (c *sourcesClient) APIServerSourcesClient() KnAPIServerSourcesClient {
 	return newKnAPIServerSourcesClient(c.client.ApiServerSources(c.namespace), c.namespace)
+}
+
+// BuiltInSourcesGVKs returns the GVKs for built in sources
+func BuiltInSourcesGVKs() []schema.GroupVersionKind {
+	return []schema.GroupVersionKind{
+		sourcesv1alpha2.SchemeGroupVersion.WithKind("ApiServerSource"),
+		sourcesv1alpha2.SchemeGroupVersion.WithKind("ContainerSource"),
+		sourcesv1alpha2.SchemeGroupVersion.WithKind("PingSource"),
+		sourcesv1alpha2.SchemeGroupVersion.WithKind("SinkBinding"),
+	}
 }

--- a/pkg/sources/v1alpha2/client_test.go
+++ b/pkg/sources/v1alpha2/client_test.go
@@ -1,0 +1,31 @@
+// Copyright © 2020 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha2
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+
+	sourcesv1alpha2 "knative.dev/eventing/pkg/apis/sources/v1alpha2"
+)
+
+func TestBuiltInSourcesGVks(t *testing.T) {
+	gvks := BuiltInSourcesGVKs()
+	for _, each := range gvks {
+		assert.DeepEqual(t, each.GroupVersion(), sourcesv1alpha2.SchemeGroupVersion)
+	}
+	assert.Equal(t, len(gvks), 4)
+}


### PR DESCRIPTION
## Description
- Identify restricted access error
- If server returns restricted access error, fallback to listing
  only eventing inbuilt sources using their GVKs.
- List every typed source and read the error
  to know if eventing is installed for `kn source list-types`.


## Changes
-  Add `isForbiddenError` in kn error factory
-  Add `ListSourcesUsingGVKs` to dynamic client
-  Add  `BuiltInSourcesGVKs` to `pkg/sources/v1alpha2/client.go` which returns inbuilt source GVKs

## Reference
Fixes #947 

/lint