### PR TITLE
feat: Add `--context` flag to choose specific context from kubeconfig

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,9 +17,14 @@
 |===
 | | Description | PR
 
+| 🎁
+| Add `--context` flag to choose specific context from kubeconfig
+| https://github.com/knative/client/pull/1234[#1234]
+
 | 🐣
 | Making a toReference public to enable reuse from kn-plugins
 | https://github.com/knative/client/pull/1203[#1203]
+
 | 🐣
 | Do not print serviceUID and configUID labels in service export result
 | https://github.com/knative/client/pull/1194[#1194]

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,7 +18,7 @@
 | | Description | PR
 
 | 🎁
-| Add `--context` flag to choose specific context from kubeconfig
+| Add `--context` and `--cluster` flags to choose specific context from kubeconfig
 | https://github.com/knative/client/pull/1234[#1234]
 
 | 🐣

--- a/docs/cmd/kn.md
+++ b/docs/cmd/kn.md
@@ -11,6 +11,7 @@ kn is the command line interface for managing Knative Serving and Eventing resou
 ### Options
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
   -h, --help                help for kn

--- a/docs/cmd/kn.md
+++ b/docs/cmd/kn.md
@@ -12,6 +12,7 @@ kn is the command line interface for managing Knative Serving and Eventing resou
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
   -h, --help                help for kn
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic

