### PR TITLE
Fix golangci-lint errors

### DIFF
--- a/pkg/dynamic/client_test.go
+++ b/pkg/dynamic/client_test.go
@@ -343,21 +343,25 @@ func TestListChannelsUsingGVKs(t *testing.T) {
 			newChannelUnstructuredObj("i1", "messaging.knative.dev/v1beta1", "InMemoryChannel"),
 		)
 		assert.Check(t, client.RawClient() != nil)
-		gv := schema.GroupVersion{"messaging.knative.dev", "v1beta1"}
+		gv := schema.GroupVersion{Group: "messaging.knative.dev", Version: "v1beta1"}
 		gvks := []schema.GroupVersionKind{gv.WithKind("InMemoryChannel")}
 
 		s, err := client.ListChannelsUsingGVKs(&gvks)
 		assert.NilError(t, err)
-		assert.Check(t, s != nil)
+		if s == nil {
+			t.Fatal("s = nil, want not nil")
+		}
 		assert.Equal(t, len(s.Items), 1)
-		assert.DeepEqual(t, s.GroupVersionKind(), schema.GroupVersionKind{messaging.GroupName, channelListVersion, channelListKind})
+		assert.DeepEqual(t, s.GroupVersionKind(), schema.GroupVersionKind{Group: messaging.GroupName, Version: channelListVersion, Kind: channelListKind})
 
 		// withType
 		s, err = client.ListChannelsUsingGVKs(&gvks, WithTypeFilter("InMemoryChannel"))
 		assert.NilError(t, err)
-		assert.Check(t, s != nil)
+		if s == nil {
+			t.Fatal("s = nil, want not nil")
+		}
 		assert.Equal(t, len(s.Items), 1)
-		assert.DeepEqual(t, s.GroupVersionKind(), schema.GroupVersionKind{messaging.GroupName, channelListVersion, channelListKind})
+		assert.DeepEqual(t, s.GroupVersionKind(), schema.GroupVersionKind{Group: messaging.GroupName, Version: channelListVersion, Kind: channelListKind})
 	})
 
 }

--- a/pkg/kn/commands/channel/list_types_test.go
+++ b/pkg/kn/commands/channel/list_types_test.go
@@ -38,11 +38,9 @@ const (
 	crdGroup           = "apiextensions.k8s.io"
 	crdVersion         = "v1beta1"
 	crdKind            = "CustomResourceDefinition"
-	crdKinds           = "customresourcedefinitions"
 	testNamespace      = "current"
 	channelLabelValue  = "true"
 	channelListVersion = "v1beta1"
-	channelListKind    = "ChannelList"
 	inMemoryChannel    = "InMemoryChannel"
 )
 
@@ -107,7 +105,9 @@ func TestListBuiltInChannelTypes(t *testing.T) {
 	fakeDynamic := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
 	channel, err := listBuiltInChannelTypes(dynamic.NewKnDynamicClient(fakeDynamic, "current"))
 	assert.NilError(t, err)
-	assert.Check(t, channel != nil)
+	if channel == nil {
+		t.Fatal("channel = nil, want not nil")
+	}
 	assert.Equal(t, len(channel.Items), 1)
 }
 
