### PR TITLE
e2e nit use pointer instead of refernece - review comment

### DIFF
--- a/lib/test/service.go
+++ b/lib/test/service.go
@@ -125,12 +125,12 @@ func ValidateServiceResources(r *KnRunResultCollector, serviceName string, reque
 
 //GetServiceFromKNServiceDescribe runs the kn service describe command
 //decodes it into a ksvc and returns it.
-func GetServiceFromKNServiceDescribe(r *KnRunResultCollector, serviceName string) servingv1.Service {
+func GetServiceFromKNServiceDescribe(r *KnRunResultCollector, serviceName string) *servingv1.Service {
 	out := r.KnTest().Kn().Run("service", "describe", serviceName, "-ojson")
 	data := json.NewDecoder(strings.NewReader(out.Stdout))
 	data.UseNumber()
 	var service servingv1.Service
 	err := data.Decode(&service)
 	assert.NilError(r.T(), err)
-	return service
+	return &service
 }


### PR DESCRIPTION
## Description

minor nit for e2e based on review comments on #1000 

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Return pointer instead of object

<!--
/lint
-->
