### PR TITLE
Add Aliases to Help Command and Remove Aliases in Short

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,15 @@
 | https://github.com/knative/client/pull/[#]
 ////
 
+[cols="1,10,3", options="header", width="100%"]
+|===
+| | Description | PR
+
+| 🎁
+| Add Aliases to Help Command and Remove Aliases in Short
+| https://github.com/knative/client/pull/1055[#1055]
+|===
+
 ## v0.18.0 (2020-10-07)
 
 [cols="1,10,3", options="header", width="100%"]

--- a/docs/cmd/kn.md
+++ b/docs/cmd/kn.md
@@ -19,16 +19,16 @@ kn is the command line interface for managing Knative Serving and Eventing resou
 
 ### SEE ALSO
 
-* [kn broker](kn_broker.md)	 - Manage message broker (alias: brokers)
-* [kn channel](kn_channel.md)	 - Manage event channels (alias: channels)
+* [kn broker](kn_broker.md)	 - Manage message
+* [kn channel](kn_channel.md)	 - Manage event channels
 * [kn completion](kn_completion.md)	 - Output shell completion code
 * [kn options](kn_options.md)	 - Print the list of flags inherited by all commands
-* [kn plugin](kn_plugin.md)	 - Manage kn plugins (alias: plugins)
-* [kn revision](kn_revision.md)	 - Manage service revisions (alias: revisions)
-* [kn route](kn_route.md)	 - List and describe service routes (alias: routes)
-* [kn service](kn_service.md)	 - Manage Knative services (aliases: ksvc, services)
-* [kn source](kn_source.md)	 - Manage event sources (alias: sources)
-* [kn subscription](kn_subscription.md)	 - Manage event subscriptions (aliases: subscriptions, sub)
-* [kn trigger](kn_trigger.md)	 - Manage event triggers (alias: triggers)
+* [kn plugin](kn_plugin.md)	 - Manage kn plugins
+* [kn revision](kn_revision.md)	 - Manage service revisions
+* [kn route](kn_route.md)	 - List and describe service routes
+* [kn service](kn_service.md)	 - Manage Knative services
+* [kn source](kn_source.md)	 - Manage event sources
+* [kn subscription](kn_subscription.md)	 - Manage event subscriptions
+* [kn trigger](kn_trigger.md)	 - Manage event triggers
 * [kn version](kn_version.md)	 - Show the version of this client
 

--- a/docs/cmd/kn_broker.md
+++ b/docs/cmd/kn_broker.md
@@ -1,10 +1,10 @@
 ## kn broker
 
-Manage message broker (alias: brokers)
+Manage message
 
 ### Synopsis
 
-Manage message broker (alias: brokers)
+Manage message
 
 ```
 kn broker
@@ -30,5 +30,5 @@ kn broker
 * [kn broker create](kn_broker_create.md)	 - Create a broker
 * [kn broker delete](kn_broker_delete.md)	 - Delete a broker
 * [kn broker describe](kn_broker_describe.md)	 - Describe broker
-* [kn broker list](kn_broker_list.md)	 - List brokers (alias: 'ls')
+* [kn broker list](kn_broker_list.md)	 - List brokers
 

--- a/docs/cmd/kn_broker_create.md
+++ b/docs/cmd/kn_broker_create.md
@@ -38,5 +38,5 @@ kn broker create NAME
 
 ### SEE ALSO
 
-* [kn broker](kn_broker.md)	 - Manage message broker (alias: brokers)
+* [kn broker](kn_broker.md)	 - Manage message
 

--- a/docs/cmd/kn_broker_delete.md
+++ b/docs/cmd/kn_broker_delete.md
@@ -42,5 +42,5 @@ kn broker delete NAME
 
 ### SEE ALSO
 
-* [kn broker](kn_broker.md)	 - Manage message broker (alias: brokers)
+* [kn broker](kn_broker.md)	 - Manage message
 

--- a/docs/cmd/kn_broker_describe.md
+++ b/docs/cmd/kn_broker_describe.md
@@ -38,5 +38,5 @@ kn broker describe NAME
 
 ### SEE ALSO
 
-* [kn broker](kn_broker.md)	 - Manage message broker (alias: brokers)
+* [kn broker](kn_broker.md)	 - Manage message
 

--- a/docs/cmd/kn_broker_list.md
+++ b/docs/cmd/kn_broker_list.md
@@ -1,10 +1,10 @@
 ## kn broker list
 
-List brokers (alias: 'ls')
+List brokers
 
 ### Synopsis
 
-List brokers (alias: 'ls')
+List brokers
 
 ```
 kn broker list
@@ -43,5 +43,5 @@ kn broker list
 
 ### SEE ALSO
 
-* [kn broker](kn_broker.md)	 - Manage message broker (alias: brokers)
+* [kn broker](kn_broker.md)	 - Manage message
 

--- a/docs/cmd/kn_channel.md
+++ b/docs/cmd/kn_channel.md
@@ -1,10 +1,10 @@
 ## kn channel
 
