### PR TITLE
chore: Add gitops feature to changelog

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -112,6 +112,11 @@
 | 🐛
 | Embed the namespace in request body while creating channels
 | https://github.com/knative/client/pull/1117[#1117]
+
+| 🎁
+| Add `--target` flag to support gitops mode (experimental)
+| https://github.com/knative/client/pull/1122[#1122]
+
 |===
 
 ### v0.19.0 (2020-11-11)

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -93,7 +93,7 @@ kn service create NAME --image IMAGE
       --scale-max int                     Maximum number of replicas.
       --scale-min int                     Minimum number of replicas.
       --service-account string            Service account name to set. An empty argument ("") clears the service account. The referenced service account must exist in the service's namespace.
-      --target string                     work on local directory instead of a remote cluster
+      --target string                     Work on local directory instead of a remote cluster (experimental)
       --user int                          The user ID to run the container (e.g., 1001).
       --volume stringArray                Add a volume from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret: or sc:). Example: --volume myvolume=cm:myconfigmap or --volume myvolume=secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --volume myvolume-.
       --wait                              Wait for 'service create' operation to be completed. (default true)

--- a/docs/cmd/kn_service_delete.md
+++ b/docs/cmd/kn_service_delete.md
@@ -36,7 +36,7 @@ kn service delete NAME [NAME ...]
   -h, --help               help for delete
   -n, --namespace string   Specify the namespace to operate in.
       --no-wait            Do not wait for 'service delete' operation to be completed. (default true)
-      --target string      work on local directory instead of a remote cluster
+      --target string      Work on local directory instead of a remote cluster (experimental)
       --wait               Wait for 'service delete' operation to be completed.
       --wait-timeout int   Seconds to wait before giving up on waiting for service to be deleted. (default 600)
 ```

--- a/docs/cmd/kn_service_describe.md
+++ b/docs/cmd/kn_service_describe.md
@@ -36,7 +36,7 @@ kn service describe NAME
   -h, --help                          help for describe
   -n, --namespace string              Specify the namespace to operate in.
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file|url.
-      --target string                 work on local directory instead of a remote cluster
+      --target string                 Work on local directory instead of a remote cluster (experimental)
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
   -v, --verbose                       More output.
 ```

--- a/docs/cmd/kn_service_list.md
+++ b/docs/cmd/kn_service_list.md
@@ -39,7 +39,7 @@ kn service list
   -n, --namespace string              Specify the namespace to operate in.
       --no-headers                    When using the default output format, don't print headers (default: print headers).
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
-      --target string                 work on local directory instead of a remote cluster
+      --target string                 Work on local directory instead of a remote cluster (experimental)
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```
 

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -77,7 +77,7 @@ kn service update NAME
       --scale-min int                     Minimum number of replicas.
       --service-account string            Service account name to set. An empty argument ("") clears the service account. The referenced service account must exist in the service's namespace.
       --tag strings                       Set tag (format: --tag revisionRef=tagName) where revisionRef can be a revision or '@latest' string representing latest ready revision. This flag can be specified multiple times.
-      --target string                     work on local directory instead of a remote cluster
+      --target string                     Work on local directory instead of a remote cluster (experimental)
       --traffic strings                   Set traffic distribution (format: --traffic revisionRef=percent) where revisionRef can be a revision or a tag or '@latest' string representing latest ready revision. This flag can be given multiple times with percent summing up to 100%.
       --untag strings                     Untag revision (format: --untag tagName). This flag can be specified multiple times.
       --user int                          The user ID to run the container (e.g., 1001).

--- a/pkg/kn/commands/human_readable_flags.go
+++ b/pkg/kn/commands/human_readable_flags.go
@@ -117,5 +117,5 @@ func TranslateTimestampSince(timestamp metav1.Time) string {
 
 // AddGitOpsFlags adds flags to enable gitops mode
 func AddGitOpsFlags(flags *pflag.FlagSet) {
-	flags.String("target", "", "work on local directory instead of a remote cluster")
+	flags.String("target", "", "Work on local directory instead of a remote cluster (experimental)")
 }


### PR DESCRIPTION
## Description

Per review comment in PR #1122.

## Changes


* Add `--target` flag aka gitops feature to changelog entry
* Add `experimental` suffix to `--target` flag

/cc @rhuss @navidshaikh @itsmurugappan 