### PR TITLE
Drop pkg/errors dependency and replace with stdlib usage

### DIFF
--- a/cmd/kn/main.go
+++ b/cmd/kn/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -22,7 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"knative.dev/client/pkg/kn/config"
@@ -151,7 +151,7 @@ func validatePlugin(root *cobra.Command, plugin plugin.Plugin) error {
 	if err == nil {
 		if !cmd.HasSubCommands() || // a leaf command can't be overridden
 			cmd.HasSubCommands() && len(args) == 0 { // a group can't be overridden either
-			return errors.Errorf("plugin %s is overriding built-in command '%s' which is not allowed", plugin.Path(), strings.Join(plugin.CommandParts(), " "))
+			return fmt.Errorf("plugin %s is overriding built-in command '%s' which is not allowed", plugin.Path(), strings.Join(plugin.CommandParts(), " "))
 		}
 	}
 	return nil
@@ -165,7 +165,7 @@ func validateRootCommand(cmd *cobra.Command) error {
 	if err == nil && foundCmd.HasSubCommands() && len(innerArgs) > 0 {
 		argsWithoutFlags, err := stripFlags(cmd, innerArgs)
 		if len(argsWithoutFlags) > 0 || err != nil {
-			return errors.Errorf("unknown sub-command '%s' for '%s'. Available sub-commands: %s", innerArgs[0], foundCmd.CommandPath(), strings.Join(root.ExtractSubCommandNames(foundCmd.Commands()), ", "))
+			return fmt.Errorf("unknown sub-command '%s' for '%s'. Available sub-commands: %s", innerArgs[0], foundCmd.CommandPath(), strings.Join(root.ExtractSubCommandNames(foundCmd.Commands()), ", "))
 		}
 		// If no args where given (only flags), then fall through to execute the command itself, which leads to
 		// a more appropriate error message

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/gregjones/httpcache v0.0.0-20190212212710-3befbb6ad0cc // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.3.1 // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v1.0.1-0.20200715031239-b95db644ed1c

--- a/pkg/kn/commands/completion/completion.go
+++ b/pkg/kn/commands/completion/completion.go
@@ -15,9 +15,8 @@
 package completion
 
 import (
+	"errors"
 	"os"
-
-	"github.com/pkg/errors"
 
 	"knative.dev/client/pkg/kn/commands"
 

--- a/pkg/kn/commands/options/options.go
+++ b/pkg/kn/commands/options/options.go
@@ -15,7 +15,8 @@
 package options
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"knative.dev/client/pkg/templates"
@@ -40,7 +41,7 @@ kn options`,
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true}, // wokeignore:rule=whitelist // TODO(#1031)
 	}
 	cmd.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
-		return errors.Errorf("%s for '%s'", err.Error(), c.CommandPath())
+		return fmt.Errorf("%s for '%s'", err.Error(), c.CommandPath())
 	})
 	cmd.SetUsageFunc(templates.NewGlobalOptionsFunc())
 	cmd.SetHelpFunc(func(command *cobra.Command, args []string) {

--- a/pkg/kn/commands/plugin/list.go
+++ b/pkg/kn/commands/plugin/list.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"knative.dev/client/pkg/kn/commands"
@@ -67,7 +66,7 @@ func listPlugins(cmd *cobra.Command, flags pluginListFlags) error {
 
 	pluginsFound, err := factory.ListPlugins()
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("cannot list plugins in %s (lookup plugins in $PATH: %t)", factory.PluginsDir(), factory.LookupInPath()))
+		return fmt.Errorf("cannot list plugins in %s (lookup plugins in $PATH: %t): %w", factory.PluginsDir(), factory.LookupInPath(), err)
 	}
 
 	out := cmd.OutOrStdout()
@@ -107,7 +106,7 @@ func listPlugins(cmd *cobra.Command, flags pluginListFlags) error {
 		eaw.PrintWarningsAndErrors(out)
 	}
 	if eaw.HasErrors() {
-		return errors.Errorf("plugin validation errors")
+		return fmt.Errorf("plugin validation errors")
 	}
 	return nil
 }

--- a/pkg/kn/commands/service/apply_mock_test.go
+++ b/pkg/kn/commands/service/apply_mock_test.go
@@ -15,11 +15,11 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"gotest.tools/assert"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/kn/config/config.go
+++ b/pkg/kn/config/config.go
@@ -21,7 +21,6 @@ import (
 	"runtime"
 
 	homedir "github.com/mitchellh/go-homedir"
-	"github.com/pkg/errors"
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
@@ -130,7 +129,7 @@ func BootstrapConfig() error {
 			// No config file to read
 			return nil
 		}
-		return errors.Wrap(err, fmt.Sprintf("cannot stat configfile %s", configFile))
+		return fmt.Errorf("cannot stat configfile %s: %w", configFile, err)
 	}
 
 	viper.SetConfigFile(GlobalConfig.ConfigFile())
@@ -249,8 +248,8 @@ func parseSinkMappings() error {
 	if key != "" {
 		err := viper.UnmarshalKey(key, &globalConfig.sinkMappings)
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("error while parsing sink mappings in configuration file %s",
-				viper.ConfigFileUsed()))
+			return fmt.Errorf("error while parsing sink mappings in configuration file %s: %w",
+				viper.ConfigFileUsed(), err)
 		}
 	}
 	return nil
@@ -261,8 +260,8 @@ func parseChannelTypeMappings() error {
 	if viper.IsSet(keyChannelTypeMappings) {
 		err := viper.UnmarshalKey(keyChannelTypeMappings, &globalConfig.channelTypeMappings)
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("error while parsing channel type mappings in configuration file %s",
-				viper.ConfigFileUsed()))
+			return fmt.Errorf("error while parsing channel type mappings in configuration file %s: %w",
+				viper.ConfigFileUsed(), err)
 		}
 	}
 	return nil

--- a/pkg/kn/plugin/manager.go
+++ b/pkg/kn/plugin/manager.go
@@ -26,7 +26,6 @@ import (
 	"text/template"
 
 	homedir "github.com/mitchellh/go-homedir"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -390,7 +389,7 @@ func findMostSpecificPluginInPath(dir string, parts []string, lookupInPath bool)
 		// Check for the name in plugin directory and PATH (if requested)
 		path, err := findInDirOrPath(name, dir, lookupInPath)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("cannot lookup plugin %s in directory %s (lookup in path: %t)", name, dir, lookupInPath))
+			return nil, fmt.Errorf("cannot lookup plugin %s in directory %s (lookup in path: %t): %w", name, dir, lookupInPath, err)
 		}
 
 		// Found, return it
@@ -440,7 +439,7 @@ func findInDirOrPath(name string, dir string, lookupInPath bool) (string, error)
 			return path, nil
 		}
 		if !os.IsNotExist(err) {
-			return "", errors.Wrap(err, fmt.Sprintf("i/o error while reading %s", path))
+			return "", fmt.Errorf("i/o error while reading %s: %w", path, err)
 		}
 
 		// Check in PATH if requested
@@ -451,7 +450,7 @@ func findInDirOrPath(name string, dir string, lookupInPath bool) (string, error)
 				return path, nil
 			}
 			if execErr, ok := err.(*exec.Error); !ok || execErr.Unwrap() != exec.ErrNotFound {
-				return "", errors.Wrap(err, fmt.Sprintf("error for looking up %s in path", name))
+				return "", fmt.Errorf("error for looking up %s in path: %w", name, err)
 			}
 		}
 	}

--- a/pkg/kn/root/root.go
+++ b/pkg/kn/root/root.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
@@ -125,7 +124,7 @@ func NewRootCommand(helpFuncs *template.FuncMap) (*cobra.Command, error) {
 
 	// Add some command context when flags can not be parsed
 	rootCmd.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
-		return errors.Errorf("%s for '%s'", err.Error(), c.CommandPath())
+		return fmt.Errorf("%s for '%s'", err.Error(), c.CommandPath())
 	})
 
 	// For glog parse error. TOO: Check why this is needed
@@ -138,7 +137,7 @@ func validateCommandStructure(cmd *cobra.Command) error {
 	for _, childCmd := range cmd.Commands() {
 		if childCmd.HasSubCommands() {
 			if childCmd.RunE != nil || childCmd.Run != nil {
-				return errors.Errorf("internal: command group '%s' must not enable any direct logic, only leaf commands are allowed to take actions", childCmd.Name())
+				return fmt.Errorf("internal: command group '%s' must not enable any direct logic, only leaf commands are allowed to take actions", childCmd.Name())
 			}
 
 			subCommands := childCmd.Commands()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -216,7 +216,6 @@ github.com/pelletier/go-toml
 # github.com/peterbourgon/diskv v2.0.1+incompatible
 github.com/peterbourgon/diskv
 # github.com/pkg/errors v0.9.1
-## explicit
 github.com/pkg/errors
 # github.com/prometheus/client_golang v1.9.0
 github.com/prometheus/client_golang/prometheus


### PR DESCRIPTION
## Description

https://github.com/pkg/errors has been mostly subsumed into the stdlib, so there's no reason to use it anymore. Less dependencies, YAY!

/assign @rhuss 