@@ -153,7 +153,7 @@ func TestChannelListTypeErrors(t *testing.T) {
 	dynamicClient := dynamicfakeClient.CreateFakeKnDynamicClient(testNamespace, newChannelCRDObj("InMemoryChannel"))
 	assert.Equal(t, dynamicClient.Namespace(), testNamespace)
 
-	output, err := channelFakeCmd([]string{"channel", "list-types"}, dynamicClient)
+	_, err := channelFakeCmd([]string{"channel", "list-types"}, dynamicClient)
 	assert.Check(t, err != nil)
 	assert.Error(t, err, "can't find specs.names.kind for InMemoryChannel")
 
@@ -164,7 +164,7 @@ func TestChannelListTypeErrors(t *testing.T) {
 		"names":   map[string]interface{}{},
 	}
 	dynamicClient = dynamicfakeClient.CreateFakeKnDynamicClient(testNamespace, obj)
-	output, err = channelFakeCmd([]string{"channel", "list-types"}, dynamicClient)
+	_, err = channelFakeCmd([]string{"channel", "list-types"}, dynamicClient)
 	assert.Check(t, err != nil)
 	assert.Error(t, err, "can't find specs.names.kind for InMemoryChannel")
 
@@ -178,7 +178,7 @@ func TestChannelListTypeErrors(t *testing.T) {
 	}
 
 	dynamicClient = dynamicfakeClient.CreateFakeKnDynamicClient(testNamespace, obj)
-	output, err = channelFakeCmd([]string{"channel", "list-types"}, dynamicClient)
+	_, err = channelFakeCmd([]string{"channel", "list-types"}, dynamicClient)
 	assert.Check(t, err != nil)
 	assert.Error(t, err, ".spec.names.kind accessor error: true is of the type bool, expected string")
 
@@ -189,7 +189,7 @@ func TestChannelListTypeErrors(t *testing.T) {
 	assert.Check(t, err != nil)
 	assert.Error(t, err, "unknown flag: --noheader")
 
-	output, err = channelFakeCmd([]string{"channel", "list-types"}, dynamicClient)
+	output, err := channelFakeCmd([]string{"channel", "list-types"}, dynamicClient)
 	assert.NilError(t, err)
 	assert.Check(t, util.ContainsAll(output[0], "TYPE", "NAME", "DESCRIPTION"))
 	assert.Check(t, util.ContainsAll(output[1], "InMemoryChannel", "InMemoryChannel"))

--- a/pkg/kn/commands/subscription/flags.go
+++ b/pkg/kn/commands/subscription/flags.go
@@ -110,7 +110,7 @@ func printSubscriptionListWithNamespace(subscriptionList *messagingv1beta1.Subsc
 	rows := make([]metav1beta1.TableRow, 0, len(subscriptionList.Items))
 
 	// temporary slice for sorting services in non-default namespace
-	var others []metav1beta1.TableRow
+	others := make([]metav1beta1.TableRow, 0, len(rows))
 
 	for _, subscription := range subscriptionList.Items {
 		// Fill in with services in `default` namespace at first

--- a/pkg/kn/flags/channel_types.go
+++ b/pkg/kn/flags/channel_types.go
@@ -119,5 +119,4 @@ func (i *ChannelRef) Parse() (*corev1.ObjectReference, error) {
 	default:
 		return nil, fmt.Errorf("Error: incorrect value '%s' for '--channel', must be in the format 'Group:Version:Kind:Name' or configure an alias in kn config and refer as: '--channel ALIAS:NAME'", i.Cref)
 	}
-	return nil, nil
 }

--- a/pkg/messaging/v1beta1/subscriptions_client_mock.go
+++ b/pkg/messaging/v1beta1/subscriptions_client_mock.go
@@ -37,8 +37,9 @@ func NewMockKnSubscriptionsClient(t *testing.T, ns ...string) *MockKnSubscriptio
 		namespace = ns[0]
 	}
 	return &MockKnSubscriptionsClient{
-		t:        t,
-		recorder: &SubscriptionsRecorder{mock.NewRecorder(t, namespace)},
+		t:         t,
+		recorder:  &SubscriptionsRecorder{mock.NewRecorder(t, namespace)},
+		namespace: namespace,
 	}
 }
 


### PR DESCRIPTION
## Description

The output of golangci-lint includes below errors:
```
$ golangci-lint run --out-format=github-actions
::error file=pkg/kn/commands/channel/list_types_test.go,line=156,col=2::ineffectual assignment to `output` (ineffassign)
::error file=pkg/kn/commands/channel/list_types_test.go,line=167,col=2::ineffectual assignment to `output` (ineffassign)
::error file=pkg/kn/commands/channel/list_types_test.go,line=181,col=2::ineffectual assignment to `output` (ineffassign)
::error file=pkg/kn/commands/subscription/flags.go,line=113,col=2::Consider preallocating `others` (prealloc)
::error file=pkg/messaging/v1beta1/subscriptions_client_mock.go,line=30,col=2::`namespace` is unused (structcheck)
::error file=pkg/dynamic/client_test.go,line=346,col=9::composites: `k8s.io/apimachinery/pkg/runtime/schema.GroupVersion` composite literal uses unkeyed fields (govet)
::error file=pkg/dynamic/client_test.go,line=353,col=45::composites: `k8s.io/apimachinery/pkg/runtime/schema.GroupVersionKind` composite literal uses unkeyed fields (govet)
::error file=pkg/dynamic/client_test.go,line=360,col=45::composites: `k8s.io/apimachinery/pkg/runtime/schema.GroupVersionKind` composite literal uses unkeyed fields (govet)
::error file=pkg/kn/flags/channel_types.go,line=122,col=2::unreachable: unreachable code (govet)
::error file=pkg/dynamic/client_test.go,line=352,col=25::SA5011: possible nil pointer dereference (staticcheck)
::error file=pkg/dynamic/client_test.go,line=359,col=25::SA5011: possible nil pointer dereference (staticcheck)
::error file=pkg/kn/commands/channel/list_types_test.go,line=111,col=30::SA5011: possible nil pointer dereference (staticcheck)
```

This will affect precheck of every PRs and will cause a `Code Style / Lint (pull_request) Failing after 55s — Lint`.

This PR is to fix those errors in order to pass the Lint check.

## Changes

* Fixes Lint check errors

<!--
/lint
-->