-Manage event channels (alias: channels)
+Manage event channels
 
 ### Synopsis
 
-Manage event channels (alias: channels)
+Manage event channels
 
 ```
 kn channel COMMAND
@@ -30,6 +30,6 @@ kn channel COMMAND
 * [kn channel create](kn_channel_create.md)	 - Create an event channel
 * [kn channel delete](kn_channel_delete.md)	 - Delete a channel
 * [kn channel describe](kn_channel_describe.md)	 - Show details of a channel
-* [kn channel list](kn_channel_list.md)	 - List channels (alias: 'ls')
+* [kn channel list](kn_channel_list.md)	 - List channels
 * [kn channel list-types](kn_channel_list-types.md)	 - List channel types
 

--- a/docs/cmd/kn_channel_create.md
+++ b/docs/cmd/kn_channel_create.md
@@ -44,5 +44,5 @@ kn channel create NAME
 
 ### SEE ALSO
 
-* [kn channel](kn_channel.md)	 - Manage event channels (alias: channels)
+* [kn channel](kn_channel.md)	 - Manage event channels
 

--- a/docs/cmd/kn_channel_delete.md
+++ b/docs/cmd/kn_channel_delete.md
@@ -35,5 +35,5 @@ kn channel delete NAME
 
 ### SEE ALSO
 
-* [kn channel](kn_channel.md)	 - Manage event channels (alias: channels)
+* [kn channel](kn_channel.md)	 - Manage event channels
 

--- a/docs/cmd/kn_channel_describe.md
+++ b/docs/cmd/kn_channel_describe.md
@@ -39,5 +39,5 @@ kn channel describe NAME
 
 ### SEE ALSO
 
-* [kn channel](kn_channel.md)	 - Manage event channels (alias: channels)
+* [kn channel](kn_channel.md)	 - Manage event channels
 

--- a/docs/cmd/kn_channel_list-types.md
+++ b/docs/cmd/kn_channel_list-types.md
@@ -42,5 +42,5 @@ kn channel list-types
 
 ### SEE ALSO
 
-* [kn channel](kn_channel.md)	 - Manage event channels (alias: channels)
+* [kn channel](kn_channel.md)	 - Manage event channels
 

--- a/docs/cmd/kn_channel_list.md
+++ b/docs/cmd/kn_channel_list.md
@@ -1,10 +1,10 @@
 ## kn channel list
 
-List channels (alias: 'ls')
+List channels
 
 ### Synopsis
 
-List channels (alias: 'ls')
+List channels
 
 ```
 kn channel list
@@ -43,5 +43,5 @@ kn channel list
 
 ### SEE ALSO
 
-* [kn channel](kn_channel.md)	 - Manage event channels (alias: channels)
+* [kn channel](kn_channel.md)	 - Manage event channels
 

--- a/docs/cmd/kn_plugin.md
+++ b/docs/cmd/kn_plugin.md
@@ -1,6 +1,6 @@
 ## kn plugin
 
-Manage kn plugins (alias: plugins)
+Manage kn plugins
 
 ### Synopsis
 
@@ -30,5 +30,5 @@ kn plugin
 ### SEE ALSO
 
 * [kn](kn.md)	 - kn manages Knative Serving and Eventing resources
-* [kn plugin list](kn_plugin_list.md)	 - List plugins (alias: 'ls')
+* [kn plugin list](kn_plugin_list.md)	 - List plugins
 

--- a/docs/cmd/kn_plugin_list.md
+++ b/docs/cmd/kn_plugin_list.md
@@ -1,6 +1,6 @@
 ## kn plugin list
 
-List plugins (alias: 'ls')
+List plugins
 
 ### Synopsis
 
@@ -33,5 +33,5 @@ kn plugin list
 
 ### SEE ALSO
 
-* [kn plugin](kn_plugin.md)	 - Manage kn plugins (alias: plugins)
+* [kn plugin](kn_plugin.md)	 - Manage kn plugins
 

--- a/docs/cmd/kn_revision.md
+++ b/docs/cmd/kn_revision.md
@@ -1,10 +1,10 @@
 ## kn revision
 
-Manage service revisions (alias: revisions)
+Manage service revisions
 
 ### Synopsis
 
