### PR TITLE
Add machine readable output (-o flag) to kn source apiserver describe

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,10 @@
 | | Description | PR
 
 | 🐛
+| Add machine readable output (-o flag) to kn source apiserver describe
+| https://github.com/knative/client/pull/1146[#1146]
+
+| 🐛
 | Fix a race condition when using Kubernetes watches
 | https://github.com/knative/client/pull/1113[#1113]
 

--- a/docs/cmd/kn_source_apiserver_describe.md
+++ b/docs/cmd/kn_source_apiserver_describe.md
@@ -14,16 +14,22 @@ kn source apiserver describe NAME
 
 ```
 
-  # Describe an ApiServer source with name 'k8sevents'
+  # Describe an api-server source with name 'k8sevents'
   kn source apiserver describe k8sevents
+
+  # Describe an api-server source with name 'k8sevents' in YAML format
+  kn source apiserver describe k8sevents -o yaml
 ```
 
 ### Options
 
 ```
-  -h, --help               help for describe
-  -n, --namespace string   Specify the namespace to operate in.
-  -v, --verbose            More output.
+      --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
+  -h, --help                          help for describe
+  -n, --namespace string              Specify the namespace to operate in.
+  -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
+      --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
+  -v, --verbose                       More output.
 ```
 
 ### Options inherited from parent commands

--- a/pkg/kn/commands/source/apiserver/describe_test.go
+++ b/pkg/kn/commands/source/apiserver/describe_test.go
@@ -50,6 +50,23 @@ func TestSimpleDescribe(t *testing.T) {
 	apiServerRecorder.Validate()
 }
 
+func TestDescribeMachineReadable(t *testing.T) {
+	apiServerClient := v1alpha2.NewMockKnAPIServerSourceClient(t, "mynamespace")
+
+	apiServerRecorder := apiServerClient.Recorder()
+	sampleSource := createAPIServerSource("testsource", "Event", "v1", "testsa", "Reference", map[string]string{"foo": "bar"}, createSinkv1("testsvc", "default"))
+	sampleSource.APIVersion = "sources.knative.dev/v1"
+	sampleSource.Kind = "ApiServerSource"
+	sampleSource.Namespace = "mynamespace"
+	apiServerRecorder.GetAPIServerSource("testsource", sampleSource, nil)
+
+	out, err := executeAPIServerSourceCommand(apiServerClient, nil, "describe", "testsource", "-o", "yaml")
+	assert.NilError(t, err)
+	assert.Assert(t, util.ContainsAll(out, "kind: ApiServerSource", "spec:", "status:", "metadata:"))
+
+	apiServerRecorder.Validate()
+}
+
 func TestDescribeError(t *testing.T) {
 	apiServerClient := v1alpha2.NewMockKnAPIServerSourceClient(t, "mynamespace")
 

--- a/pkg/sources/v1alpha2/apiserver_client.go
+++ b/pkg/sources/v1alpha2/apiserver_client.go
@@ -74,7 +74,10 @@ func (c *apiServerSourcesClient) GetAPIServerSource(name string) (*v1alpha2.ApiS
 	if err != nil {
 		return nil, knerrors.GetError(err)
 	}
-
+	err = updateSourceGVK(apiSource)
+	if err != nil {
+		return nil, err
+	}
 	return apiSource, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Arghya Sadhu <arghya88@gmail.com>


## Description

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

*Add machine readable output (-o flag) to kn source apiserver describe

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #1096

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
