### PR TITLE
fix(e2e): Remove "serving.knative.dev/route" revision label

### DIFF
--- a/test/e2e/service_export_test.go
+++ b/test/e2e/service_export_test.go
@@ -156,7 +156,6 @@ func TestServiceExport(t *testing.T) {
 				map[string]string{
 					"serving.knative.dev/configuration":           "hello",
 					"serving.knative.dev/configurationGeneration": "1",
-					"serving.knative.dev/route":                   "hello",
 					"serving.knative.dev/routingState":            "active",
 					"serving.knative.dev/service":                 "hello",
 				}),
@@ -226,7 +225,6 @@ func TestServiceExport(t *testing.T) {
 				map[string]string{
 					"serving.knative.dev/configuration":           "hello",
 					"serving.knative.dev/configurationGeneration": "1",
-					"serving.knative.dev/route":                   "hello",
 					"serving.knative.dev/routingState":            "active",
 					"serving.knative.dev/service":                 "hello",
 				}),
@@ -244,7 +242,6 @@ func TestServiceExport(t *testing.T) {
 				map[string]string{
 					"serving.knative.dev/configuration":           "hello",
 					"serving.knative.dev/configurationGeneration": "2",
-					"serving.knative.dev/route":                   "hello",
 					"serving.knative.dev/routingState":            "active",
 					"serving.knative.dev/service":                 "hello",
 				}),
@@ -301,7 +298,6 @@ func TestServiceExport(t *testing.T) {
 				map[string]string{
 					"serving.knative.dev/configuration":           "hello",
 					"serving.knative.dev/configurationGeneration": "2",
-					"serving.knative.dev/route":                   "hello",
 					"serving.knative.dev/routingState":            "active",
 					"serving.knative.dev/service":                 "hello",
 				}),


### PR DESCRIPTION
## Description
  Dont expect mentioned key on the revision labels in service
  export tests now. The test is skipped for serving v0.18 release
  and configured to only against current serving master.
  see #https://github.com/knative/serving/pull/9710

/cc @nak3 @maximilien @rhuss 