### PR TITLE
chore: Remove deprecated requests/limits flags

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -52,6 +52,10 @@
 | 🎁
 | Add arm64 binary to the release
 | https://github.com/knative/client/pull/1106[#1106]
+
+| 🗑
+| Drop deprecated `--requests-cpu,--requests-memory,--limits-cpu,--limits-memory` flags support
+| https://github.com/knative/client/pull/1110[#1110]
 |===
 
 ## v0.18.1 (2020-10-13)

--- a/docs/cmd/kn_service_apply.md
+++ b/docs/cmd/kn_service_apply.md
@@ -53,8 +53,6 @@ kn service apply s0 --filename my-svc.yml
       --label-revision stringArray        Revision label to set. name=value; you may provide this flag any number of times to set multiple labels. To unset, specify the label name followed by a "-" (e.g., name-). This flag takes precedence over the "label" flag.
       --label-service stringArray         Service label to set. name=value; you may provide this flag any number of times to set multiple labels. To unset, specify the label name followed by a "-" (e.g., name-). This flag takes precedence over the "label" flag.
       --limit strings                     The resource requirement limits for this Service. For example, 'cpu=100m,memory=256Mi'. You can use this flag multiple times. To unset a resource limit, append "-" to the resource name, e.g. '--limit memory-'.
-      --limits-cpu string                 DEPRECATED: please use --limit instead. The limits on the requested CPU (e.g., 1000m).
-      --limits-memory string              DEPRECATED: please use --limit instead. The limits on the requested memory (e.g., 1024Mi).
       --lock-to-digest                    Keep the running image for the service constant when not explicitly specifying the image. (--no-lock-to-digest pulls the image tag afresh with each new revision) (default true)
       --mount stringArray                 Mount a ConfigMap (prefix cm: or config-map:), a Secret (prefix secret: or sc:), or an existing Volume (without any prefix) on the specified directory. Example: --mount /mydir=cm:myconfigmap, --mount /mydir=secret:mysecret, or --mount /mydir=myvolume. When a configmap or a secret is specified, a corresponding volume is automatically generated. You can use this flag multiple times. For unmounting a directory, append "-", e.g. --mount /mydir-, which also removes any auto-generated volume.
   -n, --namespace string                  Specify the namespace to operate in.
@@ -64,8 +62,6 @@ kn service apply s0 --filename my-svc.yml
   -p, --port string                       The port where application listens on, in the format 'NAME:PORT', where 'NAME' is optional. Examples: '--port h2c:8080' , '--port 8080'.
       --pull-secret string                Image pull secret to set. An empty argument ("") clears the pull secret. The referenced secret must exist in the service's namespace.
       --request strings                   The resource requirement requests for this Service. For example, 'cpu=100m,memory=256Mi'. You can use this flag multiple times. To unset a resource request, append "-" to the resource name, e.g. '--request cpu-'.
-      --requests-cpu string               DEPRECATED: please use --request instead. The requested CPU (e.g., 250m).
-      --requests-memory string            DEPRECATED: please use --request instead. The requested memory (e.g., 64Mi).
       --revision-name string              The revision name to set. Must start with the service name and a dash as a prefix. Empty revision name will result in the server generating a name for the revision. Accepts golang templates, allowing {{.Service}} for the service name, {{.Generation}} for the generation, and {{.Random [n]}} for n random consonants. (default "{{.Service}}-{{.Random 5}}-{{.Generation}}")
       --scale int                         Minimum and maximum number of replicas.
       --scale-init int                    Initial number of replicas with which a service starts. Can be 0 or a positive integer.

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -73,8 +73,6 @@ kn service create NAME --image IMAGE
       --label-revision stringArray        Revision label to set. name=value; you may provide this flag any number of times to set multiple labels. To unset, specify the label name followed by a "-" (e.g., name-). This flag takes precedence over the "label" flag.
       --label-service stringArray         Service label to set. name=value; you may provide this flag any number of times to set multiple labels. To unset, specify the label name followed by a "-" (e.g., name-). This flag takes precedence over the "label" flag.
       --limit strings                     The resource requirement limits for this Service. For example, 'cpu=100m,memory=256Mi'. You can use this flag multiple times. To unset a resource limit, append "-" to the resource name, e.g. '--limit memory-'.
