### PR TITLE
Uniform multiple writeSink(s) to DescribeSink

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,10 @@
 | | Description | PR
 
 | 🐣
+| Uniform multiple writeSink to DescribeSink
+| https://github.com/knative/client/pull/1075[#1075]
+
+| 🐣
 | Add function ResolvePodSpec and move the utilities to podspec_helper
 | https://github.com/knative/client/pull/1024[#1024]
 

--- a/lib/printing/describe.go
+++ b/lib/printing/describe.go
@@ -24,7 +24,7 @@ import (
 )
 
 // DescribeSink prints the given 'sink' for the given prefix writer 'dw',
-// provide 'attribute' to print the section heading for this sink
+// provide 'attribute' to print the section heading for this sink,
 func DescribeSink(dw printers.PrefixWriter, attribute, namespace string, sink *duckv1.Destination) {
 	if sink == nil {
 		return

--- a/pkg/kn/commands/source/apiserver/describe.go
+++ b/pkg/kn/commands/source/apiserver/describe.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/spf13/cobra"
 	v1alpha2 "knative.dev/eventing/pkg/apis/sources/v1alpha2"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 
+	"knative.dev/client/lib/printing"
 	"knative.dev/client/pkg/kn/commands"
 	"knative.dev/client/pkg/printers"
 )
@@ -65,7 +65,7 @@ func NewAPIServerDescribeCommand(p *commands.KnParams) *cobra.Command {
 				return err
 			}
 
-			writeSink(dw, apiSource.Spec.Sink)
+			printing.DescribeSink(dw, "Sink", apiSource.Namespace, &apiSource.Spec.Sink)
 			dw.WriteLine()
 			if err := dw.Flush(); err != nil {
 				return err
@@ -104,20 +104,6 @@ func writeResources(dw printers.PrefixWriter, apiVersionKindSelectors []v1alpha2
 		if resource.LabelSelector != nil {
 			subWriter.WriteAttribute("Selector", labelSelectorToString(resource.LabelSelector))
 		}
-	}
-}
-
-func writeSink(dw printers.PrefixWriter, sink duckv1.Destination) {
-	subWriter := dw.WriteAttribute("Sink", "")
-	ref := sink.Ref
-	if ref != nil {
-		subWriter.WriteAttribute("Name", sink.Ref.Name)
-		subWriter.WriteAttribute("Namespace", sink.Ref.Namespace)
-		subWriter.WriteAttribute("Kind", fmt.Sprintf("%s (%s)", sink.Ref.Kind, sink.Ref.APIVersion))
-	}
-	uri := sink.URI
-	if uri != nil {
-		subWriter.WriteAttribute("URI", uri.String())
 	}
 }
 

--- a/pkg/kn/commands/source/binding/describe.go
+++ b/pkg/kn/commands/source/binding/describe.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/spf13/cobra"
 	v1alpha2 "knative.dev/eventing/pkg/apis/sources/v1alpha2"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/tracker"
 
+	"knative.dev/client/lib/printing"
 	"knative.dev/client/pkg/kn/commands"
 	"knative.dev/client/pkg/printers"
 )
