### PR TITLE
fix: Fix service export annotations

### DIFF
--- a/pkg/kn/commands/service/export.go
+++ b/pkg/kn/commands/service/export.go
@@ -42,6 +42,7 @@ var IGNORED_SERVICE_ANNOTATIONS = []string{
 var IGNORED_REVISION_ANNOTATIONS = []string{
 	"serving.knative.dev/lastPinned",
 	"serving.knative.dev/creator",
+	"serving.knative.dev/routingStateModified",
 }
 
 // NewServiceExportCommand returns a new command for exporting a service.

--- a/test/e2e/service_export_test.go
+++ b/test/e2e/service_export_test.go
@@ -60,7 +60,9 @@ func TestServiceExport(t *testing.T) {
 	serviceExport(r, "hello", getServiceWithOptions(
 		withServiceName("hello"),
 		withServiceRevisionName("hello-rev1"),
-		withConfigurationAnnotations(),
+		withConfigurationAnnotations(map[string]string{
+			"client.knative.dev/user-image": pkgtest.ImagePath("helloworld"),
+		}),
 		withServicePodSpecOption(withContainer()),
 	), "-o", "json")
 
@@ -107,7 +109,10 @@ func TestServiceExport(t *testing.T) {
 		withServices(
 			withServiceName("hello"),
 			withServiceRevisionName("hello-rev1"),
-			withConfigurationAnnotations(),
+			withConfigurationAnnotations(map[string]string{
+				"client.knative.dev/user-image": pkgtest.ImagePath("helloworld"),
+				"serving.knative.dev/routes": "hello",
+			}),
 			withServicePodSpecOption(
 				withContainer(),
 			),
@@ -138,12 +143,14 @@ func TestServiceExport(t *testing.T) {
 			withRevisionAnnotations(
 				map[string]string{
 					"client.knative.dev/user-image": pkgtest.ImagePath("helloworld"),
+					"serving.knative.dev/routes": "hello",
 				}),
 			withRevisionLabels(
 				map[string]string{
 					"serving.knative.dev/configuration":           "hello",
 					"serving.knative.dev/configurationGeneration": "1",
 					"serving.knative.dev/route":                   "hello",
+					"serving.knative.dev/routingState":            "active",
 					"serving.knative.dev/service":                 "hello",
 				}),
 			withRevisionPodSpecOption(
@@ -160,7 +167,10 @@ func TestServiceExport(t *testing.T) {
 	serviceExportWithServiceList(r, "hello", getServiceListWithOptions(
 		withServices(
 			withServiceName("hello"),
-			withConfigurationAnnotations(),
+			withConfigurationAnnotations(map[string]string{
+				"client.knative.dev/user-image": pkgtest.ImagePath("helloworld"),
+				"serving.knative.dev/routes": "hello",
+			}),
 			withServiceRevisionName("hello-rev1"),
 			withServicePodSpecOption(
 				withContainer(),
@@ -169,6 +179,9 @@ func TestServiceExport(t *testing.T) {
 		withServices(
 			withServiceName("hello"),
 			withServiceRevisionName("hello-rev2"),
+			withConfigurationAnnotations(map[string]string{
+				"serving.knative.dev/routes": "hello",
+			}),
 			withServicePodSpecOption(
 				withContainer(),
 				withEnv([]corev1.EnvVar{{Name: "a", Value: "mouse"}}),
@@ -200,12 +213,14 @@ func TestServiceExport(t *testing.T) {
 			withRevisionAnnotations(
 				map[string]string{
 					"client.knative.dev/user-image": pkgtest.ImagePath("helloworld"),
+					"serving.knative.dev/routes": "hello",
 				}),
 			withRevisionLabels(
 				map[string]string{
 					"serving.knative.dev/configuration":           "hello",
 					"serving.knative.dev/configurationGeneration": "1",
 					"serving.knative.dev/route":                   "hello",
+					"serving.knative.dev/routingState":            "active",
 					"serving.knative.dev/service":                 "hello",
 				}),
 			withRevisionPodSpecOption(
@@ -214,11 +229,16 @@ func TestServiceExport(t *testing.T) {
 		),
 		withRevisions(
 			withRevisionName("hello-rev2"),
+			withRevisionAnnotations(
+				map[string]string{
+					"serving.knative.dev/routes": "hello",
+				}),
 			withRevisionLabels(
 				map[string]string{
 					"serving.knative.dev/configuration":           "hello",
 					"serving.knative.dev/configurationGeneration": "2",
 					"serving.knative.dev/route":                   "hello",
+					"serving.knative.dev/routingState":            "active",
 					"serving.knative.dev/service":                 "hello",
 				}),
 			withRevisionPodSpecOption(
@@ -236,6 +256,9 @@ func TestServiceExport(t *testing.T) {
 		withServices(
 			withServiceName("hello"),
 			withServiceRevisionName("hello-rev2"),
+			withConfigurationAnnotations(map[string]string{
+				"serving.knative.dev/routes": "hello",
+			}),
 			withServicePodSpecOption(
 				withContainer(),
 				withEnv([]corev1.EnvVar{{Name: "a", Value: "mouse"}}),
@@ -264,11 +287,15 @@ func TestServiceExport(t *testing.T) {
 	), getKNExportWithOptions(
 		withRevisions(
 			withRevisionName("hello-rev2"),
+			withRevisionAnnotations(map[string]string{
+				"serving.knative.dev/routes": "hello",
+			}),
 			withRevisionLabels(
 				map[string]string{
 					"serving.knative.dev/configuration":           "hello",
 					"serving.knative.dev/configurationGeneration": "2",
 					"serving.knative.dev/route":                   "hello",
+					"serving.knative.dev/routingState":            "active",
 					"serving.knative.dev/service":                 "hello",
 				}),
 			withRevisionPodSpecOption(
@@ -397,11 +424,9 @@ func withConfigurationLabels(labels map[string]string) expectedServiceOption {
 		svc.Spec.Template.ObjectMeta.Labels = labels
 	}
 }
-func withConfigurationAnnotations() expectedServiceOption {
+func withConfigurationAnnotations(annotations map[string]string) expectedServiceOption {
 	return func(svc *servingv1.Service) {
-		svc.Spec.Template.ObjectMeta.Annotations = map[string]string{
-			"client.knative.dev/user-image": pkgtest.ImagePath("helloworld"),
-		}
+		svc.Spec.Template.ObjectMeta.Annotations = annotations
 	}
 }
 func withServiceRevisionName(name string) expectedServiceOption {

--- a/test/e2e/service_export_test.go
+++ b/test/e2e/service_export_test.go
@@ -43,6 +43,8 @@ type expectedKNExportOption func(*clientv1alpha1.Export)
 type podSpecOption func(*corev1.PodSpec)
 
 func TestServiceExport(t *testing.T) {
+	//FIXME: enable once 0.18 is available
+	t.Skip("The test is skipped until Serving release 0.18")
 	t.Parallel()
 	it, err := test.NewKnTest()
 	assert.NilError(t, err)

--- a/test/e2e/service_export_test.go
+++ b/test/e2e/service_export_test.go
@@ -19,6 +19,8 @@ package e2e
 
 import (
 	"encoding/json"
+	"os"
+	"strings"
 	"testing"
 
 	"gotest.tools/assert"
@@ -44,7 +46,9 @@ type podSpecOption func(*corev1.PodSpec)
 
 func TestServiceExport(t *testing.T) {
 	//FIXME: enable once 0.18 is available
-	t.Skip("The test is skipped until Serving release 0.18")
+	if strings.HasPrefix(os.Getenv("KNATIVE_SERVING_VERSION"), "0.17") {
+		t.Skip("The test is skipped on Serving version 0.17")
+	}
 	t.Parallel()
 	it, err := test.NewKnTest()
 	assert.NilError(t, err)

--- a/test/e2e/service_export_test.go
+++ b/test/e2e/service_export_test.go
@@ -111,7 +111,7 @@ func TestServiceExport(t *testing.T) {
 			withServiceRevisionName("hello-rev1"),
 			withConfigurationAnnotations(map[string]string{
 				"client.knative.dev/user-image": pkgtest.ImagePath("helloworld"),
-				"serving.knative.dev/routes": "hello",
+				"serving.knative.dev/routes":    "hello",
 			}),
 			withServicePodSpecOption(
 				withContainer(),
@@ -143,7 +143,7 @@ func TestServiceExport(t *testing.T) {
 			withRevisionAnnotations(
 				map[string]string{
 					"client.knative.dev/user-image": pkgtest.ImagePath("helloworld"),
-					"serving.knative.dev/routes": "hello",
+					"serving.knative.dev/routes":    "hello",
 				}),
 			withRevisionLabels(
 				map[string]string{
@@ -169,7 +169,7 @@ func TestServiceExport(t *testing.T) {
 			withServiceName("hello"),
 			withConfigurationAnnotations(map[string]string{
 				"client.knative.dev/user-image": pkgtest.ImagePath("helloworld"),
-				"serving.knative.dev/routes": "hello",
+				"serving.knative.dev/routes":    "hello",
 			}),
 			withServiceRevisionName("hello-rev1"),
 			withServicePodSpecOption(
@@ -213,7 +213,7 @@ func TestServiceExport(t *testing.T) {
 			withRevisionAnnotations(
 				map[string]string{
 					"client.knative.dev/user-image": pkgtest.ImagePath("helloworld"),
-					"serving.knative.dev/routes": "hello",
+					"serving.knative.dev/routes":    "hello",
 				}),
 			withRevisionLabels(
 				map[string]string{


### PR DESCRIPTION
## Description

There are 2 new annotations and 1 label added to Service metadata that currently break our E2E export tests.

Annotations:
- serving.knative.dev/routes
- serving.knative.dev/routingStateModified.

Labels:
-  serving.knative.dev/routingState

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Add `serving.knative.dev/routingStateModified` annotation to ignored export list
* Correct E2E expected values.

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #1002 

<!--
Please add an entrty to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