-      --limits-cpu string                 DEPRECATED: please use --limit instead. The limits on the requested CPU (e.g., 1000m).
-      --limits-memory string              DEPRECATED: please use --limit instead. The limits on the requested memory (e.g., 1024Mi).
       --lock-to-digest                    Keep the running image for the service constant when not explicitly specifying the image. (--no-lock-to-digest pulls the image tag afresh with each new revision) (default true)
       --mount stringArray                 Mount a ConfigMap (prefix cm: or config-map:), a Secret (prefix secret: or sc:), or an existing Volume (without any prefix) on the specified directory. Example: --mount /mydir=cm:myconfigmap, --mount /mydir=secret:mysecret, or --mount /mydir=myvolume. When a configmap or a secret is specified, a corresponding volume is automatically generated. You can use this flag multiple times. For unmounting a directory, append "-", e.g. --mount /mydir-, which also removes any auto-generated volume.
   -n, --namespace string                  Specify the namespace to operate in.
@@ -84,8 +82,6 @@ kn service create NAME --image IMAGE
   -p, --port string                       The port where application listens on, in the format 'NAME:PORT', where 'NAME' is optional. Examples: '--port h2c:8080' , '--port 8080'.
       --pull-secret string                Image pull secret to set. An empty argument ("") clears the pull secret. The referenced secret must exist in the service's namespace.
       --request strings                   The resource requirement requests for this Service. For example, 'cpu=100m,memory=256Mi'. You can use this flag multiple times. To unset a resource request, append "-" to the resource name, e.g. '--request cpu-'.
-      --requests-cpu string               DEPRECATED: please use --request instead. The requested CPU (e.g., 250m).
-      --requests-memory string            DEPRECATED: please use --request instead. The requested memory (e.g., 64Mi).
       --revision-name string              The revision name to set. Must start with the service name and a dash as a prefix. Empty revision name will result in the server generating a name for the revision. Accepts golang templates, allowing {{.Service}} for the service name, {{.Generation}} for the generation, and {{.Random [n]}} for n random consonants. (default "{{.Service}}-{{.Random 5}}-{{.Generation}}")
       --scale int                         Minimum and maximum number of replicas.
       --scale-init int                    Initial number of replicas with which a service starts. Can be 0 or a positive integer.

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -56,8 +56,6 @@ kn service update NAME
       --label-revision stringArray        Revision label to set. name=value; you may provide this flag any number of times to set multiple labels. To unset, specify the label name followed by a "-" (e.g., name-). This flag takes precedence over the "label" flag.
       --label-service stringArray         Service label to set. name=value; you may provide this flag any number of times to set multiple labels. To unset, specify the label name followed by a "-" (e.g., name-). This flag takes precedence over the "label" flag.
       --limit strings                     The resource requirement limits for this Service. For example, 'cpu=100m,memory=256Mi'. You can use this flag multiple times. To unset a resource limit, append "-" to the resource name, e.g. '--limit memory-'.
-      --limits-cpu string                 DEPRECATED: please use --limit instead. The limits on the requested CPU (e.g., 1000m).
-      --limits-memory string              DEPRECATED: please use --limit instead. The limits on the requested memory (e.g., 1024Mi).
       --lock-to-digest                    Keep the running image for the service constant when not explicitly specifying the image. (--no-lock-to-digest pulls the image tag afresh with each new revision) (default true)
       --mount stringArray                 Mount a ConfigMap (prefix cm: or config-map:), a Secret (prefix secret: or sc:), or an existing Volume (without any prefix) on the specified directory. Example: --mount /mydir=cm:myconfigmap, --mount /mydir=secret:mysecret, or --mount /mydir=myvolume. When a configmap or a secret is specified, a corresponding volume is automatically generated. You can use this flag multiple times. For unmounting a directory, append "-", e.g. --mount /mydir-, which also removes any auto-generated volume.
   -n, --namespace string                  Specify the namespace to operate in.
@@ -67,8 +65,6 @@ kn service update NAME
   -p, --port string                       The port where application listens on, in the format 'NAME:PORT', where 'NAME' is optional. Examples: '--port h2c:8080' , '--port 8080'.
       --pull-secret string                Image pull secret to set. An empty argument ("") clears the pull secret. The referenced secret must exist in the service's namespace.
       --request strings                   The resource requirement requests for this Service. For example, 'cpu=100m,memory=256Mi'. You can use this flag multiple times. To unset a resource request, append "-" to the resource name, e.g. '--request cpu-'.