@@ -85,25 +85,9 @@ func NewBindingDescribeCommand(p *commands.KnParams) *cobra.Command {
 func writeSinkBinding(dw printers.PrefixWriter, binding *v1alpha2.SinkBinding, printDetails bool) {
 	commands.WriteMetadata(dw, &binding.ObjectMeta, printDetails)
 	writeSubject(dw, binding.Namespace, &binding.Spec.Subject)
-	writeSink(dw, binding.Namespace, &binding.Spec.Sink)
+	printing.DescribeSink(dw, "Sink", binding.Namespace, &binding.Spec.Sink)
 	if binding.Spec.CloudEventOverrides != nil && binding.Spec.CloudEventOverrides.Extensions != nil {
 		writeCeOverrides(dw, binding.Spec.CloudEventOverrides.Extensions)
-	}
-}
-
-func writeSink(dw printers.PrefixWriter, namespace string, sink *duckv1.Destination) {
-	subWriter := dw.WriteAttribute("Sink", "")
-	ref := sink.Ref
-	if ref != nil {
-		subWriter.WriteAttribute("Name", sink.Ref.Name)
-		if sink.Ref.Namespace != "" && sink.Ref.Namespace != namespace {
-			subWriter.WriteAttribute("Namespace", sink.Ref.Namespace)
-		}
-		subWriter.WriteAttribute("Resource", fmt.Sprintf("%s (%s)", sink.Ref.Kind, sink.Ref.APIVersion))
-	}
-	uri := sink.URI
-	if uri != nil {
-		subWriter.WriteAttribute("URI", uri.String())
 	}
 }
 

--- a/pkg/kn/commands/source/ping/describe.go
+++ b/pkg/kn/commands/source/ping/describe.go
@@ -16,13 +16,12 @@ package ping
 
 import (
 	"errors"
-	"fmt"
 	"sort"
 
 	"github.com/spf13/cobra"
 	v1alpha2 "knative.dev/eventing/pkg/apis/sources/v1alpha2"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 
+	"knative.dev/client/lib/printing"
 	"knative.dev/client/pkg/kn/commands"
 	"knative.dev/client/pkg/printers"
 )
@@ -67,7 +66,7 @@ func NewPingDescribeCommand(p *commands.KnParams) *cobra.Command {
 			}
 
 			// Revisions summary info
-			writeSink(dw, &pingSource.Spec.Sink)
+			printing.DescribeSink(dw, "Sink", pingSource.Namespace, &pingSource.Spec.Sink)
 			dw.WriteLine()
 			if err := dw.Flush(); err != nil {
 				return err
@@ -95,20 +94,6 @@ func NewPingDescribeCommand(p *commands.KnParams) *cobra.Command {
 	flags.BoolP("verbose", "v", false, "More output.")
 
 	return pingDescribe
-}
-
-func writeSink(dw printers.PrefixWriter, sink *duckv1.Destination) {
-	subWriter := dw.WriteAttribute("Sink", "")
-	ref := sink.Ref
-	if ref != nil {
-		subWriter.WriteAttribute("Name", sink.Ref.Name)
-		subWriter.WriteAttribute("Namespace", sink.Ref.Namespace)
-		subWriter.WriteAttribute("Resource", fmt.Sprintf("%s (%s)", sink.Ref.Kind, sink.Ref.APIVersion))
-	}
-	uri := sink.URI
-	if uri != nil {
-		subWriter.WriteAttribute("URI", uri.String())
-	}
 }
 
 func writePingSource(dw printers.PrefixWriter, source *v1alpha2.PingSource, printDetails bool) {

--- a/pkg/kn/commands/trigger/describe.go
+++ b/pkg/kn/commands/trigger/describe.go
@@ -16,13 +16,12 @@ package trigger
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
 	v1beta1 "knative.dev/eventing/pkg/apis/eventing/v1beta1"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 
+	"knative.dev/client/lib/printing"
 	"knative.dev/client/pkg/kn/commands"
 	"knative.dev/client/pkg/printers"
 )
@@ -74,7 +73,7 @@ func NewTriggerDescribeCommand(p *commands.KnParams) *cobra.Command {
 			}
 
 			// Revisions summary info
-			writeSink(dw, &trigger.Spec.Subscriber)
+			printing.DescribeSink(dw, "Sink", trigger.Namespace, &trigger.Spec.Subscriber)
 			dw.WriteLine()
 			if err := dw.Flush(); err != nil {
 				return err
@@ -94,20 +93,6 @@ func NewTriggerDescribeCommand(p *commands.KnParams) *cobra.Command {
 	flags.BoolP("verbose", "v", false, "More output.")
 
 	return triggerDescribe
-}
-
-func writeSink(dw printers.PrefixWriter, sink *duckv1.Destination) {
-	subWriter := dw.WriteAttribute("Sink", "")
-	ref := sink.Ref
-	if ref != nil {
-		subWriter.WriteAttribute("Name", sink.Ref.Name)
-		subWriter.WriteAttribute("Namespace", sink.Ref.Namespace)
-		subWriter.WriteAttribute("Resource", fmt.Sprintf("%s (%s)", sink.Ref.Kind, sink.Ref.APIVersion))
-	}
-	uri := sink.URI
-	if uri != nil {
-		subWriter.WriteAttribute("URI", uri.String())
-	}
 }
 
 func writeTrigger(dw printers.PrefixWriter, trigger *v1beta1.Trigger, printDetails bool) {


### PR DESCRIPTION
## Description

There are multiple `writeSink` in source commands to print Sink object. And there is a utility `DescribeSink` in `lib/printing`. It's better to uniform them.

## Changes

* Uniform multiple writeSink(s) to a single WriteSink

