### PR TITLE
Add WithLabel list filter to serving client lib

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,6 +19,10 @@
 | 🎁
 | Add Aliases to Help Command and Remove Aliases in Short
 | https://github.com/knative/client/pull/1055[#1055]
+
+| 🎁
+| Add WithLabel list filter to serving client lib
+| https://github.com/knative/client/pull/1054[#1054]
 |===
 
 ## v0.18.0 (2020-10-07)

--- a/pkg/serving/v1/client.go
+++ b/pkg/serving/v1/client.go
@@ -141,6 +141,13 @@ func WithService(service string) ListConfig {
 	}
 }
 
+// WithLabel filters on the provided label
+func WithLabel(labelKey, labelValue string) ListConfig {
+	return func(lo *listConfigCollector) {
+		lo.Labels[labelKey] = labelValue
+	}
+}
+
 type knServingClient struct {
 	client    clientv1.ServingV1Interface
 	namespace string

--- a/pkg/serving/v1/client_mock_test.go
+++ b/pkg/serving/v1/client_mock_test.go
@@ -34,6 +34,7 @@ func TestMockKnClient(t *testing.T) {
 	// Record all services
 	recorder.GetService("hello", nil, nil)
 	recorder.ListServices(mock.Any(), nil, nil)
+	recorder.ListServices(mock.Any(), nil, nil)
 	recorder.CreateService(&servingv1.Service{}, nil)
 	recorder.UpdateService(&servingv1.Service{}, nil)
 	recorder.DeleteService("hello", time.Duration(10)*time.Second, nil)
@@ -48,6 +49,7 @@ func TestMockKnClient(t *testing.T) {
 	// Call all services
 	client.GetService("hello")
 	client.ListServices(WithName("blub"))
+	client.ListServices(WithLabel("foo", "bar"))
 	client.CreateService(&servingv1.Service{})
 	client.UpdateService(&servingv1.Service{})
 	client.DeleteService("hello", time.Duration(10)*time.Second)


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>


## Description

Adding `WithLabel` list filter to serving client lib, which is missing currently. This allows to filter lists by labels.


## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #1053 

<!--
Please add an entrty to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->


/lint

