### PR TITLE
Fix a few more occurrences of divisive language

### DIFF
--- a/cmd/kn/main.go
+++ b/cmd/kn/main.go
@@ -73,14 +73,14 @@ func run(args []string) error {
 	}
 
 	// temporary setting to parse all flags
-	rootCmd.FParseErrWhitelist = cobra.FParseErrWhitelist{UnknownFlags: true}
+	rootCmd.FParseErrWhitelist = cobra.FParseErrWhitelist{UnknownFlags: true} // wokeignore:rule=whitelist // TODO(#1031)
 	// Strip of all flags to get the non-flag commands only
 	commands, err := stripFlags(rootCmd, args)
 	if err != nil {
 		return err
 	}
 	// reset the temporary setting
-	rootCmd.FParseErrWhitelist = cobra.FParseErrWhitelist{UnknownFlags: false}
+	rootCmd.FParseErrWhitelist = cobra.FParseErrWhitelist{UnknownFlags: false} // wokeignore:rule=whitelist // TODO(#1031)
 
 	// Find plugin with the commands arguments
 	plugin, err := pluginManager.FindPlugin(commands)

--- a/cmd/kn/main_test.go
+++ b/cmd/kn/main_test.go
@@ -160,7 +160,7 @@ func TestUnknownCommands(t *testing.T) {
 	for _, d := range data {
 		args := append([]string{"kn"}, d.givenCmdArgs...)
 		rootCmd, err := root.NewRootCommand(nil)
-		rootCmd.FParseErrWhitelist = cobra.FParseErrWhitelist{UnknownFlags: true}
+		rootCmd.FParseErrWhitelist = cobra.FParseErrWhitelist{UnknownFlags: true} // wokeignore:rule=whitelist // TODO(#1031)
 		os.Args = args
 		assert.NilError(t, err)
 		err = validateRootCommand(rootCmd)
@@ -220,7 +220,7 @@ func TestStripFlags(t *testing.T) {
 
 	for i, f := range data {
 		step := fmt.Sprintf("Check %d", i)
-		cmd := &cobra.Command{FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true}}
+		cmd := &cobra.Command{FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true}} // wokeignore:rule=whitelist // TODO(#1031)
 		config.AddBootstrapFlags(cmd.Flags())
 		commands, err := stripFlags(cmd, f.givenArgs)
 		assert.DeepEqual(t, commands, f.expectedCommands)

--- a/pkg/kn/commands/options/options.go
+++ b/pkg/kn/commands/options/options.go
@@ -37,7 +37,7 @@ kn options`,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		// Allow all options
-		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true}, // wokeignore:rule=whitelist // TODO(#1031)
 	}
 	cmd.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
 		return errors.Errorf("%s for '%s'", err.Error(), c.CommandPath())

--- a/pkg/kn/config/config.go
+++ b/pkg/kn/config/config.go
@@ -104,7 +104,7 @@ func BootstrapConfig() error {
 	// initialize the config file to use (obtained via GlobalConfig.ConfigFile())
 	bootstrapFlagSet := flag.NewFlagSet("kn", flag.ContinueOnError)
 	AddBootstrapFlags(bootstrapFlagSet)
-	bootstrapFlagSet.ParseErrorsWhitelist = flag.ParseErrorsWhitelist{UnknownFlags: true}
+	bootstrapFlagSet.ParseErrorsWhitelist = flag.ParseErrorsWhitelist{UnknownFlags: true} // wokeignore:rule=whitelist // TODO(#1031)
 	bootstrapFlagSet.Usage = func() {}
 	err := bootstrapFlagSet.Parse(os.Args)
 	if err != nil && err != flag.ErrHelp {

--- a/pkg/kn/config/testing_test.go
+++ b/pkg/kn/config/testing_test.go
@@ -20,7 +20,7 @@ import (
 	"gotest.tools/assert"
 )
 
-// Dummy test to keep code coverage quality gate happy.
+// Test to keep code coverage quality gate happy.
 //
 func TestTestConfig(t *testing.T) {
 	cfg := TestConfig{

--- a/pkg/kn/traffic/compute.go
+++ b/pkg/kn/traffic/compute.go
@@ -213,10 +213,10 @@ func errorRepeatingRevision(forFlag string, name string) error {
 }
 
 // verifies if user has repeated @latest field in --tag or --traffic flags
-// verifyInputSanity checks:
+// verifyInput checks:
 // - if user has repeated @latest field in --tag or --traffic flags
 // - if provided traffic portion are integers
-func verifyInputSanity(trafficFlags *flags.Traffic) error {
+func verifyInput(trafficFlags *flags.Traffic) error {
 	var latestRevisionTag = false
 	var sum = 0
 
@@ -271,7 +271,7 @@ func verifyInputSanity(trafficFlags *flags.Traffic) error {
 // Compute takes service traffic targets and updates per given traffic flags
 func Compute(cmd *cobra.Command, targets []servingv1.TrafficTarget,
 	trafficFlags *flags.Traffic, serviceName string) ([]servingv1.TrafficTarget, error) {
-	err := verifyInputSanity(trafficFlags)
+	err := verifyInput(trafficFlags)
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +293,7 @@ func Compute(cmd *cobra.Command, targets []servingv1.TrafficTarget,
 	}
 
 	for _, each := range trafficFlags.RevisionsTags {
-		revision, tag, _ := splitByEqualSign(each) // err is checked in verifyInputSanity
+		revision, tag, _ := splitByEqualSign(each) // err is checked in verifyInput
 
 		// Second precedence: Tag latestRevision
 		if revision == latestRevisionRef {
@@ -338,8 +338,8 @@ func Compute(cmd *cobra.Command, targets []servingv1.TrafficTarget,
 
 		for _, each := range trafficFlags.RevisionsPercentages {
 			// revisionRef works here as either revision or tag as either can be specified on CLI
-			revisionRef, percent, _ := splitByEqualSign(each)  // err is verified in verifyInputSanity
-			percentInt, _ := strconv.ParseInt(percent, 10, 64) // percentInt (for int) is verified in verifyInputSanity
+			revisionRef, percent, _ := splitByEqualSign(each)  // err is verified in verifyInput
+			percentInt, _ := strconv.ParseInt(percent, 10, 64) // percentInt (for int) is verified in verifyInput
 
 			// fourth precedence: set traffic for latest revision
 			if revisionRef == latestRevisionRef {

--- a/pkg/serving/v1/client_test.go
+++ b/pkg/serving/v1/client_test.go
@@ -56,7 +56,7 @@ func TestGetService(t *testing.T) {
 		func(a clienttesting.Action) (bool, runtime.Object, error) {
 			service := newService(serviceName)
 			name := a.(clienttesting.GetAction).GetName()
-			// Sanity check
+
 			assert.Assert(t, name != "")
 			assert.Equal(t, testNamespace, a.GetNamespace())
 			if name == serviceName {
@@ -192,7 +192,7 @@ func TestDeleteService(t *testing.T) {
 	serving.AddReactor("delete", "services",
 		func(a clienttesting.Action) (bool, runtime.Object, error) {
 			name := a.(clienttesting.DeleteAction).GetName()
-			// Sanity check
+
 			assert.Assert(t, name != "")
 			assert.Equal(t, testNamespace, a.GetNamespace())
 			if name == serviceName {
@@ -244,7 +244,7 @@ func TestGetRevision(t *testing.T) {
 		func(a clienttesting.Action) (bool, runtime.Object, error) {
 			revision := newRevision(revisionName)
 			name := a.(clienttesting.GetAction).GetName()
-			// Sanity check
+
 			assert.Assert(t, name != "")
 			assert.Equal(t, testNamespace, a.GetNamespace())
 			if name == revisionName {
@@ -334,7 +334,7 @@ func TestGetRoute(t *testing.T) {
 		func(a clienttesting.Action) (bool, runtime.Object, error) {
 			route := newRoute(routeName)
 			name := a.(clienttesting.GetAction).GetName()
-			// Sanity check
+
 			assert.Assert(t, name != "")
 			assert.Equal(t, testNamespace, a.GetNamespace())
 			if name == routeName {
@@ -497,7 +497,7 @@ func TestGetConfiguration(t *testing.T) {
 		func(a clienttesting.Action) (bool, runtime.Object, error) {
 			configuration := &servingv1.Configuration{ObjectMeta: metav1.ObjectMeta{Name: configName, Namespace: testNamespace}}
 			name := a.(clienttesting.GetAction).GetName()
-			// Sanity check
+
 			assert.Assert(t, name != "")
 			assert.Equal(t, testNamespace, a.GetNamespace())
 			if name == configName {

--- a/pkg/util/logging_http_transport_test.go
+++ b/pkg/util/logging_http_transport_test.go
@@ -27,11 +27,11 @@ import (
 	"gotest.tools/assert"
 )
 
-type dummyTransport struct {
+type fakeTransport struct {
 	requestDump string
 }
 
-func (d *dummyTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+func (d *fakeTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	dump, err := httputil.DumpRequest(r, true)
 	if err != nil {
 		return nil, fmt.Errorf("dumping request: %v", err)
@@ -53,7 +53,7 @@ func (d *errorTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 
 func TestWritesRequestResponse(t *testing.T) {
 	out := &bytes.Buffer{}
-	dt := &dummyTransport{}
+	dt := &fakeTransport{}
 	transport := NewLoggingTransportWithStream(dt, out)
 
 	body := "{this: is, the: body, of: [the, request]}"
@@ -79,7 +79,7 @@ func TestWritesRequestResponse(t *testing.T) {
 
 func TestElideAuthorizationHeader(t *testing.T) {
 	out := &bytes.Buffer{}
-	transport := NewLoggingTransportWithStream(&dummyTransport{}, out)
+	transport := NewLoggingTransportWithStream(&fakeTransport{}, out)
 	req, _ := http.NewRequest("GET", "http://example.com", nil)
 	req.Header.Set("X-Normal-Header", "la la normal text")
 	req.Header.Set("Authorization", "Bearer: SECRET")


### PR DESCRIPTION
As per title.

- Flagging all whitespace occurrences with a TODO.
- Removing "dummy" and "sanity check".