### PR TITLE
Rename configUID label to ConfigurationUID 

### DIFF
--- a/pkg/kn/commands/service/export.go
+++ b/pkg/kn/commands/service/export.go
@@ -53,14 +53,14 @@ var IgnoredRevisionAnnotations = []string{
 // IgnoredServiceLabels defines the label keys which should be removed
 // from service labels before export
 var IgnoredServiceLabels = []string{
-	"serving.knative.dev/configUID",
+	"serving.knative.dev/configurationUID",
 	"serving.knative.dev/serviceUID",
 }
 
 // IgnoredRevisionLabels defines the label keys which should be removed
 // from revision labels before export
 var IgnoredRevisionLabels = []string{
-	"serving.knative.dev/configUID",
+	"serving.knative.dev/configurationUID",
 	"serving.knative.dev/serviceUID",
 }
 

--- a/test/e2e/service_export_test.go
+++ b/test/e2e/service_export_test.go
@@ -227,7 +227,7 @@ func TestServiceExport(t *testing.T) {
 		))),
 	), "--with-revisions", "--mode", "export", "-o", "yaml")
 
-	t.Log("create and export service 'foo' and verify that serviceUID and configUID labels are absent")
+	t.Log("create and export service 'foo' and verify that serviceUID and configurationUID labels are absent")
 	serviceCreateWithOptions(r, "foo")
 	output := serviceExportOutput(r, "foo", "-o", "json")
 	actSvc := servingv1.Service{}
@@ -235,11 +235,11 @@ func TestServiceExport(t *testing.T) {
 	assert.NilError(t, err)
 	_, ok := actSvc.Labels["serving.knative.dev/serviceUID"]
 	assert.Equal(t, ok, false)
-	_, ok = actSvc.Labels["serving.knative.dev/configUID"]
+	_, ok = actSvc.Labels["serving.knative.dev/configurationUID"]
 	assert.Equal(t, ok, false)
 	_, ok = actSvc.Spec.ConfigurationSpec.Template.Labels["serving.knative.dev/servingUID"]
 	assert.Equal(t, ok, false)
-	_, ok = actSvc.Spec.ConfigurationSpec.Template.Labels["serving.knative.dev/configUID"]
+	_, ok = actSvc.Spec.ConfigurationSpec.Template.Labels["serving.knative.dev/configurationUID"]
 	assert.Equal(t, ok, false)
 }
 


### PR DESCRIPTION
## Description
Rename `configuUID` label to `ConfigurationUID`  followed up by https://github.com/knative/serving/pull/10579

## Changes
- Rename the label to be removed from service export result; `configUID` --> `ConfigurationUID`