-Manage service revisions (alias: revisions)
+Manage service revisions
 
 ```
 kn revision
@@ -29,5 +29,5 @@ kn revision
 * [kn](kn.md)	 - kn manages Knative Serving and Eventing resources
 * [kn revision delete](kn_revision_delete.md)	 - Delete revisions
 * [kn revision describe](kn_revision_describe.md)	 - Show details of a revision
-* [kn revision list](kn_revision_list.md)	 - List revisions (alias: 'ls')
+* [kn revision list](kn_revision_list.md)	 - List revisions
 

--- a/docs/cmd/kn_revision_delete.md
+++ b/docs/cmd/kn_revision_delete.md
@@ -39,5 +39,5 @@ kn revision delete NAME [NAME ...]
 
 ### SEE ALSO
 
-* [kn revision](kn_revision.md)	 - Manage service revisions (alias: revisions)
+* [kn revision](kn_revision.md)	 - Manage service revisions
 

--- a/docs/cmd/kn_revision_describe.md
+++ b/docs/cmd/kn_revision_describe.md
@@ -31,5 +31,5 @@ kn revision describe NAME
 
 ### SEE ALSO
 
-* [kn revision](kn_revision.md)	 - Manage service revisions (alias: revisions)
+* [kn revision](kn_revision.md)	 - Manage service revisions
 

--- a/docs/cmd/kn_revision_list.md
+++ b/docs/cmd/kn_revision_list.md
@@ -1,6 +1,6 @@
 ## kn revision list
 
-List revisions (alias: 'ls')
+List revisions
 
 ### Synopsis
 
@@ -50,5 +50,5 @@ kn revision list
 
 ### SEE ALSO
 
-* [kn revision](kn_revision.md)	 - Manage service revisions (alias: revisions)
+* [kn revision](kn_revision.md)	 - Manage service revisions
 

--- a/docs/cmd/kn_route.md
+++ b/docs/cmd/kn_route.md
@@ -1,10 +1,10 @@
 ## kn route
 
-List and describe service routes (alias: routes)
+List and describe service routes
 
 ### Synopsis
 
-List and describe service routes (alias: routes)
+List and describe service routes
 
 ```
 kn route
@@ -28,5 +28,5 @@ kn route
 
 * [kn](kn.md)	 - kn manages Knative Serving and Eventing resources
 * [kn route describe](kn_route_describe.md)	 - Show details of a route
-* [kn route list](kn_route_list.md)	 - List routes (alias: 'ls')
+* [kn route list](kn_route_list.md)	 - List routes
 

--- a/docs/cmd/kn_route_describe.md
+++ b/docs/cmd/kn_route_describe.md
@@ -31,5 +31,5 @@ kn route describe NAME
 
 ### SEE ALSO
 
-* [kn route](kn_route.md)	 - List and describe service routes (alias: routes)
+* [kn route](kn_route.md)	 - List and describe service routes
 

--- a/docs/cmd/kn_route_list.md
+++ b/docs/cmd/kn_route_list.md
@@ -1,10 +1,10 @@
 ## kn route list
 
-List routes (alias: 'ls')
+List routes
 
 ### Synopsis
 
-List routes (alias: 'ls')
+List routes
 
 ```
 kn route list NAME
@@ -46,5 +46,5 @@ kn route list NAME
 
 ### SEE ALSO
 
-* [kn route](kn_route.md)	 - List and describe service routes (alias: routes)
+* [kn route](kn_route.md)	 - List and describe service routes
 

--- a/docs/cmd/kn_service.md
+++ b/docs/cmd/kn_service.md
@@ -1,10 +1,10 @@
 ## kn service
 
-Manage Knative services (aliases: ksvc, services)
+Manage Knative services
 
 ### Synopsis
 
-Manage Knative services (aliases: ksvc, services)
+Manage Knative services
 
 ```
 kn service
@@ -31,6 +31,6 @@ kn service
 * [kn service delete](kn_service_delete.md)	 - Delete services
 * [kn service describe](kn_service_describe.md)	 - Show details of a service
 * [kn service export](kn_service_export.md)	 - Export a service and its revisions
-* [kn service list](kn_service_list.md)	 - List services (alias: 'ls')
+* [kn service list](kn_service_list.md)	 - List services
 * [kn service update](kn_service_update.md)	 - Update a service
 

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -109,5 +109,5 @@ kn service create NAME --image IMAGE
 
 ### SEE ALSO
 
-* [kn service](kn_service.md)	 - Manage Knative services (aliases: ksvc, services)
+* [kn service](kn_service.md)	 - Manage Knative services
 

--- a/docs/cmd/kn_service_delete.md
+++ b/docs/cmd/kn_service_delete.md
@@ -46,5 +46,5 @@ kn service delete NAME [NAME ...]
 
 ### SEE ALSO
 
-* [kn service](kn_service.md)	 - Manage Knative services (aliases: ksvc, services)
+* [kn service](kn_service.md)	 - Manage Knative services
 

--- a/docs/cmd/kn_service_describe.md
+++ b/docs/cmd/kn_service_describe.md
@@ -45,5 +45,5 @@ kn service describe NAME
 
 ### SEE ALSO
 
-* [kn service](kn_service.md)	 - Manage Knative services (aliases: ksvc, services)
+* [kn service](kn_service.md)	 - Manage Knative services
 

--- a/docs/cmd/kn_service_export.md
+++ b/docs/cmd/kn_service_export.md
@@ -49,5 +49,5 @@ kn service export NAME
 
 ### SEE ALSO
 
