### PR TITLE
Fix for serviceaccounts "default" not found flaky issue

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,10 @@
 |🐛
 | Respect `-o` in `list` commands in case if no data present
 | https://github.com/knative/client/pull/1276[#1276]
+
+| 🐣
+| Fix for serviceaccounts "default" not found flaky issue
+| https://github.com/knative/client/pull/1306[#1306]
 |===
 
 ## v0.22.0 (2021-04-06)


### PR DESCRIPTION
## Description
This PR intends to fix `serviceaccount "default" not found` flaky issue which is a race condition observed on some OCP4.x platforms.

## Changes
`lib/test/integration.go` now waits for `default` serviceaccount to be ready before returning a new `KnTest` object when executing e2e tests.

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
