### PR TITLE
allow test image to be customized

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,10 @@
 |===
 | | Description | PR
 
+| 🐣
+| Allow the kn test image to be customized via environment variable
+| https://github.com/knative/client/pull/957[#957]
+
 | 🎁
 | Add support to combine service create --filename with other options
 | https://github.com/knative/client/pull/937[#937]

--- a/lib/test/integration.go
+++ b/lib/test/integration.go
@@ -29,6 +29,7 @@ const (
 	KnDefaultTestImage string        = "gcr.io/knative-samples/helloworld-go"
 	MaxRetries         int           = 10
 	RetrySleepDuration time.Duration = 5 * time.Second
+	KnTestImageEnv     string        = "KN_TEST_IMAGE" // Allow test image to be customized
 )
 
 var nsMutex sync.Mutex
@@ -40,6 +41,15 @@ var namespaceCount int
 type KnTest struct {
 	namespace string
 	kn        Kn
+}
+
+// GetKnTestImage returns either customized or default kn test image
+func GetKnTestImage() string {
+	value := os.Getenv(KnTestImageEnv)
+	if value == "" {
+		return KnDefaultTestImage
+	}
+	return value
 }
 
 // NewKnTest creates a new KnTest object

--- a/lib/test/service.go
+++ b/lib/test/service.go
@@ -28,7 +28,7 @@ import (
 
 // ServiceCreate verifies given service creation in sync mode and also verifies output
 func ServiceCreate(r *KnRunResultCollector, serviceName string) {
-	out := r.KnTest().Kn().Run("service", "create", serviceName, "--image", KnDefaultTestImage)
+	out := r.KnTest().Kn().Run("service", "create", serviceName, "--image", GetKnTestImage())
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "service", serviceName, "creating", "namespace", r.KnTest().Kn().Namespace(), "ready"))
 }
