### PR TITLE
fix: `kn source list` command print spelling problems

### DIFF
--- a/pkg/kn/commands/source/list.go
+++ b/pkg/kn/commands/source/list.go
@@ -73,7 +73,7 @@ func NewListCommand(p *commands.KnParams) *cobra.Command {
 			}
 
 			if sourceList == nil || len(sourceList.Items) == 0 {
-				fmt.Fprintf(cmd.OutOrStdout(), "No sources found in %s namespace.\n", namespace)
+				fmt.Fprintf(cmd.OutOrStdout(), "No sources found.\n")
 				return nil
 			}
 			// empty namespace indicates all namespaces flag is specified

--- a/test/e2e/source_list_test.go
+++ b/test/e2e/source_list_test.go
@@ -64,7 +64,7 @@ func TestSourceList(t *testing.T) {
 
 	t.Log("List sources empty case")
 	output := sourceList(r)
-	assert.Check(t, util.ContainsAll(output, "No", "sources", "found", "namespace"))
+	assert.Check(t, util.ContainsAll(output, "No", "sources", "found."))
 	assert.Check(t, util.ContainsNone(output, "NAME", "TYPE", "RESOURCE", "SINK", "READY"))
 
 	t.Log("Create API Server")
@@ -86,9 +86,9 @@ func TestSourceList(t *testing.T) {
 
 	t.Log("List sources filter invalid case")
 	output = sourceList(r, "--type", "testapisource0")
-	assert.Check(t, util.ContainsAll(output, "No", "sources", "found", "namespace"))
+	assert.Check(t, util.ContainsAll(output, "No", "sources", "found."))
 	output = sourceList(r, "--type", "TestSource", "-oyaml")
-	assert.Check(t, util.ContainsAll(output, "No", "sources", "found", "namespace"))
+	assert.Check(t, util.ContainsAll(output, "No", "sources", "found."))
 
 	t.Log("List available source in YAML format")
 	output = sourceList(r, "--type", "PingSource,ApiServerSource", "-oyaml")


### PR DESCRIPTION
## Description
fix `kn source list --all-namespaces` command output spelling error.
<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->


## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #962 

<!--
Please add an entrty to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
