### PR TITLE
Added back functionality to deprecated max-scale/min-scale

### DIFF
--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -336,6 +336,22 @@ func (p *ConfigurationEditFlags) Apply(
 		}
 	}
 
+	// Deprecated option
+	if cmd.Flags().Changed("min-scale") {
+		err = servinglib.UpdateMinScale(template, p.MinScale)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Deprecated option
+	if cmd.Flags().Changed("max-scale") {
+		err = servinglib.UpdateMaxScale(template, p.MaxScale)
+		if err != nil {
+			return err
+		}
+	}
+
 	if cmd.Flags().Changed("scale-min") {
 		err = servinglib.UpdateMinScale(template, p.MinScale)
 		if err != nil {

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -336,30 +336,16 @@ func (p *ConfigurationEditFlags) Apply(
 		}
 	}
 
-	// Deprecated option
-	if cmd.Flags().Changed("min-scale") {
+	// Deprecated "min-scale" in 0.19, updated to "scale-min"
+	if cmd.Flags().Changed("scale-min") || cmd.Flags().Changed("min-scale") {
 		err = servinglib.UpdateMinScale(template, p.MinScale)
 		if err != nil {
 			return err
 		}
 	}
 
-	// Deprecated option
-	if cmd.Flags().Changed("max-scale") {
-		err = servinglib.UpdateMaxScale(template, p.MaxScale)
-		if err != nil {
-			return err
-		}
-	}
-
-	if cmd.Flags().Changed("scale-min") {
-		err = servinglib.UpdateMinScale(template, p.MinScale)
-		if err != nil {
-			return err
-		}
-	}
-
-	if cmd.Flags().Changed("scale-max") {
+	// Deprecated "max-scale" in 0.19, updated to "scale-max"
+	if cmd.Flags().Changed("scale-max") || cmd.Flags().Changed("max-scale") {
 		err = servinglib.UpdateMaxScale(template, p.MaxScale)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Description

Adds back functionality for max-scale/min-scale options. I ended up swapping over naming but never added additional sections to update. 

## Changes

* Adds back functionality for max-scale/min-scale


## Reference

Fixes #1008 