### PR TITLE
fix: Fix deprecated ServiceName in revision describe test

### DIFF
--- a/pkg/kn/commands/revision/describe_test.go
+++ b/pkg/kn/commands/revision/describe_test.go
@@ -76,9 +76,6 @@ func TestDescribeRevisionYaml(t *testing.T) {
 				}},
 			},
 		},
-		Status: servingv1.RevisionStatus{
-			ServiceName: "foo-service",
-		},
 	}
 
 	action, data, err := fakeRevision([]string{"revision", "describe", "test-rev", "-o", "yaml"}, &expectedRevision)


### PR DESCRIPTION
## Description

This fix should unblock auto-upgrade PR that's changing `RevisionStatus.ServiceName` to `*.DeprecatedServiceName`. It seems to have no value in the affected unit test.

https://github.com/knative/client/pull/1207/files#diff-000f7df82089c9fe1ae3991339f7742aa78447291609f99bd15fc4ac3a71996fR122-R132

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Remove deprecated field from unit tests

## Reference

Unblocks #1207 
