### PR TITLE
Remove -mod=readonly from the helloworld's Dockerfile

### DIFF
--- a/test/test_images/helloworld/Dockerfile
+++ b/test/test_images/helloworld/Dockerfile
@@ -10,8 +10,7 @@ WORKDIR /app
 COPY ./test/test_images/helloworld/ .
 
 # Build the binary.
-# -mod=readonly ensures immutable go.mod and go.sum in container builds.
-RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o server
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o server
 
 # Use the official Alpine image for a lean production container.
 # https://hub.docker.com/_/alpine


### PR DESCRIPTION
The go.mod file was removed in
https://github.com/knative/client/commit/4ea31c444a546dc8c455da9040ffac8b91b25aae
, and breaks building using Tekton.

The error is as follows:
STEP 3: COPY ./test/test_images/helloworld/ .
STEP 4: RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o server
build flag -mod=readonly only valid when using modules
subprocess exited with status 1
subprocess exited with status 1
error building at STEP "RUN CGO_ENABLED=0 GOOS=linux go build
-mod=readonly -v -o server": exit status 1


## Description

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

*
*
*

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #

<!--
Please add an entrty to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
