### PR TITLE
Enable unparam linter and fix issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,6 +7,13 @@ run:
 linters:
   enable:
     - unconvert
+    - unparam
     - prealloc
   disable:
     - errcheck
+
+issues:
+  exclude-rules:
+    - path: test # Excludes /test, *_test.go etc.
+      linters:
+        - unparam

--- a/pkg/kn/commands/revision/list.go
+++ b/pkg/kn/commands/revision/list.go
@@ -70,7 +70,7 @@ func NewRevisionListCommand(p *commands.KnParams) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			params, err = appendRevisionNameFilter(params, client, args)
+			params, err = appendRevisionNameFilter(params, args)
 			if err != nil {
 				return err
 			}
@@ -131,7 +131,7 @@ func appendServiceFilter(lConfig []clientservingv1.ListConfig, client clientserv
 }
 
 // If an additional name is given append this as a revision name filter to the given list
-func appendRevisionNameFilter(lConfigs []clientservingv1.ListConfig, client clientservingv1.KnServingClient, args []string) ([]clientservingv1.ListConfig, error) {
+func appendRevisionNameFilter(lConfigs []clientservingv1.ListConfig, args []string) ([]clientservingv1.ListConfig, error) {
 
 	switch len(args) {
 	case 0:

--- a/pkg/kn/commands/service/update.go
+++ b/pkg/kn/commands/service/update.go
@@ -131,7 +131,7 @@ func NewServiceUpdateCommand(p *commands.KnParams) *cobra.Command {
 
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return preCheck(cmd, args)
+			return preCheck(cmd)
 		},
 	}
 
@@ -143,7 +143,7 @@ func NewServiceUpdateCommand(p *commands.KnParams) *cobra.Command {
 	return serviceUpdateCommand
 }
 
-func preCheck(cmd *cobra.Command, args []string) error {
+func preCheck(cmd *cobra.Command) error {
 	if cmd.Flags().NFlag() == 0 {
 		return fmt.Errorf("flag(s) not set\nUsage: %s", cmd.Use)
 	}

--- a/pkg/kn/traffic/compute.go
+++ b/pkg/kn/traffic/compute.go
@@ -83,7 +83,7 @@ func (e ServiceTraffic) isTagPresent(tag string) bool {
 	return false
 }
 
-func (e ServiceTraffic) untagRevision(tag string, serviceName string) bool {
+func (e ServiceTraffic) untagRevision(tag string) bool {
 	for i, target := range e {
 		if target.Tag == tag {
 			e[i].Tag = ""
@@ -281,7 +281,7 @@ func Compute(cmd *cobra.Command, targets []servingv1.TrafficTarget,
 	// First precedence: Untag revisions
 	var errTagNames []string
 	for _, tag := range trafficFlags.UntagRevisions {
-		tagExists := traffic.untagRevision(tag, serviceName)
+		tagExists := traffic.untagRevision(tag)
 		if !tagExists {
 			errTagNames = append(errTagNames, tag)
 		}

--- a/pkg/printers/tableprinter.go
+++ b/pkg/printers/tableprinter.go
@@ -90,7 +90,7 @@ func printRowsForHandlerEntry(output io.Writer, handler *handlerEntry, obj runti
 
 	if results[1].IsNil() {
 		rows := results[0].Interface().([]metav1beta1.TableRow)
-		printRows(output, rows, options)
+		printRows(output, rows)
 		return nil
 	}
 	return results[1].Interface().(error)
@@ -104,7 +104,7 @@ func printHeader(columnNames []string, w io.Writer) error {
 }
 
 // printRows writes the provided rows to output.
-func printRows(output io.Writer, rows []metav1beta1.TableRow, options PrintOptions) {
+func printRows(output io.Writer, rows []metav1beta1.TableRow) {
 	for _, row := range rows {
 		for i, cell := range row.Cells {
 			if i != 0 {

--- a/pkg/wait/poll_watcher.go
+++ b/pkg/wait/poll_watcher.go
@@ -77,14 +77,11 @@ func NewWatcher(watchFunc watchF, c rest.Interface, ns string, resource string, 
 	polling := &pollingWatcher{
 		c, ns, resource, name, timeout, make(chan bool), make(chan watch.Event), &sync.WaitGroup{},
 		newTickerPollInterval(time.Second), nativePoll(c, ns, resource, name)}
-	err = polling.start()
-	if err != nil {
-		return nil, err
-	}
+	polling.start()
 	return polling, nil
 }
 
-func (w *pollingWatcher) start() error {
+func (w *pollingWatcher) start() {
 	w.wg.Add(1)
 
 	go func() {
@@ -149,7 +146,6 @@ func (w *pollingWatcher) start() error {
 			}
 		}
 	}()
-	return nil
 }
 
 func (w *pollingWatcher) ResultChan() <-chan watch.Event {

--- a/pkg/wait/wait_for_ready.go
+++ b/pkg/wait/wait_for_ready.go
@@ -114,7 +114,7 @@ func (w *waitForReadyConfig) Wait(watcher watch.Interface, name string, options 
 	floatingTimeout := timeout
 	for {
 		start := time.Now()
-		retry, timeoutReached, err := w.waitForReadyCondition(watcher, start, name, floatingTimeout, options.errorWindowWithDefault(), msgCallback)
+		retry, timeoutReached, err := w.waitForReadyCondition(watcher, start, floatingTimeout, options.errorWindowWithDefault(), msgCallback)
 		if err != nil {
 			return err, time.Since(start)
 		}
@@ -137,7 +137,7 @@ func (w *waitForReadyConfig) Wait(watcher watch.Interface, name string, options 
 // An errorWindow can be specified which takes into account of intermediate "false" ready conditions. So before returning
 // an error, this methods waits for the errorWindow duration and if an "True" or "Unknown" event arrives in the meantime
 // for the "Ready" condition, then the method continues to wait.
-func (w *waitForReadyConfig) waitForReadyCondition(watcher watch.Interface, start time.Time, name string, timeout time.Duration, errorWindow time.Duration, msgCallback MessageCallback) (retry bool, timeoutReached bool, err error) {
+func (w *waitForReadyConfig) waitForReadyCondition(watcher watch.Interface, start time.Time, timeout time.Duration, errorWindow time.Duration, msgCallback MessageCallback) (retry bool, timeoutReached bool, err error) {
 
 	// channel used to transport the error that has been received
 	errChan := make(chan error)


### PR DESCRIPTION
## Description

Probably the linter that found the most bugs over in Serving. Think of it as a more aggressive deadcode linter, telling you about unused parameters and unused return types.

Tests are excluded as the noise ratio is much higher in them.

/assign @rhuss 