-      --requests-cpu string               DEPRECATED: please use --request instead. The requested CPU (e.g., 250m).
-      --requests-memory string            DEPRECATED: please use --request instead. The requested memory (e.g., 64Mi).
       --revision-name string              The revision name to set. Must start with the service name and a dash as a prefix. Empty revision name will result in the server generating a name for the revision. Accepts golang templates, allowing {{.Service}} for the service name, {{.Generation}} for the generation, and {{.Random [n]}} for n random consonants. (default "{{.Service}}-{{.Random 5}}-{{.Generation}}")
       --scale int                         Minimum and maximum number of replicas.
       --scale-init int                    Initial number of replicas with which a service starts. Can be 0 or a positive integer.

--- a/pkg/kn/commands/service/create_mock_test.go
+++ b/pkg/kn/commands/service/create_mock_test.go
@@ -445,40 +445,7 @@ func TestServiceCreateWithResources(t *testing.T) {
 	r.Validate()
 }
 
-func TestServiceCreateWithResourcesWarning(t *testing.T) {
-	client := knclient.NewMockKnServiceClient(t)
-
-	r := client.Recorder()
-	r.GetService("foo", nil, errors.NewNotFound(servingv1.Resource("service"), "foo"))
-
-	service := getService("foo")
-	template := &service.Spec.Template
-
-	template.Spec.Containers[0].Resources.Requests = corev1.ResourceList{
-		corev1.ResourceMemory: parseQuantity(t, "64Mi"),
-	}
-
-	template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
-		corev1.ResourceCPU: parseQuantity(t, "1000m"),
-	}
-
-	template.Spec.Containers[0].Image = "gcr.io/foo/bar:baz"
-	template.Annotations = map[string]string{servinglib.UserImageAnnotationKey: "gcr.io/foo/bar:baz"}
-	r.CreateService(service, nil)
-
-	output, err := executeServiceCommand(client, "create", "foo", "--image", "gcr.io/foo/bar:baz",
-		"--requests-memory", "64Mi",
-		"--limits-cpu", "1000m",
-		"--no-wait", "--revision-name=")
-	assert.NilError(t, err)
-	assert.Assert(t, util.ContainsAll(output, "WARNING", "--requests-cpu", "--requests-memory", "deprecated", "removed", "--request", "instead"))
-	assert.Assert(t, util.ContainsAll(output, "WARNING", "--limits-cpu", "--limits-memory", "deprecated", "removed", "--limit", "instead"))
-	assert.Assert(t, util.ContainsAll(output, "created", "foo", "default"))
-
-	r.Validate()
-}
-
-func TestServiceCreateWithResourcesError(t *testing.T) {
+func TestServiceCreateWithDeprecatedResourcesError(t *testing.T) {
 	client := knclient.NewMockKnServiceClient(t)
 	r := client.Recorder()
 
@@ -487,7 +454,7 @@ func TestServiceCreateWithResourcesError(t *testing.T) {
 		"--request", "memory=64Mi",
 		"--no-wait", "--revision-name=")
 	assert.Assert(t, err != nil)
-	assert.Assert(t, util.ContainsAll(output, "only one of", "DEPRECATED", "--requests-cpu", "--requests-memory", "--request", "can be specified"))
+	assert.Assert(t, util.ContainsAll(output, "unknown", "flag", "--requests-memory"))
 
 	r.Validate()
 }

--- a/pkg/kn/commands/service/create_test.go
+++ b/pkg/kn/commands/service/create_test.go
@@ -240,34 +240,6 @@ func TestServiceCreateEnv(t *testing.T) {
 	}
 }
 