-* [kn service](kn_service.md)	 - Manage Knative services (aliases: ksvc, services)
+* [kn service](kn_service.md)	 - Manage Knative services
 

--- a/docs/cmd/kn_service_list.md
+++ b/docs/cmd/kn_service_list.md
@@ -1,10 +1,10 @@
 ## kn service list
 
-List services (alias: 'ls')
+List services
 
 ### Synopsis
 
-List services (alias: 'ls')
+List services
 
 ```
 kn service list
@@ -46,5 +46,5 @@ kn service list
 
 ### SEE ALSO
 
-* [kn service](kn_service.md)	 - Manage Knative services (aliases: ksvc, services)
+* [kn service](kn_service.md)	 - Manage Knative services
 

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -95,5 +95,5 @@ kn service update NAME
 
 ### SEE ALSO
 
-* [kn service](kn_service.md)	 - Manage Knative services (aliases: ksvc, services)
+* [kn service](kn_service.md)	 - Manage Knative services
 

--- a/docs/cmd/kn_source.md
+++ b/docs/cmd/kn_source.md
@@ -1,10 +1,10 @@
 ## kn source
 
-Manage event sources (alias: sources)
+Manage event sources
 
 ### Synopsis
 
-Manage event sources (alias: sources)
+Manage event sources
 
 ```
 kn source SOURCE|COMMAND
@@ -29,7 +29,7 @@ kn source SOURCE|COMMAND
 * [kn](kn.md)	 - kn manages Knative Serving and Eventing resources
 * [kn source apiserver](kn_source_apiserver.md)	 - Manage Kubernetes api-server sources
 * [kn source binding](kn_source_binding.md)	 - Manage sink bindings
-* [kn source list](kn_source_list.md)	 - List event sources (alias: 'ls')
+* [kn source list](kn_source_list.md)	 - List event sources
 * [kn source list-types](kn_source_list-types.md)	 - List event source types
 * [kn source ping](kn_source_ping.md)	 - Manage ping sources
 

--- a/docs/cmd/kn_source_apiserver.md
+++ b/docs/cmd/kn_source_apiserver.md
@@ -26,7 +26,7 @@ kn source apiserver COMMAND
 
 ### SEE ALSO
 
-* [kn source](kn_source.md)	 - Manage event sources (alias: sources)
+* [kn source](kn_source.md)	 - Manage event sources
 * [kn source apiserver create](kn_source_apiserver_create.md)	 - Create an api-server source
 * [kn source apiserver delete](kn_source_apiserver_delete.md)	 - Delete an api-server source
 * [kn source apiserver describe](kn_source_apiserver_describe.md)	 - Show details of an api-server source

--- a/docs/cmd/kn_source_binding.md
+++ b/docs/cmd/kn_source_binding.md
@@ -26,7 +26,7 @@ kn source binding COMMAND
 
 ### SEE ALSO
 
-* [kn source](kn_source.md)	 - Manage event sources (alias: sources)
+* [kn source](kn_source.md)	 - Manage event sources
 * [kn source binding create](kn_source_binding_create.md)	 - Create a sink binding
 * [kn source binding delete](kn_source_binding_delete.md)	 - Delete a sink binding
 * [kn source binding describe](kn_source_binding_describe.md)	 - Show details of a sink binding

--- a/docs/cmd/kn_source_list-types.md
+++ b/docs/cmd/kn_source_list-types.md
@@ -42,5 +42,5 @@ kn source list-types
 
 ### SEE ALSO
 
-* [kn source](kn_source.md)	 - Manage event sources (alias: sources)
+* [kn source](kn_source.md)	 - Manage event sources
 

--- a/docs/cmd/kn_source_list.md
+++ b/docs/cmd/kn_source_list.md
@@ -1,10 +1,10 @@
 ## kn source list
 
-List event sources (alias: 'ls')
+List event sources
 
 ### Synopsis
 
-List event sources (alias: 'ls')
+List event sources
 
 ```
 kn source list
@@ -47,5 +47,5 @@ kn source list
 
 ### SEE ALSO
 
-* [kn source](kn_source.md)	 - Manage event sources (alias: sources)
+* [kn source](kn_source.md)	 - Manage event sources
 

--- a/docs/cmd/kn_source_ping.md
+++ b/docs/cmd/kn_source_ping.md
@@ -26,7 +26,7 @@ kn source ping COMMAND
 
 ### SEE ALSO
 
-* [kn source](kn_source.md)	 - Manage event sources (alias: sources)
+* [kn source](kn_source.md)	 - Manage event sources
 * [kn source ping create](kn_source_ping_create.md)	 - Create a ping source
 * [kn source ping delete](kn_source_ping_delete.md)	 - Delete a ping source
 * [kn source ping describe](kn_source_ping_describe.md)	 - Show details of a ping source

--- a/docs/cmd/kn_subscription.md
+++ b/docs/cmd/kn_subscription.md
@@ -1,10 +1,10 @@
 ## kn subscription
 
-Manage event subscriptions (aliases: subscriptions, sub)
+Manage event subscriptions
 
 ### Synopsis
 
-Manage event subscriptions (aliases: subscriptions, sub)
+Manage event subscriptions
 
 ```
 kn subscription COMMAND
