### PR TITLE
Allow to specify build platform for test images

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -85,6 +85,10 @@ To run the script for all end to end test images:
 A docker tag may be passed as an optional parameter. This can be useful on
 Minikube in tandem with the `--tag` [flag](#using-a-docker-tag):
 
+`PLATFORM` environment variable is optional. If it is specified, test images
+will be built for specific hardware architecture, according to its value
+(for instance,`linux/arm64`).
+
 ```bash
 eval $(minikube docker-env)
 ./test/upload-test-images.sh any-old-tag

--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -29,13 +29,21 @@ function upload_test_images() {
     tag_option="--tags $docker_tag,latest"
   fi
 
+  # If PLATFORM environment variable is specified, then images will be built for
+  # specific hardware architecture.
+  # Example of the variable values - "linux/arm64", "linux/s390x".
+  local platform=""
+  if [ -n "${PLATFORM}" ]; then
+    platform="--platform ${PLATFORM}"
+  fi
+
   # ko resolve is being used for the side-effect of publishing images,
   # so the resulting yaml produced is ignored.
   # We limit the number of concurrent builds (jobs) to avoid OOMs.
-  ko resolve --jobs=4 ${tag_option} -RBf "${image_dir}" > /dev/null
+  ko resolve --jobs=4 ${platform} ${tag_option} -RBf "${image_dir}" > /dev/null
 
   #build and publish images from vendor directory
-  ko resolve --jobs=4 ${tag_option} -RBf "${vendor_image_dir}" > /dev/null
+  ko resolve --jobs=4 ${platform} ${tag_option} -RBf "${vendor_image_dir}" > /dev/null
 }
 
 : ${KO_DOCKER_REPO:?"You must set 'KO_DOCKER_REPO'"}


### PR DESCRIPTION
## Description

<!-- Please add a short summary about what the pull request is going to bring on the table -->
This is an echo of the https://github.com/knative/eventing/pull/4763 for client. The test images are built and uploaded without a break on other architectures by specifying a `PLATFORM` env variable.

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Add a description to test/README.md
* Add a local variable `platform` (empty by default) which can be set by an environment variable `PLATFORM` at test/upload-test-images.sh

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
