### PR TITLE
Deprecates --max-scale/--min-scale for more consistent naming

### DIFF
--- a/cmd/kn/main_test.go
+++ b/cmd/kn/main_test.go
@@ -142,7 +142,7 @@ func TestUnknownCommands(t *testing.T) {
 		expectedError []string
 	}{
 		{
-			[]string{"service", "udpate", "test", "--min-scale=0"},
+			[]string{"service", "udpate", "test", "--scale-min=0"},
 			[]string{"service"},
 			[]string{"unknown sub-command", "udpate"},
 		},

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -75,8 +75,6 @@ kn service create NAME --image IMAGE
       --limits-cpu string             DEPRECATED: please use --limit instead. The limits on the requested CPU (e.g., 1000m).
       --limits-memory string          DEPRECATED: please use --limit instead. The limits on the requested memory (e.g., 1024Mi).
       --lock-to-digest                Keep the running image for the service constant when not explicitly specifying the image. (--no-lock-to-digest pulls the image tag afresh with each new revision) (default true)
-      --max-scale int                 Maximal number of replicas.
-      --min-scale int                 Minimal number of replicas.
       --mount stringArray             Mount a ConfigMap (prefix cm: or config-map:), a Secret (prefix secret: or sc:), or an existing Volume (without any prefix) on the specified directory. Example: --mount /mydir=cm:myconfigmap, --mount /mydir=secret:mysecret, or --mount /mydir=myvolume. When a configmap or a secret is specified, a corresponding volume is automatically generated. You can use this flag multiple times. For unmounting a directory, append "-", e.g. --mount /mydir-, which also removes any auto-generated volume.
   -n, --namespace string              Specify the namespace to operate in.
       --no-cluster-local              Do not specify that the service be private. (--no-cluster-local will make the service publicly available) (default true)
@@ -89,6 +87,8 @@ kn service create NAME --image IMAGE
       --requests-memory string        DEPRECATED: please use --request instead. The requested memory (e.g., 64Mi).
       --revision-name string          The revision name to set. Must start with the service name and a dash as a prefix. Empty revision name will result in the server generating a name for the revision. Accepts golang templates, allowing {{.Service}} for the service name, {{.Generation}} for the generation, and {{.Random [n]}} for n random consonants. (default "{{.Service}}-{{.Random 5}}-{{.Generation}}")
       --scale int                     Minimum and maximum number of replicas.
+      --scale-max int                 Maximum number of replicas.
+      --scale-min int                 Minimum number of replicas.
       --service-account string        Service account name to set. An empty argument ("") clears the service account. The referenced service account must exist in the service's namespace.
       --user int                      The user ID to run the container (e.g., 1001).
       --volume stringArray            Add a volume from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret: or sc:). Example: --volume myvolume=cm:myconfigmap or --volume myvolume=secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --volume myvolume-.

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -58,8 +58,6 @@ kn service update NAME
       --limits-cpu string             DEPRECATED: please use --limit instead. The limits on the requested CPU (e.g., 1000m).
       --limits-memory string          DEPRECATED: please use --limit instead. The limits on the requested memory (e.g., 1024Mi).
       --lock-to-digest                Keep the running image for the service constant when not explicitly specifying the image. (--no-lock-to-digest pulls the image tag afresh with each new revision) (default true)
-      --max-scale int                 Maximal number of replicas.
-      --min-scale int                 Minimal number of replicas.
       --mount stringArray             Mount a ConfigMap (prefix cm: or config-map:), a Secret (prefix secret: or sc:), or an existing Volume (without any prefix) on the specified directory. Example: --mount /mydir=cm:myconfigmap, --mount /mydir=secret:mysecret, or --mount /mydir=myvolume. When a configmap or a secret is specified, a corresponding volume is automatically generated. You can use this flag multiple times. For unmounting a directory, append "-", e.g. --mount /mydir-, which also removes any auto-generated volume.
   -n, --namespace string              Specify the namespace to operate in.
       --no-cluster-local              Do not specify that the service be private. (--no-cluster-local will make the service publicly available) (default true)
@@ -72,6 +70,8 @@ kn service update NAME
       --requests-memory string        DEPRECATED: please use --request instead. The requested memory (e.g., 64Mi).
       --revision-name string          The revision name to set. Must start with the service name and a dash as a prefix. Empty revision name will result in the server generating a name for the revision. Accepts golang templates, allowing {{.Service}} for the service name, {{.Generation}} for the generation, and {{.Random [n]}} for n random consonants. (default "{{.Service}}-{{.Random 5}}-{{.Generation}}")
       --scale int                     Minimum and maximum number of replicas.
+      --scale-max int                 Maximum number of replicas.
+      --scale-min int                 Minimum number of replicas.
       --service-account string        Service account name to set. An empty argument ("") clears the service account. The referenced service account must exist in the service's namespace.
       --tag strings                   Set tag (format: --tag revisionRef=tagName) where revisionRef can be a revision or '@latest' string representing latest ready revision. This flag can be specified multiple times.
       --traffic strings               Set traffic distribution (format: --traffic revisionRef=percent) where revisionRef can be a revision or a tag or '@latest' string representing latest ready revision. This flag can be given multiple times with percent summing up to 100%.

