### PR TITLE
Do not print serviceUID and configUID labels in service export result

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,16 @@
 | https://github.com/knative/client/pull/[#]
 ////
 
+## Unreleased
+[cols="1,10,3", options="header", width="100%"]
+|===
+| | Description | PR
+
+| 🐣
+| Do not print serviceUID and configUID labels in service export result
+| https://github.com/knative/client/pull/1194[#1194]
+|===
+
 ## v0.20.0 (2021-01-14)
 [cols="1,10,3", options="header", width="100%"]
 |===

--- a/pkg/kn/commands/service/export.go
+++ b/pkg/kn/commands/service/export.go
@@ -34,20 +34,25 @@ import (
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
-var IGNORED_SERVICE_ANNOTATIONS = []string{
+// IgnoredServiceAnnotations defines the annotation keys which should be
+// removed from service annotations before export
+var IgnoredServiceAnnotations = []string{
 	"serving.knative.dev/creator",
 	"serving.knative.dev/lastModifier",
 	"kubectl.kubernetes.io/last-applied-configuration",
 }
-var IGNORED_REVISION_ANNOTATIONS = []string{
+
+// IgnoredRevisionAnnotations defines the annotation keys which should be
+// removed from revision annotations before export
+var IgnoredRevisionAnnotations = []string{
 	"serving.knative.dev/lastPinned",
 	"serving.knative.dev/creator",
 	"serving.knative.dev/routingStateModified",
 }
 
-// IGNORED_SERVICE_LABELS defines the label keys which should be removed
-// from service labels before exporting it
-var IGNORED_SERVICE_LABELS = []string{
+// IgnoredServiceLabels defines the label keys which should be removed
+// from service labels before export
+var IgnoredServiceLabels = []string{
 	"serving.knative.dev/configUID",
 	"serving.knative.dev/serviceUID",
 }
@@ -331,19 +336,19 @@ func revisionListSortFunc(revisionList *servingv1.RevisionList) func(i int, j in
 }
 
 func stripIgnoredAnnotationsFromService(svc *servingv1.Service) {
-	for _, annotation := range IGNORED_SERVICE_ANNOTATIONS {
+	for _, annotation := range IgnoredServiceAnnotations {
 		delete(svc.ObjectMeta.Annotations, annotation)
 	}
 }
 
 func stripIgnoredAnnotationsFromRevision(revision *servingv1.Revision) {
-	for _, annotation := range IGNORED_REVISION_ANNOTATIONS {
+	for _, annotation := range IgnoredRevisionAnnotations {
 		delete(revision.ObjectMeta.Annotations, annotation)
 	}
 }
 
 func stripIgnoredLabelsFromService(svc *servingv1.Service) {
-	for _, label := range IGNORED_SERVICE_LABELS {
+	for _, label := range IgnoredServiceLabels {
 		delete(svc.ObjectMeta.Labels, label)
 	}
 }

--- a/pkg/kn/commands/service/export.go
+++ b/pkg/kn/commands/service/export.go
@@ -45,6 +45,13 @@ var IGNORED_REVISION_ANNOTATIONS = []string{
 	"serving.knative.dev/routingStateModified",
 }
 
+// IGNORED_SERVICE_LABELS defines the label keys which should be removed
+// from service labels before exporting it
+var IGNORED_SERVICE_LABELS = []string{
+	"serving.knative.dev/configUID",
+	"serving.knative.dev/serviceUID",
+}
+
 // NewServiceExportCommand returns a new command for exporting a service.
 func NewServiceExportCommand(p *commands.KnParams) *cobra.Command {
 
@@ -161,6 +168,7 @@ func exportLatestService(latestSvc *servingv1.Service, withRoutes bool) *serving
 	}
 
 	stripIgnoredAnnotationsFromService(&exportedSvc)
+	stripIgnoredLabelsFromService(&exportedSvc)
 
 	return &exportedSvc
 }
@@ -331,5 +339,11 @@ func stripIgnoredAnnotationsFromService(svc *servingv1.Service) {
 func stripIgnoredAnnotationsFromRevision(revision *servingv1.Revision) {
 	for _, annotation := range IGNORED_REVISION_ANNOTATIONS {
 		delete(revision.ObjectMeta.Annotations, annotation)
+	}
+}
+
+func stripIgnoredLabelsFromService(svc *servingv1.Service) {
+	for _, label := range IGNORED_SERVICE_LABELS {
+		delete(svc.ObjectMeta.Labels, label)
 	}
 }

--- a/pkg/kn/commands/service/export.go
+++ b/pkg/kn/commands/service/export.go
@@ -57,6 +57,13 @@ var IgnoredServiceLabels = []string{
 	"serving.knative.dev/serviceUID",
 }
 
+// IgnoredRevisionLabels defines the label keys which should be removed
+// from revision labels before export
+var IgnoredRevisionLabels = []string{
+	"serving.knative.dev/configUID",
+	"serving.knative.dev/serviceUID",
+}
+
 // NewServiceExportCommand returns a new command for exporting a service.
 func NewServiceExportCommand(p *commands.KnParams) *cobra.Command {
 
@@ -174,7 +181,6 @@ func exportLatestService(latestSvc *servingv1.Service, withRoutes bool) *serving
 
 	stripIgnoredAnnotationsFromService(&exportedSvc)
 	stripIgnoredLabelsFromService(&exportedSvc)
-
 	return &exportedSvc
 }
 
@@ -190,6 +196,7 @@ func exportRevision(revision *servingv1.Revision) servingv1.Revision {
 
 	exportedRevision.Spec = revision.Spec
 	stripIgnoredAnnotationsFromRevision(&exportedRevision)
+	stripIgnoredLabelsFromRevision(&exportedRevision)
 	return exportedRevision
 }
 
@@ -350,5 +357,11 @@ func stripIgnoredAnnotationsFromRevision(revision *servingv1.Revision) {
 func stripIgnoredLabelsFromService(svc *servingv1.Service) {
 	for _, label := range IgnoredServiceLabels {
 		delete(svc.ObjectMeta.Labels, label)
+	}
+}
+
+func stripIgnoredLabelsFromRevision(rev *servingv1.Revision) {
+	for _, label := range IgnoredRevisionLabels {
+		delete(rev.ObjectMeta.Labels, label)
 	}
 }


### PR DESCRIPTION
## Description
 While exporting the service using `service export` command, ignore
 the service labels with keys 'configUID' and `configUID`

## Changes
* Strip the mentioned labels from service before export

## Reference
see https://github.com/knative/serving/pull/10539 for further details

/lint

