### PR TITLE
Adding itsmurugappan to the `reviewers:` list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,3 +2,5 @@ approvers:
 - maximilien
 - client-wg-leads
 - toc
+reviewers:
+- itsmurugappan


### PR DESCRIPTION
## Description

Thanks to @itsmurugappan sustain and excellent work I would like to propose to add him to the reviewers list:

I am assuming the block is `reviewers:` (plural)
/assign @rhuss


## Changes

* OWNERS file new section `reviewers:`