--- a/docs/operations/autoscaling.md
+++ b/docs/operations/autoscaling.md
@@ -20,5 +20,5 @@ flags to configure the autoscaling behavior.
 | :------------------------- | :-------------------------------------------------------------------------------------------------------------------------- |
 | `--concurrency-limit int`  | Hard limit of concurrent requests to be processed by a single replica.                                                      |
 | `--concurrency-target int` | Recommendation for when to scale up based on the concurrent number of incoming requests. Defaults to `--concurrency-limit`. |
-| `--max-scale int`          | Maximum number of replicas.                                                                                                 |
-| `--min-scale int`          | Minimum number of replicas.                                                                                                 |
+| `--scale-max int`          | Maximum number of replicas.                                                                                                 |
+| `--scale-min int`          | Minimum number of replicas.                                                                                                 |

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -182,14 +182,14 @@ func (p *ConfigurationEditFlags) addSharedFlags(command *cobra.Command) {
 		"DEPRECATED: please use --limit instead. The limits on the requested memory (e.g., 1024Mi).")
 	p.markFlagMakesRevision("limits-memory")
 
-	command.Flags().IntVar(&p.MinScale, "min-scale", 0, "Minimal number of replicas.")
-	p.markFlagMakesRevision("min-scale")
-
-	command.Flags().IntVar(&p.MaxScale, "max-scale", 0, "Maximal number of replicas.")
-	p.markFlagMakesRevision("max-scale")
-
 	command.Flags().IntVar(&p.Scale, "scale", 0, "Minimum and maximum number of replicas.")
 	p.markFlagMakesRevision("scale")
+
+	command.Flags().IntVar(&p.MinScale, "scale-min", 0, "Minimum number of replicas.")
+	p.markFlagMakesRevision("scale-min")
+
+	command.Flags().IntVar(&p.MaxScale, "scale-max", 0, "Maximum number of replicas.")
+	p.markFlagMakesRevision("scale-max")
 
 	command.Flags().StringVar(&p.AutoscaleWindow, "autoscale-window", "", "Duration to look back for making auto-scaling decisions. The service is scaled to zero if no request was received in during that time. (eg: 10s)")
 	p.markFlagMakesRevision("autoscale-window")
@@ -430,14 +430,14 @@ func (p *ConfigurationEditFlags) Apply(
 		}
 	}
 