@@ -51,7 +51,7 @@ func ServiceList(r *KnRunResultCollector, serviceName string) {
 func ServiceDescribe(r *KnRunResultCollector, serviceName string) {
 	out := r.KnTest().Kn().Run("service", "describe", serviceName)
 	r.AssertNoError(out)
-	assert.Assert(r.T(), util.ContainsAll(out.Stdout, serviceName, r.KnTest().Kn().Namespace(), KnDefaultTestImage))
+	assert.Assert(r.T(), util.ContainsAll(out.Stdout, serviceName, r.KnTest().Kn().Namespace(), GetKnTestImage()))
 	assert.Assert(r.T(), util.ContainsAll(out.Stdout, "Conditions", "ConfigurationsReady", "Ready", "RoutesReady"))
 	assert.Assert(r.T(), util.ContainsAll(out.Stdout, "Name", "Namespace", "URL", "Age", "Revisions"))
 }

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -61,6 +61,12 @@ smoke_test() {
   # Test namespace
   ns="kne2esmoketests"
 
+  # Test image
+  img=${KN_TEST_IMAGE}
+  if [[ -z "${KN_TEST_IMAGE}" ]]; then
+    img="gcr.io/knative-samples/helloworld-go"
+  fi
+
   set -x
 
   kubectl create ns $ns || fail_test
@@ -68,15 +74,15 @@ smoke_test() {
 
   sleep 4 # Wait for the namespace to get initialized by kube-controller-manager
 
-  ./kn service create svc1 --no-wait --image gcr.io/knative-samples/helloworld-go -e TARGET=Knative -n $ns || fail_test
-  ./kn service create svc2 --no-wait --image gcr.io/knative-samples/helloworld-go -e TARGET=Knative -n $ns || fail_test
-  ./kn service create hello --image gcr.io/knative-samples/helloworld-go -e TARGET=Knative -n $ns || fail_test
+  ./kn service create svc1 --no-wait --image $img -e TARGET=Knative -n $ns || fail_test
+  ./kn service create svc2 --no-wait --image $img -e TARGET=Knative -n $ns || fail_test
+  ./kn service create hello --image $img -e TARGET=Knative -n $ns || fail_test
   ./kn service list hello -n $ns || fail_test
   ./kn service update hello --env TARGET=kn -n $ns || fail_test
   ./kn revision list hello -n $ns || fail_test
   ./kn service list -n $ns || fail_test
-  ./kn service create hello --force --image gcr.io/knative-samples/helloworld-go -e TARGET=Awesome -n $ns || fail_test
-  ./kn service create foo --force --image gcr.io/knative-samples/helloworld-go -e TARGET=foo -n $ns || fail_test
+  ./kn service create hello --force --image $img -e TARGET=Awesome -n $ns || fail_test
+  ./kn service create foo --force --image $img -e TARGET=foo -n $ns || fail_test
   ./kn revision list -n $ns || fail_test
   ./kn service list -n $ns || fail_test
   ./kn service describe hello -n $ns || fail_test

--- a/test/e2e/service_export_test.go
+++ b/test/e2e/service_export_test.go
@@ -136,7 +136,7 @@ func TestServiceExport(t *testing.T) {
 			withRevisionName("hello-rev1"),
 			withRevisionAnnotations(
 				map[string]string{
-					"client.knative.dev/user-image": "gcr.io/knative-samples/helloworld-go",
+					"client.knative.dev/user-image": test.GetKnTestImage(),
 				}),
 			withRevisionLabels(
 				map[string]string{
@@ -198,7 +198,7 @@ func TestServiceExport(t *testing.T) {
 			withRevisionName("hello-rev1"),
 			withRevisionAnnotations(
 				map[string]string{
-					"client.knative.dev/user-image": "gcr.io/knative-samples/helloworld-go",
+					"client.knative.dev/user-image": test.GetKnTestImage(),
 				}),
 			withRevisionLabels(
 				map[string]string{
@@ -399,7 +399,7 @@ func withConfigurationLabels(labels map[string]string) expectedServiceOption {
 func withConfigurationAnnotations() expectedServiceOption {
 	return func(svc *servingv1.Service) {
 		svc.Spec.Template.ObjectMeta.Annotations = map[string]string{
-			"client.knative.dev/user-image": "gcr.io/knative-samples/helloworld-go",
+			"client.knative.dev/user-image": test.GetKnTestImage(),
 		}
 	}
 }
@@ -489,7 +489,7 @@ func withContainer() podSpecOption {
 		spec.Containers = []corev1.Container{
 			{
 				Name:      "user-container",
-				Image:     test.KnDefaultTestImage,
+				Image:     test.GetKnTestImage(),
 				Resources: corev1.ResourceRequirements{},
 				ReadinessProbe: &corev1.Probe{
 					SuccessThreshold: int32(1),

--- a/test/e2e/service_file_test.go
+++ b/test/e2e/service_file_test.go
@@ -87,8 +87,8 @@ func TestServiceCreateFromFile(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 	assert.NilError(t, err)
 
-	test.CreateFile("foo.json", fmt.Sprintf(ServiceJSON, test.KnDefaultTestImage), tempDir, test.FileModeReadWrite)
-	test.CreateFile("foo.yaml", fmt.Sprintf(ServiceYAML, test.KnDefaultTestImage), tempDir, test.FileModeReadWrite)
+	test.CreateFile("foo.json", fmt.Sprintf(ServiceJSON, test.GetKnTestImage()), tempDir, test.FileModeReadWrite)
+	test.CreateFile("foo.yaml", fmt.Sprintf(ServiceYAML, test.GetKnTestImage()), tempDir, test.FileModeReadWrite)
 
 	t.Log("create foo-json service from JSON file")
 	serviceCreateFromFile(r, "foo-json", filepath.Join(tempDir, "foo.json"), true)

--- a/test/e2e/service_options_test.go
+++ b/test/e2e/service_options_test.go
@@ -140,7 +140,7 @@ func TestServiceOptions(t *testing.T) {
 }
 
 func serviceCreateWithOptions(r *test.KnRunResultCollector, serviceName string, options ...string) {
-	command := []string{"service", "create", serviceName, "--image", test.KnDefaultTestImage}
+	command := []string{"service", "create", serviceName, "--image", test.GetKnTestImage()}
 	command = append(command, options...)
 	out := r.KnTest().Kn().Run(command...)
 	assert.Check(r.T(), util.ContainsAll(out.Stdout, "service", serviceName, "Creating", "namespace", r.KnTest().Kn().Namespace(), "Ready"))

--- a/test/e2e/service_test.go
+++ b/test/e2e/service_test.go
@@ -72,7 +72,7 @@ func TestService(t *testing.T) {
 
 func serviceCreatePrivate(r *test.KnRunResultCollector, serviceName string) {
 	out := r.KnTest().Kn().Run("service", "create", serviceName,
-		"--image", test.KnDefaultTestImage, "--cluster-local")
+		"--image", test.GetKnTestImage(), "--cluster-local")
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "service", serviceName, "creating", "namespace", r.KnTest().Kn().Namespace(), "ready"))
 
@@ -83,7 +83,7 @@ func serviceCreatePrivate(r *test.KnRunResultCollector, serviceName string) {
 
 func serviceCreatePrivateUpdatePublic(r *test.KnRunResultCollector, serviceName string) {
 	out := r.KnTest().Kn().Run("service", "create", serviceName,
-		"--image", test.KnDefaultTestImage, "--cluster-local")
+		"--image", test.GetKnTestImage(), "--cluster-local")
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "service", serviceName, "creating", "namespace", r.KnTest().Kn().Namespace(), "ready"))
 
@@ -92,7 +92,7 @@ func serviceCreatePrivateUpdatePublic(r *test.KnRunResultCollector, serviceName 
 	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, serving.VisibilityLabelKey, serving.VisibilityClusterLocal))
 
 	out = r.KnTest().Kn().Run("service", "update", serviceName,
-		"--image", test.KnDefaultTestImage, "--no-cluster-local")
+		"--image", test.GetKnTestImage(), "--no-cluster-local")
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "service", serviceName, "updated", "namespace", r.KnTest().Kn().Namespace(), "ready"))
 
@@ -106,7 +106,7 @@ func serviceCreateDuplicate(r *test.KnRunResultCollector, serviceName string) {
 	r.AssertNoError(out)
 	assert.Check(r.T(), strings.Contains(out.Stdout, serviceName), "The service does not exist yet")
 
-	out = r.KnTest().Kn().Run("service", "create", serviceName, "--image", test.KnDefaultTestImage)
+	out = r.KnTest().Kn().Run("service", "create", serviceName, "--image", test.GetKnTestImage())
 	r.AssertError(out)
 	assert.Check(r.T(), util.ContainsAll(out.Stderr, "the service already exists"))
 }


### PR DESCRIPTION
## Description
Allow the kn test image to be customized via environment variable.

## Changes

* all references to KnDefaultTestImage were replaced with GetKnTestImage() function
* all hardcoded occuerences of "gcr.io/knative-samples/helloworld-go" were replaced with GetKnTestImage() function

<!--
/lint
-->
