### PR TITLE
Drop --strict flag on ko

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -42,7 +42,7 @@ function build_release() {
   echo "🚧 P  Building for Linux (ppc64le)"
   GOOS=linux GOARCH=ppc64le go build -mod=vendor -ldflags "${ld_flags}" -o ./kn-linux-ppc64le ./cmd/...
   echo "🚧 🐳 Building the container image"
-  ko resolve --strict ${KO_FLAGS} -f config/ > kn-image-location.yaml
+  ko resolve ${KO_FLAGS} -f config/ > kn-image-location.yaml
   ARTIFACTS_TO_PUBLISH="kn-darwin-amd64 kn-linux-amd64 kn-linux-arm64 kn-windows-amd64.exe kn-linux-s390x kn-linux-ppc64le kn-image-location.yaml"
   sha256sum ${ARTIFACTS_TO_PUBLISH} > checksums.txt
   ARTIFACTS_TO_PUBLISH="${ARTIFACTS_TO_PUBLISH} checksums.txt"


### PR DESCRIPTION
As per title. Since https://github.com/google/ko/commit/6586a72f8a458b6b2139fd8b97d4412afab91f03 this has been the default and we recently updated `ko` in CI.

This fixes the nightly build.

/assign @rhuss @dsimansk 