### PR TITLE
Run e2e CI job against eventing v0.19.1 since nightly is broken

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -35,6 +35,8 @@ source $(dirname $0)/common.sh
 # Add local dir to have access to built kn
 export PATH=$PATH:${REPO_ROOT_DIR}
 
+# Temp fix until eventing nightly is fixed
+export KNATIVE_EVENTING_VERSION="0.19.1"
 
 run() {
   # Create cluster


### PR DESCRIPTION
The ping source update for sink isnt working as expected.
see https://github.com/knative/eventing/issues/4584