### PR TITLE
fix(tekton e2e): Fix CONTAINER_REGISTRY name generation

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -41,10 +41,12 @@ run() {
   initialize $@
 
   # Smoke test
-  eval smoke_test || fail_test
+  # eval smoke_test || fail_test
 
   # Integration test
-  eval integration_test || fail_test
+  # eval integration_test || fail_test
+
+  bash -x $(dirname $0)/tekton-tests.sh
 
   success
 }

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -41,12 +41,10 @@ run() {
   initialize $@
 
   # Smoke test
-  # eval smoke_test || fail_test
+  eval smoke_test || fail_test
 
   # Integration test
-  # eval integration_test || fail_test
-
-  bash -x $(dirname $0)/tekton-tests.sh
+  eval integration_test || fail_test
 
   success
 }

--- a/test/tekton-tests.sh
+++ b/test/tekton-tests.sh
@@ -44,7 +44,7 @@ if (( IS_PROW )); then
   # Configure Docker so that we can create a secret for GCR
   gcloud auth configure-docker
   gcloud auth print-access-token | docker login -u oauth2accesstoken --password-stdin https://gcr.io
-  export CONTAINER_REGISTRY=gcr.io/${E2E_PROJECT_ID}/${E2E_BASE_NAME}-e2e-img/${RANDOM}
+  export CONTAINER_REGISTRY=gcr.io/${E2E_PROJECT_ID}/kn-tekton-e2e-img/${RANDOM}
   export DOCKER_CONFIG_JSON=/root/.docker/config.json
 fi
 


### PR DESCRIPTION
var `E2E_BASE_NAME` is no longer available
