### PR TITLE
Add number of instances to describe command

### DIFF
--- a/pkg/kn/commands/revision/describe.go
+++ b/pkg/kn/commands/revision/describe.go
@@ -96,6 +96,7 @@ func describe(w io.Writer, revision *servingv1.Revision, service *servingv1.Serv
 	dw := printers.NewPrefixWriter(w)
 	commands.WriteMetadata(dw, &revision.ObjectMeta, printDetails)
 	WriteImage(dw, revision)
+	WriteReplicas(dw, revision)
 	WritePort(dw, revision)
 	WriteEnv(dw, revision, printDetails)
 	WriteEnvFrom(dw, revision, printDetails)
@@ -199,6 +200,14 @@ func WriteEnvFrom(dw printers.PrefixWriter, revision *servingv1.Revision, printD
 	envFrom := stringifyEnvFrom(revision)
 	if envFrom != nil {
 		commands.WriteSliceDesc(dw, envFrom, "EnvFrom", printDetails)
+	}
+}
+
+func WriteReplicas(dw printers.PrefixWriter, revision *servingv1.Revision) {
+	actualReplicas := revision.Status.ActualReplicas
+	desiredReplicas := revision.Status.DesiredReplicas
+	if actualReplicas != 0 || desiredReplicas != 0 {
+		dw.WriteAttribute("Replicas", fmt.Sprintf("%d/%d", actualReplicas, desiredReplicas))
 	}
 }
 

--- a/pkg/kn/commands/revision/describe_test.go
+++ b/pkg/kn/commands/revision/describe_test.go
@@ -120,6 +120,7 @@ func TestDescribeRevisionBasic(t *testing.T) {
 	}
 
 	assert.Assert(t, util.ContainsAll(data, "Image:", "gcr.io/test/image", "++ Ready", "Port:", "8080"))
+	assert.Assert(t, util.ContainsAll(data, "Replicas:", "0/1"))
 	assert.Assert(t, util.ContainsAll(data, "EnvFrom:", "cm:test1, cm:test2"))
 }
 
@@ -161,6 +162,8 @@ func createTestRevision(revision string, gen int64) servingv1.Revision {
 			},
 		},
 		Status: servingv1.RevisionStatus{
+			ActualReplicas:        0,
+			DesiredReplicas:       1,
 			DeprecatedImageDigest: "gcr.io/test/image@" + imageDigest,
 			Status: duckv1.Status{
 				Conditions: goodConditions(),

--- a/pkg/kn/commands/service/describe.go
+++ b/pkg/kn/commands/service/describe.go
@@ -221,6 +221,7 @@ func writeRevisions(dw printers.PrefixWriter, revisions []*revisionDesc, printDe
 			section.WriteAttribute("Error", ready.Reason)
 		}
 		revision.WriteImage(section, revisionDesc.revision)
+		revision.WriteReplicas(section, revisionDesc.revision)
 		if printDetails {
 			revision.WritePort(section, revisionDesc.revision)
 			revision.WriteEnv(section, revisionDesc.revision, printDetails)

--- a/pkg/kn/commands/service/describe_test.go
+++ b/pkg/kn/commands/service/describe_test.go
@@ -68,6 +68,7 @@ func TestServiceDescribeBasic(t *testing.T) {
 	assert.Assert(t, util.ContainsAll(output, "Labels:", "label1=lval1, label2=lval2\n"))
 	assert.Assert(t, util.ContainsAll(output, "[1]"))
 	assert.Assert(t, cmp.Regexp("Service Account: \\s+default-sa", output))
+	assert.Assert(t, util.ContainsAll(output, "Replicas:", "0/1"))
 
 	assert.Equal(t, strings.Count(output, "rev1"), 1)
 
@@ -762,6 +763,8 @@ func createTestRevision(revision string, gen int64, conditions duckv1.Conditions
 			},
 		},
 		Status: servingv1.RevisionStatus{
+			ActualReplicas:        0,
+			DesiredReplicas:       1,
 			DeprecatedImageDigest: "gcr.io/test/image@" + imageDigest,
 			Status: duckv1.Status{
 				Conditions: conditions,


### PR DESCRIPTION
## Description

Currently the Status fields `ActualReplicas,DesiredReplicas` are set to `omitempty`. Therefore the current impl doesn't show any replica details if both values are `0`.


```
➜  client git:(main) ✗ kn service describe hello                 
Name:       hello
Namespace:  default
Age:        34s
URL:        http://hello.default.127.0.0.1.nip.io

Revisions:  
  100%  @latest (hello-00001) [1] (34s)
        Image:     docker.io/dsimansk/helloworld (pinned to 29f975)
        Replicas:  1/1

Conditions:  
  OK TYPE                   AGE REASON
  ++ Ready                  20s 
  ++ ConfigurationsReady    29s 
  ++ RoutesReady            20s 
```

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Add number of instances (`Replicas:`) to `kn service describe`
* Add number of instances (`Replicas:`) to `kn revision describe`


## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #842 


/assign @knative/client-reviewers 
