### PR TITLE
fix: Pin go-openapi/spec version to fix conflict

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,3 +29,5 @@ require (
 	knative.dev/serving v0.20.1-0.20210123202654-e61294b2ca32
 	sigs.k8s.io/yaml v1.2.0
 )
+
+replace github.com/go-openapi => github.com/go-openapi v0.19.3

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -891,3 +891,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 ## explicit
 sigs.k8s.io/yaml
+# github.com/go-openapi => github.com/go-openapi v0.19.3


### PR DESCRIPTION
## Description

Latest Serving update will bring incompatible version, for more details see [the comment](https://github.com/knative/client/pull/1207#issuecomment-770866919).

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Pin `github.com/go-openapi/spec` version to `v0.19.3`
  * The same version is used in `k8s.io/cli-runtime@v0.19.7 github.com/go-openapi/spec@v0.19.3`.


## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Unblocks #1207 