-	if cmd.Flags().Changed("min-scale") {
+	if cmd.Flags().Changed("scale-min") {
 		err = servinglib.UpdateMinScale(template, p.MinScale)
 		if err != nil {
 			return err
 		}
 	}
 
-	if cmd.Flags().Changed("max-scale") {
+	if cmd.Flags().Changed("scale-max") {
 		err = servinglib.UpdateMaxScale(template, p.MaxScale)
 		if err != nil {
 			return err
@@ -445,10 +445,10 @@ func (p *ConfigurationEditFlags) Apply(
 	}
 
 	if cmd.Flags().Changed("scale") {
-		if cmd.Flags().Changed("max-scale") {
-			return fmt.Errorf("only --scale or --max-scale can be specified")
-		} else if cmd.Flags().Changed("min-scale") {
-			return fmt.Errorf("only --scale or --min-scale can be specified")
+		if cmd.Flags().Changed("scale-max") {
+			return fmt.Errorf("only --scale or --scale-max can be specified")
+		} else if cmd.Flags().Changed("scale-min") {
+			return fmt.Errorf("only --scale or --scale-min can be specified")
 		} else {
 			err = servinglib.UpdateMaxScale(template, p.Scale)
 			if err != nil {

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -182,6 +182,14 @@ func (p *ConfigurationEditFlags) addSharedFlags(command *cobra.Command) {
 		"DEPRECATED: please use --limit instead. The limits on the requested memory (e.g., 1024Mi).")
 	p.markFlagMakesRevision("limits-memory")
 
+	command.Flags().IntVar(&p.MinScale, "min-scale", 0, "Minimal number of replicas.")
+	command.Flags().MarkHidden("min-scale")
+	p.markFlagMakesRevision("min-scale")
+
+	command.Flags().IntVar(&p.MaxScale, "max-scale", 0, "Maximal number of replicas.")
+	command.Flags().MarkHidden("max-scale")
+	p.markFlagMakesRevision("max-scale")
+
 	command.Flags().IntVar(&p.Scale, "scale", 0, "Minimum and maximum number of replicas.")
 	p.markFlagMakesRevision("scale")
 

--- a/pkg/kn/commands/service/create_test.go
+++ b/pkg/kn/commands/service/create_test.go
@@ -513,7 +513,7 @@ func TestServiceCreateRequestsLimitsMemory(t *testing.T) {
 func TestServiceCreateMaxMinScale(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
 		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
-		"--min-scale", "1", "--max-scale", "5",
+		"--scale-min", "1", "--scale-max", "5",
 		"--concurrency-target", "10", "--concurrency-limit", "100",
 		"--concurrency-utilization", "50",
 		"--no-wait"}, false)
@@ -592,11 +592,11 @@ func TestServiceCreateScaleWithNegativeValue(t *testing.T) {
 func TestServiceCreateScaleWithMaxScaleSet(t *testing.T) {
 	_, _, _, err := fakeServiceCreate([]string{
 		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
-		"--scale", "5", "--max-scale", "2", "--no-wait"}, true)
+		"--scale", "5", "--scale-max", "2", "--no-wait"}, true)
 	if err == nil {
 		t.Fatal(err)
 	}
-	expectedErrMsg := "only --scale or --max-scale can be specified"
+	expectedErrMsg := "only --scale or --scale-max can be specified"
 	if !strings.Contains(err.Error(), expectedErrMsg) {
 		t.Errorf("Invalid error output, expected: %s, got : '%s'", expectedErrMsg, err)
 	}
@@ -606,11 +606,11 @@ func TestServiceCreateScaleWithMaxScaleSet(t *testing.T) {
 func TestServiceCreateScaleWithMinScaleSet(t *testing.T) {
 	_, _, _, err := fakeServiceCreate([]string{
 		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
-		"--scale", "5", "--min-scale", "2", "--no-wait"}, true)
+		"--scale", "5", "--scale-min", "2", "--no-wait"}, true)
 	if err == nil {
 		t.Fatal(err)
 	}
-	expectedErrMsg := "only --scale or --min-scale can be specified"
+	expectedErrMsg := "only --scale or --scale-min can be specified"
 	if !strings.Contains(err.Error(), expectedErrMsg) {
 		t.Errorf("Invalid error output, expected: %s, got : '%s'", expectedErrMsg, err)
 	}

--- a/pkg/kn/commands/service/update_test.go
+++ b/pkg/kn/commands/service/update_test.go
@@ -320,7 +320,7 @@ func TestServiceUpdateMaxMinScale(t *testing.T) {
 
 	action, updated, _, err := fakeServiceUpdate(original, []string{
 		"service", "update", "foo",
-		"--min-scale", "1", "--max-scale", "5", "--concurrency-target", "10", "--concurrency-limit", "100", "--concurrency-utilization", "50", "--no-wait"})
+		"--scale-min", "1", "--scale-max", "5", "--concurrency-target", "10", "--concurrency-limit", "100", "--concurrency-utilization", "50", "--no-wait"})
 
 	if err != nil {
 		t.Fatal(err)
@@ -413,13 +413,13 @@ func TestServiceUpdateScaleWithMaxScaleSet(t *testing.T) {
 
 	_, _, _, err := fakeServiceUpdate(original, []string{
 		"service", "update", "foo",
-		"--scale", "5", "--max-scale", "2", "--no-wait"})
+		"--scale", "5", "--scale-max", "2", "--no-wait"})
 
 	if err == nil {
 		t.Fatal("Expected error, got nil")
 	}
 
-	expectedErrMsg := "only --scale or --max-scale can be specified"
+	expectedErrMsg := "only --scale or --scale-max can be specified"
 
 	if !strings.Contains(err.Error(), expectedErrMsg) {
 		t.Errorf("Invalid error output, expected: %s, got : '%s'", expectedErrMsg, err)
@@ -432,13 +432,13 @@ func TestServiceUpdateScaleWithMinScaleSet(t *testing.T) {
 
 	_, _, _, err := fakeServiceUpdate(original, []string{
 		"service", "update", "foo",
-		"--scale", "5", "--min-scale", "2", "--no-wait"})
+		"--scale", "5", "--scale-min", "2", "--no-wait"})
 
 	if err == nil {
 		t.Fatal("Expected error, got nil")
 	}
 
-	expectedErrMsg := "only --scale or --min-scale can be specified"
+	expectedErrMsg := "only --scale or --scale-min can be specified"
 
 	if !strings.Contains(err.Error(), expectedErrMsg) {
 		t.Errorf("Invalid error output, expected: %s, got : '%s'", expectedErrMsg, err)

--- a/test/e2e/service_options_test.go
+++ b/test/e2e/service_options_test.go
@@ -68,12 +68,12 @@ func TestServiceOptions(t *testing.T) {
 	test.ServiceDelete(r, "svc1")
 
 	t.Log("create and validate service with min/max scale options")
-	serviceCreateWithOptions(r, "svc2", "--min-scale", "1", "--max-scale", "3")
+	serviceCreateWithOptions(r, "svc2", "--scale-min", "1", "--scale-max", "3")
 	validateServiceMinScale(r, "svc2", "1")
 	validateServiceMaxScale(r, "svc2", "3")
 
 	t.Log("update and validate service with max scale option")
-	test.ServiceUpdate(r, "svc2", "--max-scale", "2")
+	test.ServiceUpdate(r, "svc2", "--scale-max", "2")
 	validateServiceMaxScale(r, "svc2", "2")
 
 	t.Log("create and validate service with scale options")


### PR DESCRIPTION
## Description

This PR updates --max-scale and --min-scale to --scale-max and --scale-min

## Changes

* Updated --max-scale to --scale-max
* Updated --min-scale to --scale-min

## Reference

https://github.com/knative/client/issues/822
