### PR TITLE
kn export defect to honor mode

### DIFF
--- a/pkg/kn/commands/service/export.go
+++ b/pkg/kn/commands/service/export.go
@@ -140,22 +140,20 @@ func exportService(cmd *cobra.Command, service *servingv1.Service, client client
 		return err
 	}
 
-	switch mode {
-	case ModeReplay:
+	if mode == ModeReplay {
 		svcList, err := exportServiceListForReplay(service.DeepCopy(), client, withRevisions)
 		if err != nil {
 			return err
 		}
 		return printer.PrintObj(svcList, cmd.OutOrStdout())
-	default:
-		knExport, err := exportForKNImport(service.DeepCopy(), client, withRevisions)
-		if err != nil {
-			return err
-		}
-		//print kn export
-		return printer.PrintObj(knExport, cmd.OutOrStdout())
 	}
-	return nil
+	// default is export mode
+	knExport, err := exportForKNImport(service.DeepCopy(), client, withRevisions)
+	if err != nil {
+		return err
+	}
+	//print kn export
+	return printer.PrintObj(knExport, cmd.OutOrStdout())
 }
 
 func exportLatestService(latestSvc *servingv1.Service, withRoutes bool) *servingv1.Service {

--- a/pkg/kn/commands/service/export.go
+++ b/pkg/kn/commands/service/export.go
@@ -65,6 +65,11 @@ var IgnoredRevisionLabels = []string{
 	"serving.knative.dev/serviceUID",
 }
 
+const (
+	ModeReplay = "replay"
+	ModeExport = "export"
+)
+
 // NewServiceExportCommand returns a new command for exporting a service.
 func NewServiceExportCommand(p *commands.KnParams) *cobra.Command {
 
@@ -136,21 +141,19 @@ func exportService(cmd *cobra.Command, service *servingv1.Service, client client
 	}
 
 	switch mode {
-	case "export":
-		knExport, err := exportForKNImport(service.DeepCopy(), client, withRevisions)
-		if err != nil {
-			return err
-		}
-		//print kn export
-		if err := printer.PrintObj(knExport, cmd.OutOrStdout()); err != nil {
-			return err
-		}
-	default:
+	case ModeReplay:
 		svcList, err := exportServiceListForReplay(service.DeepCopy(), client, withRevisions)
 		if err != nil {
 			return err
 		}
 		return printer.PrintObj(svcList, cmd.OutOrStdout())
+	default:
+		knExport, err := exportForKNImport(service.DeepCopy(), client, withRevisions)
+		if err != nil {
+			return err
+		}
+		//print kn export
+		return printer.PrintObj(knExport, cmd.OutOrStdout())
 	}
 	return nil
 }

--- a/pkg/kn/commands/service/export_test.go
+++ b/pkg/kn/commands/service/export_test.go
@@ -69,7 +69,9 @@ func TestServiceExport(t *testing.T) {
 	} {
 		exportServiceTestForReplay(t, &tc)
 		tc.expectedKNExport = libtest.BuildKNExportWithOptions()
-		exportServiceTest(t, &tc)
+		exportServiceTest(t, &tc, true)
+		//test default
+		exportServiceTest(t, &tc, false)
 	}
 }
 
@@ -84,8 +86,12 @@ func exportServiceTestForReplay(t *testing.T, tc *testCase) {
 	assert.DeepEqual(t, tc.latestSvc, &actSvc)
 }
 
-func exportServiceTest(t *testing.T, tc *testCase) {
-	output, err := executeServiceExportCommand(t, tc, "export", tc.latestSvc.ObjectMeta.Name, "--mode", "export", "-o", "json")
+func exportServiceTest(t *testing.T, tc *testCase, addMode bool) {
+	args := []string{"export", tc.latestSvc.ObjectMeta.Name, "-o", "json"}
+	if addMode {
+		args = append(args, []string{"--mode", "export"}...)
+	}
+	output, err := executeServiceExportCommand(t, tc, args...)
 	assert.NilError(t, err)
 
 	tc.expectedKNExport.Spec.Service = *tc.latestSvc

--- a/pkg/kn/commands/service/export_test.go
+++ b/pkg/kn/commands/service/export_test.go
@@ -56,12 +56,6 @@ func TestServiceExportError(t *testing.T) {
 
 	_, err := executeServiceExportCommand(t, tc, "export", tc.latestSvc.ObjectMeta.Name)
 	assert.Error(t, err, "'kn service export' requires output format")
-
-	_, err = executeServiceExportCommand(t, tc, "export", tc.latestSvc.ObjectMeta.Name, "--with-revisions", "-o", "json")
-	assert.Error(t, err, "'kn service export --with-revisions' requires a mode, please specify one of replay|export")
-
-	_, err = executeServiceExportCommand(t, tc, "export", tc.latestSvc.ObjectMeta.Name, "--with-revisions", "--mode", "k8s", "-o", "yaml")
-	assert.Error(t, err, "'kn service export --with-revisions' requires a mode, please specify one of replay|export")
 }
 
 func TestServiceExport(t *testing.T) {

--- a/test/e2e/service_export_test.go
+++ b/test/e2e/service_export_test.go
@@ -60,7 +60,7 @@ func TestServiceExport(t *testing.T) {
 		servingtest.WithConfigSpec(test.BuildConfigurationSpec()),
 		servingtest.WithBYORevisionName("hello-rev1"),
 		test.WithRevisionAnnotations(map[string]string{"client.knative.dev/user-image": pkgtest.ImagePath("helloworld")}),
-	), "-o", "json")
+	), "--mode", "replay", "-o", "json")
 
 	t.Log("update service - add env variable")
 	test.ServiceUpdate(r, "hello", "--env", "a=mouse", "--revision-name", "rev2", "--no-lock-to-digest")
@@ -68,7 +68,7 @@ func TestServiceExport(t *testing.T) {
 		servingtest.WithConfigSpec(test.BuildConfigurationSpec()),
 		servingtest.WithBYORevisionName("hello-rev2"),
 		servingtest.WithEnv(corev1.EnvVar{Name: "a", Value: "mouse"}),
-	), "-o", "json")
+	), "--mode", "replay", "-o", "json")
 
 	t.Log("export service-revision2 with kubernetes-resources")
 	serviceExportWithServiceList(r, "hello", test.BuildServiceListWithOptions(


### PR DESCRIPTION
## Description

Mode is ignored, when --with-revisions flag is not mentioned, this pr makes sure that mode is always honored.

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* "replay" is the default mode
* replay without revisions will print ksvc
* replay with revisions will print ksvc list
* export mode with/without revisions will return knexport type

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #1087 

cc @dsimansk 

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
