### PR TITLE
fix(e2e): Run eventing e2e tests only against nightly and fix service export tests

### DIFF
--- a/test/e2e/service_export_test.go
+++ b/test/e2e/service_export_test.go
@@ -45,9 +45,10 @@ type expectedKNExportOption func(*clientv1alpha1.Export)
 type podSpecOption func(*corev1.PodSpec)
 
 func TestServiceExport(t *testing.T) {
-	//FIXME: enable once 0.18 is available
-	if strings.HasPrefix(os.Getenv("KNATIVE_SERVING_VERSION"), "0.17") {
-		t.Skip("The test is skipped on Serving version 0.17")
+	//FIXME: enable once 0.19 is available
+	// see: https://github.com/knative/serving/pull/9685
+	if strings.HasPrefix(os.Getenv("KNATIVE_SERVING_VERSION"), "0.18") {
+		t.Skip("The test is skipped on Serving version 0.18")
 	}
 	t.Parallel()
 	it, err := test.NewKnTest()
@@ -502,6 +503,8 @@ func getPodSpecWithOptions(options ...podSpecOption) corev1.PodSpec {
 	for _, fn := range options {
 		fn(&spec)
 	}
+	// Service links are disabled by default now see https://github.com/knative/serving/pull/9685
+	spec.EnableServiceLinks = ptr.Bool(false)
 	return spec
 }
 

--- a/test/presubmit-integration-tests-latest-release.sh
+++ b/test/presubmit-integration-tests-latest-release.sh
@@ -18,6 +18,6 @@
 # integration tests against Knative Serving / Eventing of a specific version.
 
 export KNATIVE_SERVING_VERSION="0.18.0"
-export KNATIVE_EVENTING_VERSION="0.18.0"
+#export KNATIVE_EVENTING_VERSION="0.18.0"
 
 $(dirname $0)/presubmit-tests.sh --integration-tests


### PR DESCRIPTION
see https://github.com/knative/eventing/issues/4165
see https://github.com/knative/serving/pull/9685
