### PR TITLE
Enable errorlint and fix all issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,6 +6,7 @@ run:
 
 linters:
   enable:
+    - errorlint
     - unconvert
     - prealloc
   disable:

--- a/cmd/kn/main.go
+++ b/cmd/kn/main.go
@@ -114,7 +114,7 @@ func run(args []string) error {
 // Get only the args provided but no options
 func stripFlags(rootCmd *cobra.Command, args []string) ([]string, error) {
 	if err := rootCmd.ParseFlags(filterHelpOptions(args)); err != nil {
-		return []string{}, fmt.Errorf("error while parsing flags from args %v: %s", args, err.Error())
+		return []string{}, fmt.Errorf("error while parsing flags from args %v: %w", args, err)
 	}
 	return rootCmd.Flags().Args(), nil
 }

--- a/pkg/dynamic/lib.go
+++ b/pkg/dynamic/lib.go
@@ -50,7 +50,7 @@ func groupFromUnstructured(u *unstructured.Unstructured) (string, error) {
 	content := u.UnstructuredContent()
 	group, found, err := unstructured.NestedString(content, "spec", "group")
 	if err != nil || !found {
-		return "", fmt.Errorf("can't find group for source GVR: %v", err)
+		return "", fmt.Errorf("can't find group for source GVR: %w", err)
 	}
 	return group, nil
 }
@@ -62,7 +62,7 @@ func versionFromUnstructured(u *unstructured.Unstructured) (version string, err 
 		// fallback to .spec.version
 		version, found, err = unstructured.NestedString(content, "spec", "version")
 		if err != nil || !found {
-			return version, fmt.Errorf("can't find version for source GVR: %v", err)
+			return version, fmt.Errorf("can't find version for source GVR: %w", err)
 		}
 	} else {
 		for _, v := range versions {
@@ -86,7 +86,7 @@ func resourceFromUnstructured(u *unstructured.Unstructured) (string, error) {
 	content := u.UnstructuredContent()
 	resource, found, err := unstructured.NestedString(content, "spec", "names", "plural")
 	if err != nil || !found {
-		return "", fmt.Errorf("can't find resource for source GVR: %v", err)
+		return "", fmt.Errorf("can't find resource for source GVR: %w", err)
 	}
 	return resource, nil
 }
@@ -95,7 +95,7 @@ func kindFromUnstructured(u *unstructured.Unstructured) (string, error) {
 	content := u.UnstructuredContent()
 	kind, found, err := unstructured.NestedString(content, "spec", "names", "kind")
 	if !found || err != nil {
-		return "", fmt.Errorf("can't find source kind from source CRD: %v", err)
+		return "", fmt.Errorf("can't find source kind from source CRD: %w", err)
 	}
 	return kind, nil
 }

--- a/pkg/kn/commands/options/options.go
+++ b/pkg/kn/commands/options/options.go
@@ -41,7 +41,7 @@ kn options`,
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true}, // wokeignore:rule=whitelist // TODO(#1031)
 	}
 	cmd.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
-		return fmt.Errorf("%s for '%s'", err.Error(), c.CommandPath())
+		return fmt.Errorf("%w for '%s'", err, c.CommandPath())
 	})
 	cmd.SetUsageFunc(templates.NewGlobalOptionsFunc())
 	cmd.SetHelpFunc(func(command *cobra.Command, args []string) {

--- a/pkg/kn/commands/service/describe.go
+++ b/pkg/kn/commands/service/describe.go
@@ -283,7 +283,7 @@ func getRevisionDescriptions(client clientservingv1.KnServingClient, service *se
 	for _, target := range trafficTargets {
 		revision, err := extractRevisionFromTarget(client, target)
 		if err != nil {
-			return nil, fmt.Errorf("cannot extract revision from service %s: %v", service.Name, err)
+			return nil, fmt.Errorf("cannot extract revision from service %s: %w", service.Name, err)
 		}
 		revisionsSeen.Insert(revision.Name)
 		desc, err := newRevisionDesc(*revision, &target, service)
@@ -353,7 +353,7 @@ func completeWithUntargetedRevisions(client clientservingv1.KnServingClient, ser
 func newRevisionDesc(revision servingv1.Revision, target *servingv1.TrafficTarget, service *servingv1.Service) (*revisionDesc, error) {
 	generation, err := strconv.ParseInt(revision.Labels[serving.ConfigurationGenerationLabelKey], 0, 0)
 	if err != nil {
-		return nil, fmt.Errorf("cannot extract configuration generation for revision %s: %v", revision.Name, err)
+		return nil, fmt.Errorf("cannot extract configuration generation for revision %s: %w", revision.Name, err)
 	}
 	revisionDesc := revisionDesc{
 		revision:                &revision,

--- a/pkg/kn/commands/service/service.go
+++ b/pkg/kn/commands/service/service.go
@@ -60,7 +60,7 @@ func waitForService(client clientservingv1.KnServingClient, serviceName string, 
 func showUrl(client clientservingv1.KnServingClient, serviceName string, originalRevision string, what string, out io.Writer) error {
 	service, err := client.GetService(serviceName)
 	if err != nil {
-		return fmt.Errorf("cannot fetch service '%s' in namespace '%s' for extracting the URL: %v", serviceName, client.Namespace(), err)
+		return fmt.Errorf("cannot fetch service '%s' in namespace '%s' for extracting the URL: %w", serviceName, client.Namespace(), err)
 	}
 
 	url := service.Status.URL.String()

--- a/pkg/kn/commands/service/update.go
+++ b/pkg/kn/commands/service/update.go
@@ -87,7 +87,8 @@ func NewServiceUpdateCommand(p *commands.KnParams) *cobra.Command {
 				var baseRevision *servingv1.Revision
 				if !cmd.Flags().Changed("image") && editFlags.LockToDigest {
 					baseRevision, err = client.GetBaseRevision(service)
-					if _, ok := err.(*clientservingv1.NoBaseRevisionError); ok {
+					var errNoBaseRevision clientservingv1.NoBaseRevisionError
+					if errors.As(err, &errNoBaseRevision) {
 						fmt.Fprintf(cmd.OutOrStdout(), "Warning: No revision found to update image digest")
 					}
 				}

--- a/pkg/kn/commands/source/duck/multisourcelist.go
+++ b/pkg/kn/commands/source/duck/multisourcelist.go
@@ -109,7 +109,7 @@ func sinkFromUnstructured(u *unstructured.Unstructured) (*duckv1.Destination, er
 	content := u.UnstructuredContent()
 	sink, found, err := unstructured.NestedFieldCopy(content, "spec", "sink")
 	if err != nil {
-		return nil, fmt.Errorf("cant find sink in given unstructured object at spec.sink field: %v", err)
+		return nil, fmt.Errorf("cant find sink in given unstructured object at spec.sink field: %w", err)
 	}
 
 	if !found {
@@ -118,12 +118,12 @@ func sinkFromUnstructured(u *unstructured.Unstructured) (*duckv1.Destination, er
 
 	sinkM, err := json.Marshal(sink)
 	if err != nil {
-		return nil, fmt.Errorf("error marshaling sink %v: %v", sink, err)
+		return nil, fmt.Errorf("error marshaling sink %v: %w", sink, err)
 	}
 
 	var sinkD duckv1.Destination
 	if err := json.Unmarshal(sinkM, &sinkD); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal source sink: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal source sink: %w", err)
 	}
 
 	return &sinkD, nil
@@ -133,17 +133,17 @@ func conditionsFromUnstructured(u *unstructured.Unstructured) (*duckv1.Condition
 	content := u.UnstructuredContent()
 	conds, found, err := unstructured.NestedFieldCopy(content, "status", "conditions")
 	if !found || err != nil {
-		return nil, fmt.Errorf("cant find conditions in given unstructured object at status.conditions field: %v", err)
+		return nil, fmt.Errorf("cant find conditions in given unstructured object at status.conditions field: %w", err)
 	}
 
 	condsM, err := json.Marshal(conds)
 	if err != nil {
-		return nil, fmt.Errorf("error marshaling conditions %v: %v", conds, err)
+		return nil, fmt.Errorf("error marshaling conditions %v: %w", conds, err)
 	}
 
 	var condsD duckv1.Conditions
 	if err := json.Unmarshal(condsM, &condsD); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal source status conditions: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal source status conditions: %w", err)
 	}
 
 	return &condsD, nil

--- a/pkg/kn/commands/trigger/update.go
+++ b/pkg/kn/commands/trigger/update.go
@@ -89,7 +89,7 @@ func NewTriggerUpdateCommand(p *commands.KnParams) *cobra.Command {
 					updated, removed, err := triggerUpdateFlags.GetUpdateFilters()
 					if err != nil {
 						return fmt.Errorf(
-							"cannot update trigger '%s' because %s", name, err)
+							"cannot update trigger '%s' because %w", name, err)
 					}
 					existing := extractFilters(trigger)
 					b.Filters(existing.Merge(updated).Remove(removed))

--- a/pkg/kn/config/config.go
+++ b/pkg/kn/config/config.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -106,7 +107,7 @@ func BootstrapConfig() error {
 	bootstrapFlagSet.ParseErrorsWhitelist = flag.ParseErrorsWhitelist{UnknownFlags: true} // wokeignore:rule=whitelist // TODO(#1031)
 	bootstrapFlagSet.Usage = func() {}
 	err := bootstrapFlagSet.Parse(os.Args)
-	if err != nil && err != flag.ErrHelp {
+	if err != nil && !errors.Is(err, flag.ErrHelp) {
 		return err
 	}
 

--- a/pkg/kn/plugin/manager.go
+++ b/pkg/kn/plugin/manager.go
@@ -450,7 +450,7 @@ func findInDirOrPath(name string, dir string, lookupInPath bool) (string, error)
 				// Found in path
 				return path, nil
 			}
-			if errors.Is(err, exec.ErrNotFound) {
+			if !errors.Is(err, exec.ErrNotFound) {
 				return "", fmt.Errorf("error for looking up %s in path: %w", name, err)
 			}
 		}

--- a/pkg/kn/plugin/manager.go
+++ b/pkg/kn/plugin/manager.go
@@ -15,6 +15,7 @@
 package plugin
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -449,7 +450,7 @@ func findInDirOrPath(name string, dir string, lookupInPath bool) (string, error)
 				// Found in path
 				return path, nil
 			}
-			if execErr, ok := err.(*exec.Error); !ok || execErr.Unwrap() != exec.ErrNotFound {
+			if errors.Is(err, exec.ErrNotFound) {
 				return "", fmt.Errorf("error for looking up %s in path: %w", name, err)
 			}
 		}

--- a/pkg/kn/plugin/verify.go
+++ b/pkg/kn/plugin/verify.go
@@ -15,6 +15,7 @@
 package plugin
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -83,7 +84,7 @@ func verifyPath(path string, seenPlugins map[string]string, eaw VerificationErro
 	// Verify that plugin actually exists
 	fileInfo, err := os.Stat(path)
 	if err != nil {
-		if err == os.ErrNotExist {
+		if errors.Is(err, os.ErrNotExist) {
 			return eaw.AddError("cannot find plugin in %s", path)
 		}
 		return eaw.AddError("cannot stat %s: %v", path, err)

--- a/pkg/kn/root/root.go
+++ b/pkg/kn/root/root.go
@@ -124,7 +124,7 @@ func NewRootCommand(helpFuncs *template.FuncMap) (*cobra.Command, error) {
 
 	// Add some command context when flags can not be parsed
 	rootCmd.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
-		return fmt.Errorf("%s for '%s'", err.Error(), c.CommandPath())
+		return fmt.Errorf("%w for '%s'", err, c.CommandPath())
 	})
 
 	// For glog parse error. TOO: Check why this is needed

--- a/pkg/printers/tablegenerator.go
+++ b/pkg/printers/tablegenerator.go
@@ -103,7 +103,7 @@ func (h *HumanReadablePrinter) GenerateTable(obj runtime.Object, options PrintOp
 func (h *HumanReadablePrinter) TableHandler(columnDefinitions []metav1beta1.TableColumnDefinition, printFunc interface{}) error {
 	printFuncValue := reflect.ValueOf(printFunc)
 	if err := ValidateRowPrintHandlerFunc(printFuncValue); err != nil {
-		utilruntime.HandleError(fmt.Errorf("unable to register print function: %v", err))
+		utilruntime.HandleError(fmt.Errorf("unable to register print function: %w", err))
 		return err
 	}
 	entry := &handlerEntry{

--- a/pkg/serving/config_changes.go
+++ b/pkg/serving/config_changes.go
@@ -67,7 +67,7 @@ func UpdateMaxScale(template *servingv1.RevisionTemplateSpec, max int) error {
 func UpdateAutoscaleWindow(template *servingv1.RevisionTemplateSpec, window string) error {
 	_, err := time.ParseDuration(window)
 	if err != nil {
-		return fmt.Errorf("invalid duration for 'autoscale-window': %v", err)
+		return fmt.Errorf("invalid duration for 'autoscale-window': %w", err)
 	}
 	return UpdateRevisionTemplateAnnotation(template, autoscaling.WindowAnnotationKey, window)
 }

--- a/pkg/util/logging_http_transport.go
+++ b/pkg/util/logging_http_transport.go
@@ -61,7 +61,7 @@ func (t *LoggingHttpTransport) RoundTrip(r *http.Request) (*http.Response, error
 	reqBytes, err := httputil.DumpRequestOut(r, true)
 	if err != nil {
 		fmt.Fprintln(stream, "error dumping request:", err)
-		return nil, fmt.Errorf("dumping request: %v", err)
+		return nil, fmt.Errorf("dumping request: %w", err)
 	}
 	fmt.Fprintln(stream, "===== REQUEST =====")
 	fmt.Fprintln(stream, string(reqBytes))

--- a/pkg/util/logging_http_transport_test.go
+++ b/pkg/util/logging_http_transport_test.go
@@ -34,7 +34,7 @@ type fakeTransport struct {
 func (d *fakeTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	dump, err := httputil.DumpRequest(r, true)
 	if err != nil {
-		return nil, fmt.Errorf("dumping request: %v", err)
+		return nil, fmt.Errorf("dumping request: %w", err)
 	}
 	d.requestDump = string(dump)
 	return &http.Response{


### PR DESCRIPTION
## Description

This enables the `errorlint` linter, which is super helpful in catching "wrong" usages of errors (i.e. unsafe casts, ensuring errors are wrapped etc.)

## Changes

* Enable the `errorlint` linter
* Make sure all errors that somehow contain a child error properly wrap the child
* Replace all comparisons and casts with deepchecks using `Is` and `As`

/assign @rhuss 
