### PR TITLE
Update OWNERS_ALIASES to match autogen in community

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,5 @@
 approvers:
 - client-writers
-- toc
+- technical-oversight-committee
 reviewers:
 - client-reviewers

--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,5 @@
 approvers:
-- maximilien
-- dsimansk
-- client-wg-leads
+- client-writers
 - toc
 reviewers:
-- itsmurugappan
+- client-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,6 +5,13 @@ aliases:
   - markusthoemmes
   - mattmoor
   - rhuss
+  client-reviewers:
+  - itsmurugappan
   client-wg-leads:
-  - rhuss
   - navidshaikh
+  - rhuss
+  client-writers:
+  - dsimansk
+  - maximilien
+  - navidshaikh
+  - rhuss


### PR DESCRIPTION
See https://github.com/knative/community/pull/552 for the addition of groups/full OWNERS_ALIASES that will be synced.

This is a preparatory PR for landing OWNERS_ALIASES automation across the Knative org (alternative to the CODEOWNERS changes in knative-sandbox).

If this seems to be expanding permissions or otherwise likely to cause a problem, `/hold` this PR and comment here or on https://github.com/knative/community/pull/552.
