### PR TITLE
fix: Fix var initialization in lib/service function

### DIFF
--- a/lib/test/service.go
+++ b/lib/test/service.go
@@ -43,16 +43,6 @@ type ExpectedRevisionListOption func(*servingv1.RevisionList)
 // ExpectedKNExportOption enables further configuration of a Export.
 type ExpectedKNExportOption func(*clientv1alpha1.Export)
 
-var revisionSpec = servingv1.RevisionSpec{
-	PodSpec: corev1.PodSpec{
-		Containers: []corev1.Container{{
-			Image: pkgtest.ImagePath("helloworld"),
-		}},
-		EnableServiceLinks: ptr.Bool(false),
-	},
-	TimeoutSeconds: ptr.Int64(config.DefaultRevisionTimeoutSeconds),
-}
-
 // ServiceCreate verifies given service creation in sync mode and also verifies output
 func ServiceCreate(r *KnRunResultCollector, serviceName string) {
 	out := r.KnTest().Kn().Run("service", "create", serviceName, "--image", pkgtest.ImagePath("helloworld"))
@@ -222,7 +212,7 @@ func BuildConfigurationSpec(co ...servingtest.ConfigOption) *servingv1.Configura
 	c := &servingv1.Configuration{
 		Spec: servingv1.ConfigurationSpec{
 			Template: servingv1.RevisionTemplateSpec{
-				Spec: *revisionSpec.DeepCopy(),
+				Spec: *BuildRevisionSpec(pkgtest.ImagePath("helloworld")),
 			},
 		},
 	}
@@ -231,6 +221,19 @@ func BuildConfigurationSpec(co ...servingtest.ConfigOption) *servingv1.Configura
 	}
 	c.SetDefaults(context.Background())
 	return &c.Spec
+}
+
+// BuildRevisionSpec for provided image
+func BuildRevisionSpec(image string) *servingv1.RevisionSpec {
+	return &servingv1.RevisionSpec{
+		PodSpec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Image: image,
+			}},
+			EnableServiceLinks: ptr.Bool(false),
+		},
+		TimeoutSeconds: ptr.Int64(config.DefaultRevisionTimeoutSeconds),
+	}
 }
 
 // BuildServiceWithOptions returns ksvc with options provided


### PR DESCRIPTION
## Description

I ran into the issue with E2E execution and `--imagetemplate`, when `TestServiceExport` fails comparing the wrong image value. I've found out that actual RevisionSpec used for the expected value is initialized with wrong value, hence the fix should mitigate that.

```bash
./test/local-e2e-tests.sh -run ^TestServiceExport$ --imagetemplate docker.io/dsimansk/{{.Name}}

# fails with
...
        - 								Image:   "/helloworld:latest",
        + 								Image:   "docker.io/dsimansk/helloworld",


```

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Add `BuildRevisionSpec` to lib/test/service.go to fix the issue

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes N/A

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