-func TestServiceCreateWithDeprecatedRequests(t *testing.T) {
-	action, created, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
-		"--requests-cpu", "250m", "--requests-memory", "64Mi",
-		"--no-wait"}, false)
-
-	if err != nil {
-		t.Fatal(err)
-	} else if !action.Matches("create", "services") {
-		t.Fatalf("Bad action %v", action)
-	}
-
-	expectedRequestsVars := corev1.ResourceList{
-		corev1.ResourceCPU:    parseQuantity(t, "250m"),
-		corev1.ResourceMemory: parseQuantity(t, "64Mi"),
-	}
-
-	template := &created.Spec.Template
-
-	if err != nil {
-		t.Fatal(err)
-	} else if !reflect.DeepEqual(
-		template.Spec.Containers[0].Resources.Requests,
-		expectedRequestsVars) {
-		t.Fatalf("wrong requests vars %v", template.Spec.Containers[0].Resources.Requests)
-	}
-}
-
 func TestServiceCreateWithRequests(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
 		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
@@ -293,34 +265,6 @@ func TestServiceCreateWithRequests(t *testing.T) {
 		template.Spec.Containers[0].Resources.Requests,
 		expectedRequestsVars) {
 		t.Fatalf("wrong requests vars %v", template.Spec.Containers[0].Resources.Requests)
-	}
-}
-
-func TestServiceCreateWithDeprecatedLimits(t *testing.T) {
-	action, created, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
-		"--limits-cpu", "1000m", "--limits-memory", "1024Mi",
-		"--no-wait"}, false)
-
-	if err != nil {
-		t.Fatal(err)
-	} else if !action.Matches("create", "services") {
-		t.Fatalf("Bad action %v", action)
-	}
-
-	expectedLimitsVars := corev1.ResourceList{
-		corev1.ResourceCPU:    parseQuantity(t, "1000m"),
-		corev1.ResourceMemory: parseQuantity(t, "1024Mi"),
-	}
-
-	template := &created.Spec.Template
-
-	if err != nil {
-		t.Fatal(err)
-	} else if !reflect.DeepEqual(
-		template.Spec.Containers[0].Resources.Limits,
-		expectedLimitsVars) {
-		t.Fatalf("wrong limits vars %v", template.Spec.Containers[0].Resources.Limits)
 	}
 }
 
@@ -352,45 +296,6 @@ func TestServiceCreateWithLimits(t *testing.T) {
 	}
 }
 