--- a/docs/cmd/kn_broker.md
+++ b/docs/cmd/kn_broker.md
@@ -16,6 +16,7 @@ kn broker
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_broker.md
+++ b/docs/cmd/kn_broker.md
@@ -15,6 +15,7 @@ kn broker
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_broker_create.md
+++ b/docs/cmd/kn_broker_create.md
@@ -28,6 +28,7 @@ kn broker create NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_broker_create.md
+++ b/docs/cmd/kn_broker_create.md
@@ -27,6 +27,7 @@ kn broker create NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_broker_delete.md
+++ b/docs/cmd/kn_broker_delete.md
@@ -31,6 +31,7 @@ kn broker delete NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_broker_delete.md
+++ b/docs/cmd/kn_broker_delete.md
@@ -30,6 +30,7 @@ kn broker delete NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_broker_describe.md
+++ b/docs/cmd/kn_broker_describe.md
@@ -36,6 +36,7 @@ kn broker describe NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_broker_describe.md
+++ b/docs/cmd/kn_broker_describe.md
@@ -37,6 +37,7 @@ kn broker describe NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_broker_list.md
+++ b/docs/cmd/kn_broker_list.md
@@ -33,6 +33,7 @@ kn broker list
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_broker_list.md
+++ b/docs/cmd/kn_broker_list.md
@@ -32,6 +32,7 @@ kn broker list
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_channel.md
+++ b/docs/cmd/kn_channel.md
@@ -15,6 +15,7 @@ kn channel COMMAND
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_channel.md
+++ b/docs/cmd/kn_channel.md
@@ -16,6 +16,7 @@ kn channel COMMAND
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_channel_create.md
+++ b/docs/cmd/kn_channel_create.md
@@ -33,6 +33,7 @@ kn channel create NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_channel_create.md
+++ b/docs/cmd/kn_channel_create.md
@@ -34,6 +34,7 @@ kn channel create NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_channel_delete.md
+++ b/docs/cmd/kn_channel_delete.md
@@ -25,6 +25,7 @@ kn channel delete NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_channel_delete.md
+++ b/docs/cmd/kn_channel_delete.md
@@ -24,6 +24,7 @@ kn channel delete NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_channel_describe.md
+++ b/docs/cmd/kn_channel_describe.md
@@ -31,6 +31,7 @@ kn channel describe NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_channel_describe.md
+++ b/docs/cmd/kn_channel_describe.md
@@ -32,6 +32,7 @@ kn channel describe NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_channel_list-types.md
+++ b/docs/cmd/kn_channel_list-types.md
@@ -31,6 +31,7 @@ kn channel list-types
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_channel_list-types.md
+++ b/docs/cmd/kn_channel_list-types.md
@@ -32,6 +32,7 @@ kn channel list-types
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_channel_list.md
+++ b/docs/cmd/kn_channel_list.md
@@ -32,6 +32,7 @@ kn channel list
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_channel_list.md
+++ b/docs/cmd/kn_channel_list.md
@@ -33,6 +33,7 @@ kn channel list
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_completion.md
+++ b/docs/cmd/kn_completion.md
@@ -38,6 +38,7 @@ kn completion SHELL
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_completion.md
+++ b/docs/cmd/kn_completion.md
@@ -37,6 +37,7 @@ kn completion SHELL
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_options.md
+++ b/docs/cmd/kn_options.md
@@ -26,6 +26,7 @@ kn options
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_options.md
+++ b/docs/cmd/kn_options.md
@@ -27,6 +27,7 @@ kn options
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_plugin.md
+++ b/docs/cmd/kn_plugin.md
@@ -23,6 +23,7 @@ kn plugin
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_plugin.md
+++ b/docs/cmd/kn_plugin.md
@@ -22,6 +22,7 @@ kn plugin
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_plugin_list.md
+++ b/docs/cmd/kn_plugin_list.md
@@ -27,6 +27,7 @@ kn plugin list
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_plugin_list.md
+++ b/docs/cmd/kn_plugin_list.md
@@ -26,6 +26,7 @@ kn plugin list
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_revision.md
+++ b/docs/cmd/kn_revision.md
@@ -16,6 +16,7 @@ kn revision
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_revision.md
+++ b/docs/cmd/kn_revision.md
@@ -15,6 +15,7 @@ kn revision
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_revision_delete.md
+++ b/docs/cmd/kn_revision_delete.md
@@ -28,6 +28,7 @@ kn revision delete NAME [NAME ...]
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_revision_delete.md
+++ b/docs/cmd/kn_revision_delete.md
@@ -27,6 +27,7 @@ kn revision delete NAME [NAME ...]
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_revision_describe.md
+++ b/docs/cmd/kn_revision_describe.md
@@ -21,6 +21,7 @@ kn revision describe NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_revision_describe.md
+++ b/docs/cmd/kn_revision_describe.md
@@ -20,6 +20,7 @@ kn revision describe NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_revision_list.md
+++ b/docs/cmd/kn_revision_list.md
@@ -44,6 +44,7 @@ kn revision list
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_revision_list.md
+++ b/docs/cmd/kn_revision_list.md
@@ -43,6 +43,7 @@ kn revision list
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_route.md
+++ b/docs/cmd/kn_route.md
@@ -15,6 +15,7 @@ kn route
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_route.md
+++ b/docs/cmd/kn_route.md
@@ -16,6 +16,7 @@ kn route
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_route_describe.md
+++ b/docs/cmd/kn_route_describe.md
@@ -21,6 +21,7 @@ kn route describe NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_route_describe.md
+++ b/docs/cmd/kn_route_describe.md
@@ -20,6 +20,7 @@ kn route describe NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_route_list.md
+++ b/docs/cmd/kn_route_list.md
@@ -35,6 +35,7 @@ kn route list NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_route_list.md
+++ b/docs/cmd/kn_route_list.md
@@ -36,6 +36,7 @@ kn route list NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_service.md
+++ b/docs/cmd/kn_service.md
@@ -15,6 +15,7 @@ kn service
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_service.md
+++ b/docs/cmd/kn_service.md
@@ -16,6 +16,7 @@ kn service
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_service_apply.md
+++ b/docs/cmd/kn_service_apply.md
@@ -74,6 +74,7 @@ kn service apply s0 --filename my-svc.yml
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_service_apply.md
+++ b/docs/cmd/kn_service_apply.md
@@ -73,6 +73,7 @@ kn service apply s0 --filename my-svc.yml
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -100,6 +100,7 @@ kn service create NAME --image IMAGE
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -99,6 +99,7 @@ kn service create NAME --image IMAGE
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_service_delete.md
+++ b/docs/cmd/kn_service_delete.md
@@ -41,6 +41,7 @@ kn service delete NAME [NAME ...]
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_service_delete.md
+++ b/docs/cmd/kn_service_delete.md
@@ -40,6 +40,7 @@ kn service delete NAME [NAME ...]
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_service_describe.md
+++ b/docs/cmd/kn_service_describe.md
@@ -40,6 +40,7 @@ kn service describe NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_service_describe.md
+++ b/docs/cmd/kn_service_describe.md
@@ -41,6 +41,7 @@ kn service describe NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_service_export.md
+++ b/docs/cmd/kn_service_export.md
@@ -38,6 +38,7 @@ kn service export NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_service_export.md
+++ b/docs/cmd/kn_service_export.md
@@ -39,6 +39,7 @@ kn service export NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_service_import.md
+++ b/docs/cmd/kn_service_import.md
@@ -31,6 +31,7 @@ kn service import FILENAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_service_import.md
+++ b/docs/cmd/kn_service_import.md
@@ -30,6 +30,7 @@ kn service import FILENAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_service_list.md
+++ b/docs/cmd/kn_service_list.md
@@ -43,6 +43,7 @@ kn service list
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_service_list.md
+++ b/docs/cmd/kn_service_list.md
@@ -42,6 +42,7 @@ kn service list
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -86,6 +86,7 @@ kn service update NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -85,6 +85,7 @@ kn service update NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source.md
+++ b/docs/cmd/kn_source.md
@@ -16,6 +16,7 @@ kn source SOURCE|COMMAND
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source.md
+++ b/docs/cmd/kn_source.md
@@ -15,6 +15,7 @@ kn source SOURCE|COMMAND
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_apiserver.md
+++ b/docs/cmd/kn_source_apiserver.md
@@ -15,6 +15,7 @@ kn source apiserver COMMAND
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_apiserver.md
+++ b/docs/cmd/kn_source_apiserver.md
@@ -16,6 +16,7 @@ kn source apiserver COMMAND
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_apiserver_create.md
+++ b/docs/cmd/kn_source_apiserver_create.md
@@ -33,6 +33,7 @@ kn source apiserver create NAME --resource RESOURCE --sink SINK
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_apiserver_create.md
+++ b/docs/cmd/kn_source_apiserver_create.md
@@ -32,6 +32,7 @@ kn source apiserver create NAME --resource RESOURCE --sink SINK
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_apiserver_delete.md
+++ b/docs/cmd/kn_source_apiserver_delete.md
@@ -25,6 +25,7 @@ kn source apiserver delete NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_apiserver_delete.md
+++ b/docs/cmd/kn_source_apiserver_delete.md
@@ -24,6 +24,7 @@ kn source apiserver delete NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_apiserver_describe.md
+++ b/docs/cmd/kn_source_apiserver_describe.md
@@ -31,6 +31,7 @@ kn source apiserver describe NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_apiserver_describe.md
+++ b/docs/cmd/kn_source_apiserver_describe.md
@@ -32,6 +32,7 @@ kn source apiserver describe NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_apiserver_list.md
+++ b/docs/cmd/kn_source_apiserver_list.md
@@ -33,6 +33,7 @@ kn source apiserver list
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_apiserver_list.md
+++ b/docs/cmd/kn_source_apiserver_list.md
@@ -32,6 +32,7 @@ kn source apiserver list
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_apiserver_update.md
+++ b/docs/cmd/kn_source_apiserver_update.md
@@ -32,6 +32,7 @@ kn source apiserver update NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_apiserver_update.md
+++ b/docs/cmd/kn_source_apiserver_update.md
@@ -33,6 +33,7 @@ kn source apiserver update NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_binding.md
+++ b/docs/cmd/kn_source_binding.md
@@ -15,6 +15,7 @@ kn source binding COMMAND
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_binding.md
+++ b/docs/cmd/kn_source_binding.md
@@ -16,6 +16,7 @@ kn source binding COMMAND
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_binding_create.md
+++ b/docs/cmd/kn_source_binding_create.md
@@ -28,6 +28,7 @@ kn source binding create NAME --subject SUBJECT --sink SINK
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_binding_create.md
+++ b/docs/cmd/kn_source_binding_create.md
@@ -27,6 +27,7 @@ kn source binding create NAME --subject SUBJECT --sink SINK
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_binding_delete.md
+++ b/docs/cmd/kn_source_binding_delete.md
@@ -24,6 +24,7 @@ kn source binding delete NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_binding_delete.md
+++ b/docs/cmd/kn_source_binding_delete.md
@@ -25,6 +25,7 @@ kn source binding delete NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_binding_describe.md
+++ b/docs/cmd/kn_source_binding_describe.md
@@ -32,6 +32,7 @@ kn source binding describe NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_binding_describe.md
+++ b/docs/cmd/kn_source_binding_describe.md
@@ -31,6 +31,7 @@ kn source binding describe NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_binding_list.md
+++ b/docs/cmd/kn_source_binding_list.md
@@ -32,6 +32,7 @@ kn source binding list
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_binding_list.md
+++ b/docs/cmd/kn_source_binding_list.md
@@ -33,6 +33,7 @@ kn source binding list
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_binding_update.md
+++ b/docs/cmd/kn_source_binding_update.md
@@ -28,6 +28,7 @@ kn source binding update NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_binding_update.md
+++ b/docs/cmd/kn_source_binding_update.md
@@ -27,6 +27,7 @@ kn source binding update NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_container.md
+++ b/docs/cmd/kn_source_container.md
@@ -16,6 +16,7 @@ kn source container create|delete|update|list|describe
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_container.md
+++ b/docs/cmd/kn_source_container.md
@@ -15,6 +15,7 @@ kn source container create|delete|update|list|describe
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_container_create.md
+++ b/docs/cmd/kn_source_container_create.md
@@ -39,6 +39,7 @@ kn source container create NAME --image IMAGE --sink SINK
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_container_create.md
+++ b/docs/cmd/kn_source_container_create.md
@@ -38,6 +38,7 @@ kn source container create NAME --image IMAGE --sink SINK
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_container_delete.md
+++ b/docs/cmd/kn_source_container_delete.md
@@ -25,6 +25,7 @@ kn source container delete NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_container_delete.md
+++ b/docs/cmd/kn_source_container_delete.md
@@ -24,6 +24,7 @@ kn source container delete NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_container_describe.md
+++ b/docs/cmd/kn_source_container_describe.md
@@ -26,6 +26,7 @@ kn source container describe NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_container_describe.md
+++ b/docs/cmd/kn_source_container_describe.md
@@ -25,6 +25,7 @@ kn source container describe NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_container_list.md
+++ b/docs/cmd/kn_source_container_list.md
@@ -33,6 +33,7 @@ kn source container list
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_container_list.md
+++ b/docs/cmd/kn_source_container_list.md
@@ -32,6 +32,7 @@ kn source container list
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_container_update.md
+++ b/docs/cmd/kn_source_container_update.md
@@ -38,6 +38,7 @@ kn source container update NAME --image IMAGE
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_container_update.md
+++ b/docs/cmd/kn_source_container_update.md
@@ -39,6 +39,7 @@ kn source container update NAME --image IMAGE
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_list-types.md
+++ b/docs/cmd/kn_source_list-types.md
@@ -31,6 +31,7 @@ kn source list-types
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_list-types.md
+++ b/docs/cmd/kn_source_list-types.md
@@ -32,6 +32,7 @@ kn source list-types
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_list.md
+++ b/docs/cmd/kn_source_list.md
@@ -37,6 +37,7 @@ kn source list
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_list.md
+++ b/docs/cmd/kn_source_list.md
@@ -36,6 +36,7 @@ kn source list
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_ping.md
+++ b/docs/cmd/kn_source_ping.md
@@ -15,6 +15,7 @@ kn source ping COMMAND
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_ping.md
+++ b/docs/cmd/kn_source_ping.md
@@ -16,6 +16,7 @@ kn source ping COMMAND
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_ping_create.md
+++ b/docs/cmd/kn_source_ping_create.md
@@ -29,6 +29,7 @@ kn source ping create NAME --sink SINK
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_ping_create.md
+++ b/docs/cmd/kn_source_ping_create.md
@@ -28,6 +28,7 @@ kn source ping create NAME --sink SINK
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_ping_delete.md
+++ b/docs/cmd/kn_source_ping_delete.md
@@ -25,6 +25,7 @@ kn source ping delete NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_ping_delete.md
+++ b/docs/cmd/kn_source_ping_delete.md
@@ -24,6 +24,7 @@ kn source ping delete NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_ping_describe.md
+++ b/docs/cmd/kn_source_ping_describe.md
@@ -32,6 +32,7 @@ kn source ping describe NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_ping_describe.md
+++ b/docs/cmd/kn_source_ping_describe.md
@@ -31,6 +31,7 @@ kn source ping describe NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_ping_list.md
+++ b/docs/cmd/kn_source_ping_list.md
@@ -32,6 +32,7 @@ kn source ping list
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_source_ping_list.md
+++ b/docs/cmd/kn_source_ping_list.md
@@ -33,6 +33,7 @@ kn source ping list
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_ping_update.md
+++ b/docs/cmd/kn_source_ping_update.md
@@ -29,6 +29,7 @@ kn source ping update NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_source_ping_update.md
+++ b/docs/cmd/kn_source_ping_update.md
@@ -28,6 +28,7 @@ kn source ping update NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_subscription.md
+++ b/docs/cmd/kn_subscription.md
@@ -15,6 +15,7 @@ kn subscription COMMAND
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_subscription.md
+++ b/docs/cmd/kn_subscription.md
@@ -16,6 +16,7 @@ kn subscription COMMAND
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_subscription_create.md
+++ b/docs/cmd/kn_subscription_create.md
@@ -32,6 +32,7 @@ kn subscription create NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_subscription_create.md
+++ b/docs/cmd/kn_subscription_create.md
@@ -31,6 +31,7 @@ kn subscription create NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_subscription_delete.md
+++ b/docs/cmd/kn_subscription_delete.md
@@ -25,6 +25,7 @@ kn subscription delete NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_subscription_delete.md
+++ b/docs/cmd/kn_subscription_delete.md
@@ -24,6 +24,7 @@ kn subscription delete NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_subscription_describe.md
+++ b/docs/cmd/kn_subscription_describe.md
@@ -29,6 +29,7 @@ kn subscription describe NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_subscription_describe.md
+++ b/docs/cmd/kn_subscription_describe.md
@@ -28,6 +28,7 @@ kn subscription describe NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_subscription_list.md
+++ b/docs/cmd/kn_subscription_list.md
@@ -32,6 +32,7 @@ kn subscription list
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_subscription_list.md
+++ b/docs/cmd/kn_subscription_list.md
@@ -33,6 +33,7 @@ kn subscription list
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_subscription_update.md
+++ b/docs/cmd/kn_subscription_update.md
@@ -31,6 +31,7 @@ kn subscription update NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_subscription_update.md
+++ b/docs/cmd/kn_subscription_update.md
@@ -30,6 +30,7 @@ kn subscription update NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_trigger.md
+++ b/docs/cmd/kn_trigger.md
@@ -16,6 +16,7 @@ kn trigger
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_trigger.md
+++ b/docs/cmd/kn_trigger.md
@@ -15,6 +15,7 @@ kn trigger
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_trigger_create.md
+++ b/docs/cmd/kn_trigger_create.md
@@ -32,6 +32,7 @@ kn trigger create NAME --sink SINK
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_trigger_create.md
+++ b/docs/cmd/kn_trigger_create.md
@@ -31,6 +31,7 @@ kn trigger create NAME --sink SINK
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_trigger_delete.md
+++ b/docs/cmd/kn_trigger_delete.md
@@ -24,6 +24,7 @@ kn trigger delete NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_trigger_delete.md
+++ b/docs/cmd/kn_trigger_delete.md
@@ -25,6 +25,7 @@ kn trigger delete NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_trigger_describe.md
+++ b/docs/cmd/kn_trigger_describe.md
@@ -32,6 +32,7 @@ kn trigger describe NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_trigger_describe.md
+++ b/docs/cmd/kn_trigger_describe.md
@@ -31,6 +31,7 @@ kn trigger describe NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_trigger_list.md
+++ b/docs/cmd/kn_trigger_list.md
@@ -32,6 +32,7 @@ kn trigger list
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_trigger_list.md
+++ b/docs/cmd/kn_trigger_list.md
@@ -33,6 +33,7 @@ kn trigger list
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_trigger_update.md
+++ b/docs/cmd/kn_trigger_update.md
@@ -36,6 +36,7 @@ kn trigger update NAME
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/docs/cmd/kn_trigger_update.md
+++ b/docs/cmd/kn_trigger_update.md
@@ -35,6 +35,7 @@ kn trigger update NAME
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_version.md
+++ b/docs/cmd/kn_version.md
@@ -16,6 +16,7 @@ kn version
 ### Options inherited from parent commands
 
 ```
+      --cluster string      name of the kubeconfig cluster to use
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
       --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)

--- a/docs/cmd/kn_version.md
+++ b/docs/cmd/kn_version.md
@@ -17,6 +17,7 @@ kn version
 
 ```
       --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
       --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
       --log-http            log http traffic
 ```

--- a/pkg/kn/commands/types.go
+++ b/pkg/kn/commands/types.go
@@ -42,6 +42,7 @@ import (
 type KnParams struct {
 	Output                 io.Writer
 	KubeCfgPath            string
+	KubeContext            string
 	ClientConfig           clientcmd.ClientConfig
 	NewServingClient       func(namespace string) (clientservingv1.KnServingClient, error)
 	NewGitopsServingClient func(namespace string, dir string) (clientservingv1.KnServingClient, error)
@@ -167,14 +168,18 @@ func (params *KnParams) RestConfig() (*rest.Config, error) {
 // GetClientConfig gets ClientConfig from KubeCfgPath
 func (params *KnParams) GetClientConfig() (clientcmd.ClientConfig, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	configOverrides := &clientcmd.ConfigOverrides{}
+	if len(params.KubeContext) > 0 {
+		configOverrides.CurrentContext = params.KubeContext
+	}
 	if len(params.KubeCfgPath) == 0 {
-		return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{}), nil
+		return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides), nil
 	}
 
 	_, err := os.Stat(params.KubeCfgPath)
 	if err == nil {
 		loadingRules.ExplicitPath = params.KubeCfgPath
-		return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{}), nil
+		return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides), nil
 	}
 
 	if !os.IsNotExist(err) {
@@ -183,8 +188,8 @@ func (params *KnParams) GetClientConfig() (clientcmd.ClientConfig, error) {
 
 	paths := filepath.SplitList(params.KubeCfgPath)
 	if len(paths) > 1 {
-		return nil, fmt.Errorf("Can not find config file. '%s' looks like a path. "+
+		return nil, fmt.Errorf("can not find config file. '%s' looks like a path. "+
 			"Please use the env var KUBECONFIG if you want to check for multiple configuration files", params.KubeCfgPath)
 	}
-	return nil, fmt.Errorf("Config file '%s' can not be found", params.KubeCfgPath)
+	return nil, fmt.Errorf("config file '%s' can not be found", params.KubeCfgPath)
 }

--- a/pkg/kn/commands/types.go
+++ b/pkg/kn/commands/types.go
@@ -169,7 +169,7 @@ func (params *KnParams) RestConfig() (*rest.Config, error) {
 func (params *KnParams) GetClientConfig() (clientcmd.ClientConfig, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	configOverrides := &clientcmd.ConfigOverrides{}
-	if len(params.KubeContext) > 0 {
+	if params.KubeContext != "" {
 		configOverrides.CurrentContext = params.KubeContext
 	}
 	if len(params.KubeCfgPath) == 0 {

--- a/pkg/kn/commands/types.go
+++ b/pkg/kn/commands/types.go
@@ -43,6 +43,7 @@ type KnParams struct {
 	Output                 io.Writer
 	KubeCfgPath            string
 	KubeContext            string
+	KubeCluster            string
 	ClientConfig           clientcmd.ClientConfig
 	NewServingClient       func(namespace string) (clientservingv1.KnServingClient, error)
 	NewGitopsServingClient func(namespace string, dir string) (clientservingv1.KnServingClient, error)
@@ -171,6 +172,9 @@ func (params *KnParams) GetClientConfig() (clientcmd.ClientConfig, error) {
 	configOverrides := &clientcmd.ConfigOverrides{}
 	if params.KubeContext != "" {
 		configOverrides.CurrentContext = params.KubeContext
+	}
+	if params.KubeCluster != "" {
+		configOverrides.Context.Cluster = params.KubeCluster
 	}
 	if len(params.KubeCfgPath) == 0 {
 		return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides), nil

--- a/pkg/kn/commands/types_test.go
+++ b/pkg/kn/commands/types_test.go
@@ -101,6 +101,7 @@ func TestPrepareConfig(t *testing.T) {
 type typeTestCase struct {
 	kubeCfgPath   string
 	kubeContext   string
+	kubeCluster   string
 	explicitPath  string
 	expectedError string
 }
@@ -111,17 +112,20 @@ func TestGetClientConfig(t *testing.T) {
 		{
 			"",
 			"",
+			"",
 			clientcmd.NewDefaultClientConfigLoadingRules().ExplicitPath,
 			"",
 		},
 		{
 			"/testing/assets/kube-config-01.yml",
 			"foo",
+			"bar",
 			"",
 			fmt.Sprintf("config file '%s' can not be found", "/testing/assets/kube-config-01.yml"),
 		},
 		{
 			multiConfigs,
+			"",
 			"",
 			"",
 			fmt.Sprintf("can not find config file. '%s' looks like a path. Please use the env var KUBECONFIG if you want to check for multiple configuration files", multiConfigs),
@@ -143,10 +147,11 @@ func TestGetClientConfig(t *testing.T) {
 			configAccess := clientConfig.ConfigAccess()
 			assert.Assert(t, configAccess.GetExplicitFile() == tc.explicitPath)
 
-			if len(tc.kubeContext) > 0 {
+			if tc.kubeContext != "" {
 				config, err := clientConfig.RawConfig()
 				assert.NilError(t, err)
-				assert.Assert(t, config.CurrentContext == "foo")
+				assert.Assert(t, config.CurrentContext == tc.kubeContext)
+				assert.Assert(t, config.Contexts[tc.kubeContext].Cluster == tc.kubeCluster)
 			}
 		}
 	}

--- a/pkg/kn/commands/types_test.go
+++ b/pkg/kn/commands/types_test.go
@@ -100,6 +100,7 @@ func TestPrepareConfig(t *testing.T) {
 
 type typeTestCase struct {
 	kubeCfgPath   string
+	kubeContext   string
 	explicitPath  string
 	expectedError string
 }
@@ -109,22 +110,26 @@ func TestGetClientConfig(t *testing.T) {
 	for _, tc := range []typeTestCase{
 		{
 			"",
+			"",
 			clientcmd.NewDefaultClientConfigLoadingRules().ExplicitPath,
 			"",
 		},
 		{
 			"/testing/assets/kube-config-01.yml",
+			"foo",
 			"",
-			fmt.Sprintf("Config file '%s' can not be found", "/testing/assets/kube-config-01.yml"),
+			fmt.Sprintf("config file '%s' can not be found", "/testing/assets/kube-config-01.yml"),
 		},
 		{
 			multiConfigs,
 			"",
-			fmt.Sprintf("Can not find config file. '%s' looks like a path. Please use the env var KUBECONFIG if you want to check for multiple configuration files", multiConfigs),
+			"",
+			fmt.Sprintf("can not find config file. '%s' looks like a path. Please use the env var KUBECONFIG if you want to check for multiple configuration files", multiConfigs),
 		},
 	} {
 		p := &KnParams{
 			KubeCfgPath: tc.kubeCfgPath,
+			KubeContext: tc.kubeContext,
 		}
 
 		clientConfig, err := p.GetClientConfig()
@@ -136,8 +141,13 @@ func TestGetClientConfig(t *testing.T) {
 
 		if clientConfig != nil {
 			configAccess := clientConfig.ConfigAccess()
-
 			assert.Assert(t, configAccess.GetExplicitFile() == tc.explicitPath)
+
+			if len(tc.kubeContext) > 0 {
+				config, err := clientConfig.RawConfig()
+				assert.NilError(t, err)
+				assert.Assert(t, config.CurrentContext == "foo")
+			}
 		}
 	}
 }

--- a/pkg/kn/root/root.go
+++ b/pkg/kn/root/root.go
@@ -76,6 +76,7 @@ func NewRootCommand(helpFuncs *template.FuncMap) (*cobra.Command, error) {
 
 	// Global flags
 	rootCmd.PersistentFlags().StringVar(&p.KubeCfgPath, "kubeconfig", "", "kubectl configuration file (default: ~/.kube/config)")
+	rootCmd.PersistentFlags().StringVar(&p.KubeContext, "context", "", "name of the kubeconfig context to use")
 	flags.AddBothBoolFlags(rootCmd.PersistentFlags(), &p.LogHTTP, "log-http", "", false, "log http traffic")
 
 	// Grouped commands

--- a/pkg/kn/root/root.go
+++ b/pkg/kn/root/root.go
@@ -77,6 +77,7 @@ func NewRootCommand(helpFuncs *template.FuncMap) (*cobra.Command, error) {
 	// Global flags
 	rootCmd.PersistentFlags().StringVar(&p.KubeCfgPath, "kubeconfig", "", "kubectl configuration file (default: ~/.kube/config)")
 	rootCmd.PersistentFlags().StringVar(&p.KubeContext, "context", "", "name of the kubeconfig context to use")
+	rootCmd.PersistentFlags().StringVar(&p.KubeCluster, "cluster", "", "name of the kubeconfig cluster to use")
 	flags.AddBothBoolFlags(rootCmd.PersistentFlags(), &p.LogHTTP, "log-http", "", false, "log http traffic")
 
 	// Grouped commands

--- a/pkg/kn/root/root_test.go
+++ b/pkg/kn/root/root_test.go
@@ -44,6 +44,7 @@ func TestNewRootCommand(t *testing.T) {
 
 	assert.Assert(t, rootCmd.PersistentFlags().Lookup("config") != nil)
 	assert.Assert(t, rootCmd.PersistentFlags().Lookup("kubeconfig") != nil)
+	assert.Assert(t, rootCmd.PersistentFlags().Lookup("context") != nil)
 
 	assert.Assert(t, rootCmd.RunE == nil)
 

--- a/pkg/kn/root/root_test.go
+++ b/pkg/kn/root/root_test.go
@@ -45,6 +45,7 @@ func TestNewRootCommand(t *testing.T) {
 	assert.Assert(t, rootCmd.PersistentFlags().Lookup("config") != nil)
 	assert.Assert(t, rootCmd.PersistentFlags().Lookup("kubeconfig") != nil)
 	assert.Assert(t, rootCmd.PersistentFlags().Lookup("context") != nil)
+	assert.Assert(t, rootCmd.PersistentFlags().Lookup("cluster") != nil)
 
 	assert.Assert(t, rootCmd.RunE == nil)
 


### PR DESCRIPTION
## Description

I've noticed new comments on the issue and though it should be pretty straightforward and great addition to `kn`. Most of the changes are docs (in separate commit).

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Add `--context` flag to choose specific context from kubeconfig


## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #925 

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
