### PR TITLE
Drop deprecated --async flag support

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,10 @@
 | | Description | PR
 
 | 🐣
+| Drop deprecated --async flag support
+| https://github.com/knative/client/pull/1094[#1094]
+
+| 🐣
 | Uniform multiple writeSink to DescribeSink
 | https://github.com/knative/client/pull/1075[#1075]
 

--- a/docs/cmd/kn_broker_delete.md
+++ b/docs/cmd/kn_broker_delete.md
@@ -24,7 +24,6 @@ kn broker delete NAME
 ### Options
 
 ```
-      --async              DEPRECATED: please use --no-wait instead. Do not wait for 'broker delete' operation to be completed. (default true)
   -h, --help               help for delete
   -n, --namespace string   Specify the namespace to operate in.
       --no-wait            Do not wait for 'broker delete' operation to be completed. (default true)

--- a/docs/cmd/kn_revision_delete.md
+++ b/docs/cmd/kn_revision_delete.md
@@ -21,7 +21,6 @@ kn revision delete NAME [NAME ...]
 ### Options
 
 ```
-      --async              DEPRECATED: please use --no-wait instead. Do not wait for 'revision delete' operation to be completed. (default true)
   -h, --help               help for delete
   -n, --namespace string   Specify the namespace to operate in.
       --no-wait            Do not wait for 'revision delete' operation to be completed. (default true)

--- a/docs/cmd/kn_service_apply.md
+++ b/docs/cmd/kn_service_apply.md
@@ -37,7 +37,6 @@ kn service apply s0 --filename my-svc.yml
       --annotation-revision stringArray   Revision annotation to set. name=value; you may provide this flag any number of times to set multiple annotations. To unset, specify the annotation name followed by a "-" (e.g., name-). This flag takes precedence over the "annotation" flag.
       --annotation-service stringArray    Service annotation to set. name=value; you may provide this flag any number of times to set multiple annotations. To unset, specify the annotation name followed by a "-" (e.g., name-). This flag takes precedence over the "annotation" flag.
       --arg stringArray                   Add argument to the container command. Example: --arg myArg1 --arg --myArg2 --arg myArg3=3. You can use this flag multiple times.
-      --async                             DEPRECATED: please use --no-wait instead. Do not wait for 'service apply' operation to be completed.
       --autoscale-window string           Duration to look back for making auto-scaling decisions. The service is scaled to zero if no request was received in during that time. (eg: 10s)
       --cluster-local                     Specify that the service be private. (--no-cluster-local will make the service publicly available)
       --cmd string                        Specify command to be used as entrypoint instead of default one. Example: --cmd /app/start or --cmd /app/start --arg myArg to pass additional arguments.

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -57,7 +57,6 @@ kn service create NAME --image IMAGE
       --annotation-revision stringArray   Revision annotation to set. name=value; you may provide this flag any number of times to set multiple annotations. To unset, specify the annotation name followed by a "-" (e.g., name-). This flag takes precedence over the "annotation" flag.
       --annotation-service stringArray    Service annotation to set. name=value; you may provide this flag any number of times to set multiple annotations. To unset, specify the annotation name followed by a "-" (e.g., name-). This flag takes precedence over the "annotation" flag.
       --arg stringArray                   Add argument to the container command. Example: --arg myArg1 --arg --myArg2 --arg myArg3=3. You can use this flag multiple times.
-      --async                             DEPRECATED: please use --no-wait instead. Do not wait for 'service create' operation to be completed.
       --autoscale-window string           Duration to look back for making auto-scaling decisions. The service is scaled to zero if no request was received in during that time. (eg: 10s)
       --cluster-local                     Specify that the service be private. (--no-cluster-local will make the service publicly available)
       --cmd string                        Specify command to be used as entrypoint instead of default one. Example: --cmd /app/start or --cmd /app/start --arg myArg to pass additional arguments.

