### PR TITLE
Improve test coverage of main package

### DIFF
--- a/cmd/kn/main.go
+++ b/cmd/kn/main.go
@@ -44,12 +44,7 @@ func main() {
 		}),
 	)
 
-	err := run(os.Args[1:])
-	if err != nil && len(os.Args) > 1 {
-		printError(err)
-		// This is the only point from where to exit when an error occurs
-		os.Exit(1)
-	}
+	os.Exit(runWithExit(os.Args[1:]))
 }
 
 // runError is used when during the execution of a command/plugin an error occurs and
@@ -61,6 +56,14 @@ type runError struct {
 // Error implements the error() interface
 func (e *runError) Error() string {
 	return e.err.Error()
+}
+
+func runWithExit(args []string) int {
+	if err := run(args); err != nil {
+		printError(err)
+		return 1
+	}
+	return 0
 }
 
 // Run the main program. Args are the args as given on the command line (excluding the program name itself)

--- a/cmd/kn/main_test.go
+++ b/cmd/kn/main_test.go
@@ -17,10 +17,11 @@ package main
 import (
 	"errors"
 	"fmt"
-	"knative.dev/client/pkg/kn/plugin"
 	"os"
 	"strings"
 	"testing"
+
+	"knative.dev/client/pkg/kn/plugin"
 
 	"github.com/spf13/cobra"
 	"gotest.tools/v3/assert"
@@ -334,7 +335,7 @@ func TestRunWithExit(t *testing.T) {
 	}
 }
 
-type internalPlugin struct{
+type internalPlugin struct {
 	executeError func() error
 	commandParts []string
 }
@@ -355,7 +356,7 @@ func TestRun(t *testing.T) {
 		args           []string
 		expectedOut    []string
 		expectedErrOut []string
-		plugin plugin.Plugin
+		plugin         plugin.Plugin
 	}{
 		{
 			[]string{"kn", "version"},
@@ -401,7 +402,7 @@ func TestRun(t *testing.T) {
 			[]string{"plugin", "overriding", "'service create'"},
 			&internalPlugin{
 				executeError: nil,
-				commandParts: []string{"service","create"},
+				commandParts: []string{"service", "create"},
 			},
 		},
 		{


### PR DESCRIPTION
## Description

Refactor `main` function to improve test coverage and testability of it as well.

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Refactor to minimal  `main()`
* Wrap `run` in `runWithExit()` to produce exit codes.

## Reference

Related to #1322 