@@ -30,6 +30,6 @@ kn subscription COMMAND
 * [kn subscription create](kn_subscription_create.md)	 - Create a subscription
 * [kn subscription delete](kn_subscription_delete.md)	 - Delete a subscription
 * [kn subscription describe](kn_subscription_describe.md)	 - Show details of a subscription
-* [kn subscription list](kn_subscription_list.md)	 - List subscriptions (alias: 'ls')
+* [kn subscription list](kn_subscription_list.md)	 - List subscriptions
 * [kn subscription update](kn_subscription_update.md)	 - Update an event subscription
 

--- a/docs/cmd/kn_subscription_create.md
+++ b/docs/cmd/kn_subscription_create.md
@@ -42,5 +42,5 @@ kn subscription create NAME
 
 ### SEE ALSO
 
-* [kn subscription](kn_subscription.md)	 - Manage event subscriptions (aliases: subscriptions, sub)
+* [kn subscription](kn_subscription.md)	 - Manage event subscriptions
 

--- a/docs/cmd/kn_subscription_delete.md
+++ b/docs/cmd/kn_subscription_delete.md
@@ -35,5 +35,5 @@ kn subscription delete NAME
 
 ### SEE ALSO
 
-* [kn subscription](kn_subscription.md)	 - Manage event subscriptions (aliases: subscriptions, sub)
+* [kn subscription](kn_subscription.md)	 - Manage event subscriptions
 

--- a/docs/cmd/kn_subscription_describe.md
+++ b/docs/cmd/kn_subscription_describe.md
@@ -39,5 +39,5 @@ kn subscription describe NAME
 
 ### SEE ALSO
 
-* [kn subscription](kn_subscription.md)	 - Manage event subscriptions (aliases: subscriptions, sub)
+* [kn subscription](kn_subscription.md)	 - Manage event subscriptions
 

--- a/docs/cmd/kn_subscription_list.md
+++ b/docs/cmd/kn_subscription_list.md
@@ -1,10 +1,10 @@
 ## kn subscription list
 
-List subscriptions (alias: 'ls')
+List subscriptions
 
 ### Synopsis
 
-List subscriptions (alias: 'ls')
+List subscriptions
 
 ```
 kn subscription list
@@ -43,5 +43,5 @@ kn subscription list
 
 ### SEE ALSO
 
-* [kn subscription](kn_subscription.md)	 - Manage event subscriptions (aliases: subscriptions, sub)
+* [kn subscription](kn_subscription.md)	 - Manage event subscriptions
 

--- a/docs/cmd/kn_subscription_update.md
+++ b/docs/cmd/kn_subscription_update.md
@@ -41,5 +41,5 @@ kn subscription update NAME
 
 ### SEE ALSO
 
-* [kn subscription](kn_subscription.md)	 - Manage event subscriptions (aliases: subscriptions, sub)
+* [kn subscription](kn_subscription.md)	 - Manage event subscriptions
 

--- a/docs/cmd/kn_trigger.md
+++ b/docs/cmd/kn_trigger.md
@@ -1,10 +1,10 @@
 ## kn trigger
 
-Manage event triggers (alias: triggers)
+Manage event triggers
 
 ### Synopsis
 
-Manage event triggers (alias: triggers)
+Manage event triggers
 
 ```
 kn trigger
@@ -30,6 +30,6 @@ kn trigger
 * [kn trigger create](kn_trigger_create.md)	 - Create a trigger
 * [kn trigger delete](kn_trigger_delete.md)	 - Delete a trigger
 * [kn trigger describe](kn_trigger_describe.md)	 - Show details of a trigger
-* [kn trigger list](kn_trigger_list.md)	 - List triggers (alias: 'ls')
+* [kn trigger list](kn_trigger_list.md)	 - List triggers
 * [kn trigger update](kn_trigger_update.md)	 - Update a trigger
 

--- a/docs/cmd/kn_trigger_create.md
+++ b/docs/cmd/kn_trigger_create.md
@@ -42,5 +42,5 @@ kn trigger create NAME --sink SINK
 
 ### SEE ALSO
 
-* [kn trigger](kn_trigger.md)	 - Manage event triggers (alias: triggers)
+* [kn trigger](kn_trigger.md)	 - Manage event triggers
 

--- a/docs/cmd/kn_trigger_delete.md
+++ b/docs/cmd/kn_trigger_delete.md
@@ -35,5 +35,5 @@ kn trigger delete NAME
 
 ### SEE ALSO
 
-* [kn trigger](kn_trigger.md)	 - Manage event triggers (alias: triggers)
+* [kn trigger](kn_trigger.md)	 - Manage event triggers
 

