### PR TITLE
Fix a couple typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@
 
 The Knative client `kn` is your door to the [Knative](https://knative.dev)
 world. It allows you to create Knative resources interactively from the command
-line or from within Shell scripts.
+line or from within scripts.
 
 `kn` offers you:
 
 - Full support for managing all features of
   [Knative Serving](https://github.com/knative/serving) (services, revisions,
   traffic splits)
-- Growing support [Knative eventing](https://github.com/knative/eventing),
+- Growing support for [Knative eventing](https://github.com/knative/eventing),
   closely following its development (managing of sources & triggers)
 - A plugin architecture similar to that of `kubectl` plugins
-- A thin client-specific API in golang which helps in tasks like synchronously
+- A thin client-specific API in golang which helps with tasks like synchronously
   waiting on Knative service write operations.
 - An easy integration of Knative into Tekton Pipelines by using
   [`kn` in a Tekton `Task`](https://github.com/tektoncd/catalog/tree/master/task/kn).
@@ -28,8 +28,8 @@ This client uses the
 [Knative Serving](https://github.com/knative/docs/blob/master/docs/serving/spec/knative-api-specification-1.0.md)
 and
 [Knative Eventing](https://github.com/knative/eventing/tree/master/docs/spec)
-API exclusively so that it will work with any Knative installation, even those
-that are not Kubernetes based. It does not help in _installing_ Knative itself
+APIs exclusively so that it will work with any Knative installation, even those
+that are not Kubernetes based. It does not help with _installing_ Knative itself
 though. Please refer to the various
 [Knative installation options](https://knative.dev/docs/install/) for how to
 install Knative with its prerequisites.


### PR DESCRIPTION
Fixes a couple very minor typos I noticed while going over the README