### PR TITLE
Remove force update of go-licenses binary

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -92,11 +92,6 @@ run() {
 
 
 codegen() {
-  #TODO: Workaround to update go-licenses until prow-tests image is updated
-  local temp_dir="$(mktemp -d)"
-  pushd "${temp_dir}" > /dev/null 2>&1
-  GO111MODULE=on go get github.com/google/go-licenses@latest || return 1
-  popd > /dev/null 2>&1
   # Update dependencies
   update_deps
 


### PR DESCRIPTION
## Description

Remove the force update hack introduced due to `prow-tests:stable` didn't contained the latest `go-licenses` binary. It should ok now, and tests should be passing.

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Remove force update of go-licenses binary