-func TestServiceCreateDeprecatedRequestsLimitsCPU(t *testing.T) {
-	action, created, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
-		"--requests-cpu", "250m", "--limits-cpu", "1000m",
-		"--no-wait"}, false)
-
-	if err != nil {
-		t.Fatal(err)
-	} else if !action.Matches("create", "services") {
-		t.Fatalf("Bad action %v", action)
-	}
-
-	expectedRequestsVars := corev1.ResourceList{
-		corev1.ResourceCPU: parseQuantity(t, "250m"),
-	}
-
-	expectedLimitsVars := corev1.ResourceList{
-		corev1.ResourceCPU: parseQuantity(t, "1000m"),
-	}
-
-	template := &created.Spec.Template
-
-	if err != nil {
-		t.Fatal(err)
-	} else {
-		if !reflect.DeepEqual(
-			template.Spec.Containers[0].Resources.Requests,
-			expectedRequestsVars) {
-			t.Fatalf("wrong requests vars %v", template.Spec.Containers[0].Resources.Requests)
-		}
-
-		if !reflect.DeepEqual(
-			template.Spec.Containers[0].Resources.Limits,
-			expectedLimitsVars) {
-			t.Fatalf("wrong limits vars %v", template.Spec.Containers[0].Resources.Limits)
-		}
-	}
-}
-
 func TestServiceCreateRequestsLimitsCPU(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
 		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
@@ -409,46 +314,6 @@ func TestServiceCreateRequestsLimitsCPU(t *testing.T) {
 
 	expectedLimitsVars := corev1.ResourceList{
 		corev1.ResourceCPU: parseQuantity(t, "1000m"),
-	}
-
-	template := &created.Spec.Template
-
-	if err != nil {
-		t.Fatal(err)
-	} else {
-		if !reflect.DeepEqual(
-			template.Spec.Containers[0].Resources.Requests,
-			expectedRequestsVars) {
-			t.Fatalf("wrong requests vars %v", template.Spec.Containers[0].Resources.Requests)
-		}
-
-		if !reflect.DeepEqual(
-			template.Spec.Containers[0].Resources.Limits,
-			expectedLimitsVars) {
-			t.Fatalf("wrong limits vars %v", template.Spec.Containers[0].Resources.Limits)
-		}
-	}
-}
-
-func TestServiceCreateDeprecatedRequestsLimitsMemory(t *testing.T) {
-	action, created, _, err := fakeServiceCreate([]string{
-		"service", "create", "foo",
-		"--image", "gcr.io/foo/bar:baz",
-		"--requests-memory", "64Mi",
-		"--limits-memory", "1024Mi", "--no-wait"}, false)
-
-	if err != nil {
-		t.Fatal(err)
-	} else if !action.Matches("create", "services") {
-		t.Fatalf("Bad action %v", action)
-	}
-
-	expectedRequestsVars := corev1.ResourceList{
-		corev1.ResourceMemory: parseQuantity(t, "64Mi"),
-	}
-
-	expectedLimitsVars := corev1.ResourceList{
-		corev1.ResourceMemory: parseQuantity(t, "1024Mi"),
 	}
 
 	template := &created.Spec.Template
@@ -620,8 +485,8 @@ func TestServiceCreateScaleWithMinScaleSet(t *testing.T) {
 func TestServiceCreateRequestsLimitsCPUMemory(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
 		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",
-		"--requests-cpu", "250m", "--limits-cpu", "1000m",
-		"--requests-memory", "64Mi", "--limits-memory", "1024Mi",
+		"--request", "cpu=250m", "--limit", "cpu=1000m",
+		"--request", "memory=64Mi", "--limit", "memory=1024Mi",
 		"--no-wait"}, false)
 
 	if err != nil {

--- a/pkg/kn/commands/service/update_test.go
+++ b/pkg/kn/commands/service/update_test.go
@@ -578,7 +578,7 @@ func TestServiceUpdateRequestsLimitsCPU(t *testing.T) {
 	service := createMockServiceWithResources(t, "250", "64Mi", "1000m", "1024Mi")
 
 	action, updated, _, err := fakeServiceUpdate(service, []string{
-		"service", "update", "foo", "--requests-cpu", "500m", "--limits-cpu", "1000m", "--no-wait"})
+		"service", "update", "foo", "--request", "cpu=500m", "--limit", "cpu=1000m", "--no-wait"})
 	if err != nil {
 		t.Fatal(err)
 	} else if !action.Matches("update", "services") {
@@ -616,7 +616,7 @@ func TestServiceUpdateRequestsLimitsMemory(t *testing.T) {
 	service := createMockServiceWithResources(t, "100m", "64Mi", "1000m", "1024Mi")
 
 	action, updated, _, err := fakeServiceUpdate(service, []string{
-		"service", "update", "foo", "--requests-memory", "128Mi", "--limits-memory", "2048Mi", "--no-wait"})
+		"service", "update", "foo", "--request", "memory=128Mi", "--limit", "memory=2048Mi", "--no-wait"})
 	if err != nil {
 		t.Fatal(err)
 	} else if !action.Matches("update", "services") {
@@ -655,8 +655,8 @@ func TestServiceUpdateRequestsLimitsCPU_and_Memory(t *testing.T) {
 
 	action, updated, _, err := fakeServiceUpdate(service, []string{
 		"service", "update", "foo",
-		"--requests-cpu", "500m", "--limits-cpu", "2000m",
-		"--requests-memory", "128Mi", "--limits-memory", "2048Mi", "--no-wait"})
+		"--request", "cpu=500m,memory=128Mi",
+		"--limit", "cpu=2000m,memory=2048Mi", "--no-wait"})
 	if err != nil {
 		t.Fatal(err)
 	} else if !action.Matches("update", "services") {

--- a/pkg/kn/flags/podspec_helper.go
+++ b/pkg/kn/flags/podspec_helper.go
@@ -224,31 +224,6 @@ func UpdateResources(spec *corev1.PodSpec, resources corev1.ResourceRequirements
 	return nil
 }
 
-// UpdateResourcesDeprecated updates resources as requested
-func UpdateResourcesDeprecated(spec *corev1.PodSpec, requestsResourceList corev1.ResourceList, limitsResourceList corev1.ResourceList) error {
-	container, err := containerOfPodSpec(spec)
-	if err != nil {
-		return err
-	}
-	if container.Resources.Requests == nil {
-		container.Resources.Requests = corev1.ResourceList{}
-	}
-
-	for k, v := range requestsResourceList {
-		container.Resources.Requests[k] = v
-	}
-
-	if container.Resources.Limits == nil {
-		container.Resources.Limits = corev1.ResourceList{}
-	}
-
-	for k, v := range limitsResourceList {
-		container.Resources.Limits[k] = v
-	}
-
-	return nil
-}
-
 // UpdateServiceAccountName updates the service account name used for the corresponding knative service
 func UpdateServiceAccountName(spec *corev1.PodSpec, serviceAccountName string) {
 	serviceAccountName = strings.TrimSpace(serviceAccountName)


### PR DESCRIPTION
## Description

This PR removes `--requests-cpu,--requests-memory,--limits-cpu,--limits-memory` that should be deprecated already per code comment:
```
// TODO: Flag marked deprecated in release v0.15.0, remove in release v0.18.0
```


@navidshaikh @rhuss @maximilien @daisy-ycguo @itsmurugappan 
If there's any reason or support concern that those flags might be still used/useful, please bring it up.



<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Remove `--requests-cpu,--requests-memory,--limits-cpu,--limits-memory`

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes N/A

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