--- a/docs/cmd/kn_trigger_describe.md
+++ b/docs/cmd/kn_trigger_describe.md
@@ -36,5 +36,5 @@ kn trigger describe NAME
 
 ### SEE ALSO
 
-* [kn trigger](kn_trigger.md)	 - Manage event triggers (alias: triggers)
+* [kn trigger](kn_trigger.md)	 - Manage event triggers
 

--- a/docs/cmd/kn_trigger_list.md
+++ b/docs/cmd/kn_trigger_list.md
@@ -1,10 +1,10 @@
 ## kn trigger list
 
-List triggers (alias: 'ls')
+List triggers
 
 ### Synopsis
 
-List triggers (alias: 'ls')
+List triggers
 
 ```
 kn trigger list
@@ -43,5 +43,5 @@ kn trigger list
 
 ### SEE ALSO
 
-* [kn trigger](kn_trigger.md)	 - Manage event triggers (alias: triggers)
+* [kn trigger](kn_trigger.md)	 - Manage event triggers
 

--- a/docs/cmd/kn_trigger_update.md
+++ b/docs/cmd/kn_trigger_update.md
@@ -46,5 +46,5 @@ kn trigger update NAME
 
 ### SEE ALSO
 
-* [kn trigger](kn_trigger.md)	 - Manage event triggers (alias: triggers)
+* [kn trigger](kn_trigger.md)	 - Manage event triggers
 

--- a/pkg/kn/commands/broker/broker.go
+++ b/pkg/kn/commands/broker/broker.go
@@ -26,7 +26,7 @@ import (
 func NewBrokerCommand(p *commands.KnParams) *cobra.Command {
 	brokerCmd := &cobra.Command{
 		Use:     "broker",
-		Short:   "Manage message broker (alias: brokers)",
+		Short:   "Manage message",
 		Aliases: []string{"brokers"},
 	}
 	brokerCmd.AddCommand(NewBrokerCreateCommand(p))

--- a/pkg/kn/commands/broker/list.go
+++ b/pkg/kn/commands/broker/list.go
@@ -43,7 +43,7 @@ func NewBrokerListCommand(p *commands.KnParams) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "list",
-		Short:   "List brokers (alias: 'ls')",
+		Short:   "List brokers",
 		Aliases: []string{"ls"},
 		Example: listExample,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/pkg/kn/commands/channel/channel.go
+++ b/pkg/kn/commands/channel/channel.go
@@ -27,7 +27,7 @@ import (
 func NewChannelCommand(p *commands.KnParams) *cobra.Command {
 	channelCmd := &cobra.Command{
 		Use:     "channel COMMAND",
-		Short:   "Manage event channels (alias: channels)",
+		Short:   "Manage event channels",
 		Aliases: []string{"channels"},
 	}
 	channelCmd.AddCommand(NewChannelCreateCommand(p))

--- a/pkg/kn/commands/channel/list.go
+++ b/pkg/kn/commands/channel/list.go
@@ -29,7 +29,7 @@ func NewChannelListCommand(p *commands.KnParams) *cobra.Command {
 
 	listCommand := &cobra.Command{
 		Use:     "list",
-		Short:   "List channels (alias: 'ls')",
+		Short:   "List channels",
 		Aliases: []string{"ls"},
 		Example: `
   # List all channels

