### PR TITLE
Permit revision name in apply

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1112,5 +1112,9 @@ Ignore PRs:
 |===
 | | Description | PR
 
+| 🐛
+| Permit revision name in `service apply`
+| https://github.com/knative/client/pull/1185[#1185]
+
 |===
 ////

--- a/pkg/kn/commands/service/apply.go
+++ b/pkg/kn/commands/service/apply.go
@@ -66,7 +66,6 @@ func NewServiceApplyCommand(p *commands.KnParams) *cobra.Command {
 			}
 
 			var service *servingv1.Service
-			applyFlags.RevisionName = ""
 			if applyFlags.Filename == "" {
 				service, err = constructService(cmd, applyFlags, name, namespace)
 			} else {


### PR DESCRIPTION
## Description

Permit using `--revision-name` with the `apply` command

## Changes

* Don't zero out the revision name field

## Reference

Fixes #1184

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
