### PR TITLE
Embed the namespace in request body while creating channels

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,16 @@
 | https://github.com/knative/client/pull/[#]
 ////
 
+### Unreleased
+[cols="1,10,3", options="header", width="100%"]
+|===
+| | Description | PR
+
+| 🐛
+| Embed the namespace in request body while creating channels
+| https://github.com/knative/client/pull/1117[#1117]
+|===
+
 ### v0.19.0 (2020-11-11)
 [cols="1,10,3", options="header", width="100%"]
 |===

--- a/pkg/kn/commands/channel/channel_test.go
+++ b/pkg/kn/commands/channel/channel_test.go
@@ -76,6 +76,6 @@ func cleanupChannelMockClient() {
 	channelClientFactory = nil
 }
 
-func createChannel(name string, gvk *schema.GroupVersionKind) *v1beta1.Channel {
-	return clientv1beta1.NewChannelBuilder(name).Type(gvk).Build()
+func createChannel(name, namespace string, gvk *schema.GroupVersionKind) *v1beta1.Channel {
+	return clientv1beta1.NewChannelBuilder(name, namespace).Type(gvk).Build()
 }

--- a/pkg/kn/commands/channel/create.go
+++ b/pkg/kn/commands/channel/create.go
@@ -60,7 +60,7 @@ func NewChannelCreateCommand(p *commands.KnParams) *cobra.Command {
 				return err
 			}
 
-			cb := knmessagingv1beta1.NewChannelBuilder(name)
+			cb := knmessagingv1beta1.NewChannelBuilder(name, namespace)
 
 			if cmd.Flag("type").Changed {
 				gvk, err := ctypeFlags.Parse()

--- a/pkg/kn/commands/channel/create_test.go
+++ b/pkg/kn/commands/channel/create_test.go
@@ -43,7 +43,7 @@ func TestCreateChannelErrorCaseTypeFormat(t *testing.T) {
 func TestCreateChannelDefaultChannel(t *testing.T) {
 	cClient := v1beta1.NewMockKnChannelsClient(t)
 	cRecorder := cClient.Recorder()
-	cRecorder.CreateChannel(createChannel("pipe", nil), nil)
+	cRecorder.CreateChannel(createChannel("pipe", "default", nil), nil)
 	out, err := executeChannelCommand(cClient, "create", "pipe")
 	assert.NilError(t, err, "channel should be created")
 	assert.Assert(t, util.ContainsAll(out, "created", "pipe", "default"))
@@ -53,7 +53,7 @@ func TestCreateChannelDefaultChannel(t *testing.T) {
 func TestCreateChannelWithTypeFlagInMemoryChannel(t *testing.T) {
 	cClient := v1beta1.NewMockKnChannelsClient(t)
 	cRecorder := cClient.Recorder()
-	cRecorder.CreateChannel(createChannel("pipe", &schema.GroupVersionKind{Group: "messaging.knative.dev", Version: "v1beta1", Kind: "InMemoryChannel"}), nil)
+	cRecorder.CreateChannel(createChannel("pipe", "default", &schema.GroupVersionKind{Group: "messaging.knative.dev", Version: "v1beta1", Kind: "InMemoryChannel"}), nil)
 	out, err := executeChannelCommand(cClient, "create", "pipe", "--type", "imcv1beta1")
 	assert.NilError(t, err, "channel should be created")
 	assert.Assert(t, util.ContainsAll(out, "created", "pipe", "default"))

--- a/pkg/kn/commands/channel/describe_test.go
+++ b/pkg/kn/commands/channel/describe_test.go
@@ -45,7 +45,7 @@ func TestDescribeChannelErrorCaseNotFound(t *testing.T) {
 func TestDescribeChannel(t *testing.T) {
 	cClient := v1beta1.NewMockKnChannelsClient(t)
 	cRecorder := cClient.Recorder()
-	cRecorder.GetChannel("pipe", createChannel("pipe", &schema.GroupVersionKind{Group: "messaging.knative.dev", Version: "v1beta1", Kind: "InMemoryChannel"}), nil)
+	cRecorder.GetChannel("pipe", createChannel("pipe", "default", &schema.GroupVersionKind{Group: "messaging.knative.dev", Version: "v1beta1", Kind: "InMemoryChannel"}), nil)
 	out, err := executeChannelCommand(cClient, "describe", "pipe")
 	assert.NilError(t, err, "channel should be described")
 	assert.Assert(t, util.ContainsAll(out, "messaging.knative.dev", "v1beta1", "InMemoryChannel", "pipe"))

--- a/pkg/kn/commands/channel/list_test.go
+++ b/pkg/kn/commands/channel/list_test.go
@@ -41,8 +41,8 @@ func TestChannelList(t *testing.T) {
 	cRecorder := cClient.Recorder()
 	clist := &messagingv1beta1.ChannelList{}
 	clist.Items = []messagingv1beta1.Channel{
-		*createChannel("c0", &schema.GroupVersionKind{Group: "messaging.knative.dev", Version: "v1beta1", Kind: "InMemoryChannel"}),
-		*createChannel("c1", &schema.GroupVersionKind{Group: "messaging.knative.dev", Version: "v1beta1", Kind: "InMemoryChannel"}),
+		*createChannel("c0", "default", &schema.GroupVersionKind{Group: "messaging.knative.dev", Version: "v1beta1", Kind: "InMemoryChannel"}),
+		*createChannel("c1", "default", &schema.GroupVersionKind{Group: "messaging.knative.dev", Version: "v1beta1", Kind: "InMemoryChannel"}),
 	}
 	cRecorder.ListChannel(clist, nil)
 	out, err := executeChannelCommand(cClient, "list")

--- a/pkg/messaging/v1beta1/channels_client.go
+++ b/pkg/messaging/v1beta1/channels_client.go
@@ -122,10 +122,11 @@ type ChannelBuilder struct {
 }
 
 // NewChannelBuilder for building Channel object
-func NewChannelBuilder(name string) *ChannelBuilder {
+func NewChannelBuilder(name, namespace string) *ChannelBuilder {
 	return &ChannelBuilder{channel: &v1beta1.Channel{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:      name,
+			Namespace: namespace,
 		},
 	}}
 }


### PR DESCRIPTION
## Description
 Embed the namespace in request body while creating channels
 since on the eventing side, defaulting for channel isnt picking
 the namespace from the context (see https://github.com/knative/eventing/issues/4514)

 workaround for #1100
 this changeset should be reverted when eventing#4514 is resolved

## Changes
- Add namespace in the channel object meta while creating the channels

## Reference
workaround for #1100 and https://github.com/knative/eventing/issues/4514

