### PR TITLE
Reorg OWNERS and introduced OWNERS_ALIASES

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,4 @@
 approvers:
-- sixolet
-- cppforlife
-- rhuss
 - maximilien
-- navidshaikh
-# TOC members as a fallback
-- mattmoor
-- evankanderson
+- client-wg-leads
+- toc

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,10 @@
+aliases:
+  toc:
+  - evankanderson
+  - grantr
+  - markusthoemmes
+  - mattmoor
+  - rhuss
+  client-wg-leads:
+  - rhuss
+  - navidshaikh


### PR DESCRIPTION
This update is for aligning with the other Knative projects so
that a group like the TOC list can be updated with less efforts
in the future.

Also I took the occasion to clean up a bit, so removed
@cppforlife and @sixolet as they are not active in the project since
at least one year. Happy to re-add both accounts again in the future.

Thanks a lot Naomi and Dmitriy for all your contribution and kicking off the client !