### PR TITLE
chore: Update CRDs API version to v1

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,17 @@
 | https://github.com/knative/client/pull/[#]
 ////
 
+## (Unreleased)
+[cols="1,10,3", options="header", width="100%"]
+|===
+| | Description | PR
+
+| ✨
+| Update CRDs API version to `v1`
+| https://github.com/knative/client/issues/1248[#1248]
+
+|===
+
 ## v0.21.0 (2021-02-23)
 [cols="1,10,3", options="header", width="100%"]
 |===

--- a/pkg/dynamic/client.go
+++ b/pkg/dynamic/client.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	crdGroup           = "apiextensions.k8s.io"
-	crdVersion         = "v1beta1"
+	crdVersion         = "v1"
 	crdKind            = "CustomResourceDefinition"
 	crdKinds           = "customresourcedefinitions"
 	sourcesLabelKey    = "duck.knative.dev/source"

--- a/pkg/kn/commands/channel/list_types_test.go
+++ b/pkg/kn/commands/channel/list_types_test.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	crdGroup           = "apiextensions.k8s.io"
-	crdVersion         = "v1beta1"
+	crdVersion         = "v1"
 	crdKind            = "CustomResourceDefinition"
 	testNamespace      = "current"
 	channelLabelValue  = "true"

--- a/pkg/kn/commands/source/list_test.go
+++ b/pkg/kn/commands/source/list_test.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	crdGroup          = "apiextensions.k8s.io"
-	crdVersion        = "v1beta1"
+	crdVersion        = "v1"
 	crdKind           = "CustomResourceDefinition"
 	sourcesLabelKey   = "duck.knative.dev/source"
 	sourcesLabelValue = "true"

--- a/test/e2e/source_list_test.go
+++ b/test/e2e/source_list_test.go
@@ -44,7 +44,7 @@ func TestSourceListTypes(t *testing.T) {
 	t.Log("List available source types in YAML format")
 
 	output = sourceListTypes(r, "-oyaml")
-	assert.Check(t, util.ContainsAll(output, "apiextensions.k8s.io/v1beta1", "CustomResourceDefinition", "Ping", "ApiServer"))
+	assert.Check(t, util.ContainsAll(output, "apiextensions.k8s.io/v1", "CustomResourceDefinition", "Ping", "ApiServer"))
 }
 
 func TestSourceList(t *testing.T) {


### PR DESCRIPTION
## Description

The CRDs `v1beta1` version is deprecated since K8s 1.16 and will be removed in `1.22`. However, it may produce a warning on newer Kubernetes clusters already.

We should probably handle the warning as well and don't fail prematurely. 

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Update CRDs API version to `v1`

## Reference


Fixes N/A

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