--- a/docs/cmd/kn_service_delete.md
+++ b/docs/cmd/kn_service_delete.md
@@ -28,7 +28,6 @@ kn service delete NAME [NAME ...]
 
 ```
       --all                Delete all services in a namespace.
-      --async              DEPRECATED: please use --no-wait instead. Do not wait for 'service delete' operation to be completed. (default true)
   -h, --help               help for delete
   -n, --namespace string   Specify the namespace to operate in.
       --no-wait            Do not wait for 'service delete' operation to be completed. (default true)

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -42,7 +42,6 @@ kn service update NAME
       --annotation-revision stringArray   Revision annotation to set. name=value; you may provide this flag any number of times to set multiple annotations. To unset, specify the annotation name followed by a "-" (e.g., name-). This flag takes precedence over the "annotation" flag.
       --annotation-service stringArray    Service annotation to set. name=value; you may provide this flag any number of times to set multiple annotations. To unset, specify the annotation name followed by a "-" (e.g., name-). This flag takes precedence over the "annotation" flag.
       --arg stringArray                   Add argument to the container command. Example: --arg myArg1 --arg --myArg2 --arg myArg3=3. You can use this flag multiple times.
-      --async                             DEPRECATED: please use --no-wait instead. Do not wait for 'service update' operation to be completed.
       --autoscale-window string           Duration to look back for making auto-scaling decisions. The service is scaled to zero if no request was received in during that time. (eg: 10s)
       --cluster-local                     Specify that the service be private. (--no-cluster-local will make the service publicly available)
       --cmd string                        Specify command to be used as entrypoint instead of default one. Example: --cmd /app/start or --cmd /app/start --arg myArg to pass additional arguments.

--- a/pkg/kn/commands/service/create.go
+++ b/pkg/kn/commands/service/create.go
@@ -157,12 +157,6 @@ func replaceService(client clientservingv1.KnServingClient, service *servingv1.S
 }
 
 func waitIfRequested(client clientservingv1.KnServingClient, serviceName string, waitFlags commands.WaitFlags, verbDoing string, verbDone string, out io.Writer) error {
-	//TODO: deprecated condition should be removed with --async flag
-	if waitFlags.Async {
-		fmt.Fprintf(out, "\nWARNING: flag --async is deprecated and going to be removed in future release, please use --no-wait instead.\n\n")
-		fmt.Fprintf(out, "Service '%s' %s in namespace '%s'.\n", serviceName, verbDone, client.Namespace())
-		return nil
-	}
 	if !waitFlags.Wait {
 		fmt.Fprintf(out, "Service '%s' %s in namespace '%s'.\n", serviceName, verbDone, client.Namespace())
 		return nil

--- a/pkg/kn/commands/service/update.go
+++ b/pkg/kn/commands/service/update.go
@@ -109,8 +109,7 @@ func NewServiceUpdateCommand(p *commands.KnParams) *cobra.Command {
 			}
 
 			out := cmd.OutOrStdout()
-			//TODO: deprecated condition should be once --async is gone
-			if !waitFlags.Async && waitFlags.Wait {
+			if waitFlags.Wait {
 				fmt.Fprintf(out, "Updating Service '%s' in namespace '%s':\n", args[0], namespace)
 				fmt.Fprintln(out, "")
 				err := waitForService(client, name, out, waitFlags.TimeoutInSeconds)
@@ -120,9 +119,6 @@ func NewServiceUpdateCommand(p *commands.KnParams) *cobra.Command {
 				fmt.Fprintln(out, "")
 				return showUrl(client, name, latestRevisionBeforeUpdate, "updated", out)
 			} else {
-				if waitFlags.Async {
-					fmt.Fprintf(out, "\nWARNING: flag --async is deprecated and going to be removed in future release, please use --no-wait instead.\n\n")
-				}
 				fmt.Fprintf(out, "Service '%s' updated in namespace '%s'.\n", args[0], namespace)
 			}
 

--- a/pkg/kn/commands/wait_flags.go
+++ b/pkg/kn/commands/wait_flags.go
@@ -33,11 +33,9 @@ type WaitFlags struct {
 	TimeoutInSeconds int
 	// If set then apply resources and wait for completion
 	Wait bool
-	//TODO: deprecated variable should be removed with --async flag
-	Async bool
 }
 
-// Add flags which influence the sync/async behaviour when creating or updating
+// Add flags which influence the wait/no-wait behaviour when creating or updating
 // resources. Set `waitDefault` argument if the default behaviour is synchronous.
 // Use `what` for describing what is waited for.
 func (p *WaitFlags) AddConditionWaitFlags(command *cobra.Command, waitTimeoutDefault int, action, what, until string) {
@@ -48,8 +46,6 @@ func (p *WaitFlags) AddConditionWaitFlags(command *cobra.Command, waitTimeoutDef
 		waitDefault = false
 	}
 
-	//TODO: deprecated flag should be removed in next release
-	command.Flags().BoolVar(&p.Async, "async", !waitDefault, "DEPRECATED: please use --no-wait instead. "+knflags.InvertUsage(waitUsage))
 	knflags.AddBothBoolFlagsUnhidden(command.Flags(), &p.Wait, "wait", "", waitDefault, waitUsage)
 	timeoutUsage := fmt.Sprintf("Seconds to wait before giving up on waiting for %s to be %s.", what, until)
 	command.Flags().IntVar(&p.TimeoutInSeconds, "wait-timeout", waitTimeoutDefault, timeoutUsage)

--- a/pkg/kn/commands/wait_flags_test.go
+++ b/pkg/kn/commands/wait_flags_test.go
@@ -32,14 +32,13 @@ type waitTestCase struct {
 	isParseErrorExpected bool
 }
 
-//TODO: deprecated test should be removed with --async flag
 func TestAddWaitForReadyDeprecatedFlags(t *testing.T) {
 	for i, tc := range []waitTestCase{
-		{[]string{"--async"}, 60, false, false},
+		{[]string{"--no-wait"}, 60, false, false},
 		{[]string{}, 60, true, false},
 		{[]string{"--wait-timeout=120"}, 120, true, false},
 		// Can't be easily prevented, the timeout is just ignored in this case:
-		{[]string{"--async", "--wait-timeout=120"}, 120, false, false},
+		{[]string{"--no-wait", "--wait-timeout=120"}, 120, false, false},
 		{[]string{"--wait-timeout=bla"}, 0, true, true},
 	} {
 
@@ -58,12 +57,12 @@ func TestAddWaitForReadyDeprecatedFlags(t *testing.T) {
 			continue
 		}
 
-		//  reconcile to ensure wait, no-wait and async behaves as expected
+		//  reconcile to ensure wait, no-wait behave as expected
 		err = knflags.ReconcileBoolFlags(cmd.Flags())
 		assert.NilError(t, err)
 
-		if flags.Async == tc.isWaitExpected {
-			t.Errorf("%d: wrong async mode detected: %t (expected) != %t (actual)", i, tc.isWaitExpected, flags.Async)
+		if flags.Wait != tc.isWaitExpected {
+			t.Errorf("%d: wrong wait mode detected: %t (expected) != %t (actual)", i, tc.isWaitExpected, flags.Wait)
 		}
 		if flags.TimeoutInSeconds != tc.timeoutExpected {
 			t.Errorf("%d: Invalid timeout set. %d (expected) != %d (actual)", i, tc.timeoutExpected, flags.TimeoutInSeconds)
@@ -95,7 +94,7 @@ func TestAddWaitForReadyFlags(t *testing.T) {
 			continue
 		}
 
-		//  reconcile to ensure wait, no-wait and async behaves as expected
+		//  reconcile to ensure wait, no-wait behave as expected
 		err = knflags.ReconcileBoolFlags(cmd.Flags())
 		assert.NilError(t, err)
 		fmt.Println("wait value")

--- a/pkg/kn/flags/bool.go
+++ b/pkg/kn/flags/bool.go
@@ -68,19 +68,6 @@ func ReconcileBoolFlags(f *pflag.FlagSet) error {
 			return
 		}
 
-		// handle async flag
-		if flag.Name == "async" && flag.Changed {
-			if f.Lookup("wait").Changed || f.Lookup("no-wait").Changed {
-				err = fmt.Errorf("only one of (DEPRECATED) --async, --wait and --no-wait may be specified")
-				return
-			}
-			err = checkExplicitFalse(flag, "wait")
-			if err != nil {
-				return
-			}
-			f.Lookup("no-wait").Value.Set("true")
-		}
-
 		// Walk the "no-" versions of the flags. Make sure we didn't set
 		// both, and set the positive value to the opposite of the "no-"
 		// value if it exists.

--- a/pkg/kn/flags/bool_test.go
+++ b/pkg/kn/flags/bool_test.go
@@ -29,13 +29,6 @@ type boolPairTestCase struct {
 	expectedErrText string
 }
 
-type boolPairTestCaseDeprecated struct {
-	waitDefaultVal  bool
-	flags           []string
-	expectedResult  bool
-	expectedErrText string
-}
-
 func TestBooleanPair(t *testing.T) {
 	cases := []*boolPairTestCase{
 		{"foo", true, []string{}, true, ""},
@@ -67,30 +60,6 @@ func TestBooleanPair(t *testing.T) {
 		f := &pflag.FlagSet{}
 		var result bool
 		AddBothBoolFlags(f, &result, c.name, "", c.defaultVal, "set "+c.name)
-		f.Parse(c.flags)
-		err := ReconcileBoolFlags(f)
-		if c.expectedErrText != "" {
-			assert.ErrorContains(t, err, c.expectedErrText)
-		} else {
-			assert.Equal(t, result, c.expectedResult)
-		}
-	}
-}
-
-func TestBooleanPairWithDeprecatedSyncFlag(t *testing.T) {
-	cases := []*boolPairTestCaseDeprecated{
-		{true, []string{}, false, ""},
-		{true, []string{"--async"}, true, ""},
-		{true, []string{"--async", "--no-wait"}, false, "only one of (DEPRECATED) --async, --wait and --no-wait may be specified"},
-		// delete operation
-		{false, []string{""}, true, ""},
-		{false, []string{"--async=false"}, false, "use --wait instead of providing \"false\" to --async"},
-	}
-	for _, c := range cases {
-		var result, wait bool
-		f := &pflag.FlagSet{}
-		AddBothBoolFlags(f, &wait, "wait", "", c.waitDefaultVal, "set wait")
-		f.BoolVar(&result, "async", !c.waitDefaultVal, "DEPRECATED: set async")
 		f.Parse(c.flags)
 		err := ReconcileBoolFlags(f)
 		if c.expectedErrText != "" {


### PR DESCRIPTION
## Description
Drop deprecated --async flag support  in the favor of --no-wait flag

## Changes
* Drop --async flag
* Remove the respective test cases
* Add CHANGELONG

## Reference

Fixes #1089 