--- a/pkg/kn/commands/plugin/list.go
+++ b/pkg/kn/commands/plugin/list.go
@@ -41,7 +41,7 @@ func NewPluginListCommand(p *commands.KnParams) *cobra.Command {
 	plFlags := pluginListFlags{}
 	pluginListCommand := &cobra.Command{
 		Use:     "list",
-		Short:   "List plugins (alias: 'ls')",
+		Short:   "List plugins",
 		Aliases: []string{"ls"},
 		Long: `List all installed plugins.
 

--- a/pkg/kn/commands/plugin/list_test.go
+++ b/pkg/kn/commands/plugin/list_test.go
@@ -39,7 +39,7 @@ func TestPluginListBasic(t *testing.T) {
 	}
 
 	assert.Assert(t, pluginListCmd.Use == "list")
-	assert.Assert(t, pluginListCmd.Short == "List plugins (alias: 'ls')")
+	assert.Assert(t, pluginListCmd.Short == "List plugins")
 	assert.Assert(t, strings.Contains(pluginListCmd.Long, "List all installed plugins"))
 	assert.Assert(t, pluginListCmd.RunE != nil)
 }

--- a/pkg/kn/commands/plugin/plugin.go
+++ b/pkg/kn/commands/plugin/plugin.go
@@ -23,7 +23,7 @@ import (
 func NewPluginCommand(p *commands.KnParams) *cobra.Command {
 	pluginCmd := &cobra.Command{
 		Use:     "plugin",
-		Short:   "Manage kn plugins (alias: plugins)",
+		Short:   "Manage kn plugins",
 		Aliases: []string{"plugins"},
 		Long: `Manage kn plugins
 

--- a/pkg/kn/commands/revision/list.go
+++ b/pkg/kn/commands/revision/list.go
@@ -39,7 +39,7 @@ func NewRevisionListCommand(p *commands.KnParams) *cobra.Command {
 
 	revisionListCommand := &cobra.Command{
 		Use:     "list",
-		Short:   "List revisions (alias: 'ls')",
+		Short:   "List revisions",
 		Aliases: []string{"ls"},
 		Long:    "List revisions for a given service.",
 		Example: `

--- a/pkg/kn/commands/revision/revision.go
+++ b/pkg/kn/commands/revision/revision.go
@@ -24,7 +24,7 @@ import (
 func NewRevisionCommand(p *commands.KnParams) *cobra.Command {
 	revisionCmd := &cobra.Command{
 		Use:     "revision",
-		Short:   "Manage service revisions (alias: revisions)",
+		Short:   "Manage service revisions",
 		Aliases: []string{"revisions"},
 	}
 	revisionCmd.AddCommand(NewRevisionListCommand(p))

--- a/pkg/kn/commands/route/list.go
+++ b/pkg/kn/commands/route/list.go
@@ -32,7 +32,7 @@ func NewRouteListCommand(p *commands.KnParams) *cobra.Command {
 	routeListFlags := flags.NewListPrintFlags(RouteListHandlers)
 	routeListCommand := &cobra.Command{
 		Use:     "list NAME",
-		Short:   "List routes (alias: 'ls')",
+		Short:   "List routes",
 		Aliases: []string{"ls"},
 		Example: `
   # List all routes

--- a/pkg/kn/commands/route/route.go
+++ b/pkg/kn/commands/route/route.go
@@ -23,7 +23,7 @@ import (
 func NewRouteCommand(p *commands.KnParams) *cobra.Command {
 	routeCmd := &cobra.Command{
 		Use:     "route",
-		Short:   "List and describe service routes (alias: routes)",
+		Short:   "List and describe service routes",
 		Aliases: []string{"routes"},
 	}
 	routeCmd.AddCommand(NewRouteListCommand(p))

--- a/pkg/kn/commands/service/list.go
+++ b/pkg/kn/commands/service/list.go
@@ -32,7 +32,7 @@ func NewServiceListCommand(p *commands.KnParams) *cobra.Command {
 
 	serviceListCommand := &cobra.Command{
 		Use:     "list",
-		Short:   "List services (alias: 'ls')",
+		Short:   "List services",
 		Aliases: []string{"ls"},
 		Example: `
   # List all services

--- a/pkg/kn/commands/service/service.go
+++ b/pkg/kn/commands/service/service.go
@@ -34,7 +34,7 @@ const (
 func NewServiceCommand(p *commands.KnParams) *cobra.Command {
 	serviceCmd := &cobra.Command{
 		Use:     "service",
-		Short:   "Manage Knative services (aliases: ksvc, services)",
+		Short:   "Manage Knative services",
 		Aliases: []string{"ksvc", "services"},
 	}
 	serviceCmd.AddCommand(NewServiceListCommand(p))

--- a/pkg/kn/commands/source/list.go
+++ b/pkg/kn/commands/source/list.go
@@ -43,7 +43,7 @@ func NewListCommand(p *commands.KnParams) *cobra.Command {
 	listFlags := flags.NewListPrintFlags(ListHandlers)
 	listCommand := &cobra.Command{
 		Use:     "list",
-		Short:   "List event sources (alias: 'ls')",
+		Short:   "List event sources",
 		Aliases: []string{"ls"},
 		Example: listExample,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/kn/commands/source/source.go
+++ b/pkg/kn/commands/source/source.go
@@ -26,7 +26,7 @@ import (
 func NewSourceCommand(p *commands.KnParams) *cobra.Command {
 	sourceCmd := &cobra.Command{
 		Use:     "source SOURCE|COMMAND",
-		Short:   "Manage event sources (alias: sources)",
+		Short:   "Manage event sources",
 		Aliases: []string{"sources"},
 	}
 	sourceCmd.AddCommand(NewListTypesCommand(p))

--- a/pkg/kn/commands/subscription/list.go
+++ b/pkg/kn/commands/subscription/list.go
@@ -31,7 +31,7 @@ func NewSubscriptionListCommand(p *commands.KnParams) *cobra.Command {
 
 	listCommand := &cobra.Command{
 		Use:   "list",
-		Short: "List subscriptions (alias: 'ls')",
+		Short: "List subscriptions",
 		Example: `
   # List all subscriptions
   kn subscription list

--- a/pkg/kn/commands/subscription/subscription.go
+++ b/pkg/kn/commands/subscription/subscription.go
@@ -30,7 +30,7 @@ import (
 func NewSubscriptionCommand(p *commands.KnParams) *cobra.Command {
 	subscriptionCmd := &cobra.Command{
 		Use:     "subscription COMMAND",
-		Short:   "Manage event subscriptions (aliases: subscriptions, sub)",
+		Short:   "Manage event subscriptions",
 		Aliases: []string{"subscriptions", "sub"},
 	}
 	subscriptionCmd.AddCommand(NewSubscriptionCreateCommand(p))

--- a/pkg/kn/commands/trigger/list.go
+++ b/pkg/kn/commands/trigger/list.go
@@ -29,7 +29,7 @@ func NewTriggerListCommand(p *commands.KnParams) *cobra.Command {
 
 	triggerListCommand := &cobra.Command{
 		Use:     "list",
-		Short:   "List triggers (alias: 'ls')",
+		Short:   "List triggers",
 		Aliases: []string{"ls"},
 		Example: `
   # List all triggers

--- a/pkg/kn/commands/trigger/trigger.go
+++ b/pkg/kn/commands/trigger/trigger.go
@@ -29,7 +29,7 @@ const (
 func NewTriggerCommand(p *commands.KnParams) *cobra.Command {
 	triggerCmd := &cobra.Command{
 		Use:     "trigger",
-		Short:   "Manage event triggers (alias: triggers)",
+		Short:   "Manage event triggers",
 		Aliases: []string{"triggers"},
 	}
 	triggerCmd.AddCommand(NewTriggerCreateCommand(p))

--- a/pkg/templates/template_engine_test.go
+++ b/pkg/templates/template_engine_test.go
@@ -133,6 +133,7 @@ func validateSubUsageOutput(t *testing.T, stdOut string, cmd *cobra.Command) {
 	assert.Assert(t, util.ContainsAll(stdOut, "Usage", cmd.CommandPath()+" [options]"))
 	assert.Assert(t, util.ContainsAll(stdOut, "Options", "--local-opt", "local option"))
 	assert.Assert(t, util.ContainsAll(stdOut, "Use", "root", "options", "global"))
+	assert.Assert(t, util.ContainsAll(stdOut, "Aliases", "alias"))
 }
 
 func newTestTemplateEngine() (*cobra.Command, templateEngine) {
@@ -162,10 +163,11 @@ func newTestTemplateEngine() (*cobra.Command, templateEngine) {
 
 func newCmd(name string) *cobra.Command {
 	ret := &cobra.Command{
-		Use:   name,
-		Short: "desc-" + name,
-		Long:  "longdesc-" + name,
-		Run:   func(cmd *cobra.Command, args []string) {},
+		Use:     name,
+		Short:   "desc-" + name,
+		Long:    "longdesc-" + name,
+		Run:     func(cmd *cobra.Command, args []string) {},
+		Aliases: []string{"alias"},
 	}
 	ret.Flags().String("local-opt", "", "local option")
 	return ret

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -24,6 +24,18 @@ import (
 // and adapted to the specific needs of `kn`
 
 const (
+	// sectionUsage is the help template section that displays the command's usage.
+	sectionUsage = `{{if and .Runnable (ne .UseLine "") (not (isRootCmd .))}}Usage:
+  {{useLine .}}
+
+{{end}}`
+
+	// sectionAliases is the help template section that displays the command's aliases.
+	sectionAliases = `{{ if ne (len .Aliases) 0}}Aliases: 
+  {{.NameAndAliases}}
+
+{{end}}`
+
 	// sectionExamples is the help template section that displays command examples.
 	sectionExamples = `{{if .HasExample}}Examples:
 {{trimRight .Example}}
@@ -53,12 +65,6 @@ const (
 
 {{end}}`
 
-	// sectionUsage is the help template section that displays the command's usage.
-	sectionUsage = `{{if and .Runnable (ne .UseLine "") (not (isRootCmd .))}}Usage:
-  {{useLine .}}
-
-{{end}}`
-
 	// sectionTipsHelp is the help template section that displays the '--help' hint.
 	sectionTipsHelp = `{{if .HasSubCommands}}Use "{{rootCmdName}} <command> --help" for more information about a given command.
 {{end}}`
@@ -71,13 +77,13 @@ const (
 func usageTemplate() string {
 	sections := []string{
 		"\n\n",
-		//		sectionAliases,
+		sectionUsage,
+		sectionAliases,
 		sectionExamples,
 		sectionCommandGroups,
 		sectionSubCommands,
 		sectionPlugins,
 		sectionFlags,
-		sectionUsage,
 		sectionTipsHelp,
 		sectionTipsGlobalOptions,
 	}


### PR DESCRIPTION
## Description

This pull request makes changes for when using help to see more information about a command:
* Adds aliases to the help command output
* Reorders the help command output so that usage and aliases are displayed before examples and options
* Removes aliases from the short description of commands

These changes will help to make maintaining documentation around aliases easier so that the short descriptions of commands don't need to be updated each time with the addition or removal of aliases. 

The reordering of the help section was [discussed in the corresponding issue](https://github.com/knative/client/issues/1045#issuecomment-705590161).

## Reference

Fixes #1045

/lint