### PR TITLE
Drop master references to knative repos

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -556,7 +556,7 @@
 | https://github.com/knative/client/pull/834[#834]
 
 | 🐣
-| Update and expanded https://github.com/knative/client/blob/master/conventions/cli.md[CLI convention document]
+| Update and expanded https://github.com/knative/client/blob/main/conventions/cli.md[CLI convention document]
 | https://github.com/knative/client/pull/831[#831]
 
 | 🐛

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white)](https://pkg.go.dev/knative.dev/client)
 [![Go Report Card](https://goreportcard.com/badge/knative/client)](https://goreportcard.com/report/knative/client)
 [![Releases](https://img.shields.io/github/release-pre/knative/client.svg)](https://github.com/knative/client/releases)
-[![LICENSE](https://img.shields.io/github/license/knative/client.svg)](https://github.com/knative/client/blob/master/LICENSE)
+[![LICENSE](https://img.shields.io/github/license/knative/client.svg)](https://github.com/knative/client/blob/main/LICENSE)
 [![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://knative.slack.com)
 
 The Knative client `kn` is your door to the [Knative](https://knative.dev)
@@ -25,9 +25,9 @@ line or from within scripts.
 
 
 This client uses the
-[Knative Serving](https://github.com/knative/docs/blob/master/docs/serving/spec/knative-api-specification-1.0.md)
+[Knative Serving](https://github.com/knative/docs/blob/main/docs/serving/spec/knative-api-specification-1.0.md)
 and
-[Knative Eventing](https://github.com/knative/eventing/tree/master/docs/spec)
+[Knative Eventing](https://github.com/knative/eventing/tree/main/docs/spec)
 APIs exclusively so that it will work with any Knative installation, even those
 that are not Kubernetes based. It does not help with _installing_ Knative itself
 though. Please refer to the various

--- a/docs/dev/developer-guide.md
+++ b/docs/dev/developer-guide.md
@@ -8,7 +8,7 @@ _This guide is not complete and has still many gaps that we are going to fill ov
 
 ## Flow
 
-The journey starts at [main.go](https://github.com/knative/client/blob/master/cmd/kn/main.go) which is the entry point when you call `kn`.
+The journey starts at [main.go](https://github.com/knative/client/blob/main/cmd/kn/main.go) which is the entry point when you call `kn`.
 You find here the main control flow, which can be roughly divided into three phases:
 
   - _Bootstrap_ is about retrieving essential configuration parameters from command-line flags, and a configuration file.
@@ -68,7 +68,7 @@ For testing purposes, `config.GlobalConfig` can be replaced by a mock implementa
 
 ## Flags
 
-_This section will hold some information about how flag parsing of commands is supposed to work, including using helper functions for enforcing the conventions defined in [cli conventions](https://github.com/knative/client/blob/master/conventions/cli.md)_
+_This section will hold some information about how flag parsing of commands is supposed to work, including using helper functions for enforcing the conventions defined in [cli conventions](https://github.com/knative/client/blob/main/conventions/cli.md)_
 
 ## Clients for accessing the backend
 

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -4,14 +4,14 @@ Plugins follow a similar architecture to
 [kubectl plugins](https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/)
 with some small differences. One key difference is that `kn` plugins can either
 live in your `PATH` or in a chosen and specified directory.
-[Kn plugins](https://github.com/knative/client/tree/master/docs/cmd/kn_plugin.md)
+[Kn plugins](https://github.com/knative/client/tree/main/docs/cmd/kn_plugin.md)
 show how to install and create new plugins as well as gives some examples and
 best practices.
 
 To see what plugins are installed on your machine, you can use the
-[`plugin`](https://github.com/knative/client/tree/master/docs/cmd/kn_plugin.md)
+[`plugin`](https://github.com/knative/client/tree/main/docs/cmd/kn_plugin.md)
 command group's
-[`list`](https://github.com/knative/client/tree/master/docs/cmd/kn_plugin_list.md)
+[`list`](https://github.com/knative/client/tree/main/docs/cmd/kn_plugin_list.md)
 command.
 
 Plugins provide extended functionality that is not part of the core `kn`

--- a/docs/workflows/basic.md
+++ b/docs/workflows/basic.md
@@ -2,7 +2,7 @@
 
 In this basic workflow we show the CRUD (create, read, update, delete) operations
 on a service. We use a well known
-[simple Hello World service](https://github.com/knative/docs/tree/master/docs/serving/samples/hello-world/helloworld-go)
+[simple Hello World service](https://github.com/knative/docs/tree/main/docs/serving/samples/hello-world/helloworld-go)
 that reads the environment variable `TARGET` and prints it as output.
 
 - **Create a service in the `default` namespace from an image**

--- a/pkg/serving/v1/gitops_test.go
+++ b/pkg/serving/v1/gitops_test.go
@@ -90,7 +90,7 @@ func TestGitOpsOperations(t *testing.T) {
 		assert.NilError(t, err)
 		assert.DeepEqual(t, fooserviceList, result)
 	})
-	t.Run("create service without master directory", func(t *testing.T) {
+	t.Run("create service without tmp directory", func(t *testing.T) {
 		err := diffClusterClient.CreateService(fooSvc)
 		assert.ErrorContains(t, err, "directory 'tmp' not present, please create the directory and try again")
 	})

--- a/test/README.md
+++ b/test/README.md
@@ -80,7 +80,7 @@ Two e2e tests prow jobs are run in CI:
 The [`upload-test-images.sh`](./upload-test-images.sh) script can be used to
 build and push the test images used by the e2e tests. The script
 expects your environment to be setup as described in
-[DEVELOPMENT.md](https://github.com/knative/serving/blob/master/DEVELOPMENT.md#install-requirements).
+[DEVELOPMENT.md](https://github.com/knative/serving/blob/main/DEVELOPMENT.md#install-requirements).
 
 To run the script for all end to end test images:
 


### PR DESCRIPTION
## Description

As per title, dropping all the refs to master that are now renamed to main. Also fixed a small occurrence in a test that seemed wrong anyway.

/assign @rhuss 