### PR TITLE
Move warning handler from `main()` to `RestConfig()`

### DIFF
--- a/cmd/kn/main.go
+++ b/cmd/kn/main.go
@@ -24,8 +24,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/rest"
-
 	"knative.dev/client/pkg/kn/config"
 	"knative.dev/client/pkg/kn/plugin"
 	"knative.dev/client/pkg/kn/root"
@@ -36,14 +34,6 @@ func init() {
 }
 
 func main() {
-	// Override client-go's warning handler to give us nicely printed warnings.
-	rest.SetDefaultWarningHandler(
-		rest.NewWarningWriter(os.Stderr, rest.WarningWriterOptions{
-			// only print a given warning the first time we receive it
-			Deduplicate: true,
-		}),
-	)
-
 	os.Exit(runWithExit(os.Args[1:]))
 }
 

--- a/pkg/kn/commands/types.go
+++ b/pkg/kn/commands/types.go
@@ -194,6 +194,7 @@ func (params *KnParams) RestConfig() (*rest.Config, error) {
 	if params.LogHTTP {
 		config.Wrap(util.NewLoggingTransport)
 	}
+	// Override client-go's warning handler to give us nicely printed warnings.
 	config.WarningHandler = rest.NewWarningWriter(os.Stderr, rest.WarningWriterOptions{
 		// only print a given warning the first time we receive it
 		Deduplicate: true,

--- a/pkg/kn/commands/types.go
+++ b/pkg/kn/commands/types.go
@@ -192,10 +192,12 @@ func (params *KnParams) RestConfig() (*rest.Config, error) {
 		return nil, knerrors.GetError(err)
 	}
 	if params.LogHTTP {
-		// TODO: When we update to the newer version of client-go, replace with
-		// config.Wrap() for future compat.
-		config.WrapTransport = util.NewLoggingTransport
+		config.Wrap(util.NewLoggingTransport)
 	}
+	config.WarningHandler = rest.NewWarningWriter(os.Stderr, rest.WarningWriterOptions{
+		// only print a given warning the first time we receive it
+		Deduplicate: true,
+	})
 
 	return config, nil
 }


### PR DESCRIPTION
## Description

NOTE: it isn't crucial for the release. It can be reviewed afterwards.

The motivation is to have streamlined `main()` function. Therefore I've moved warning handler creation to more suitable place, that should serve as rest config entrypoint.

Seems to work fine :)
```
➜  client git:(pr/cleanup-main) kn service list           
Warning: Test warning
```


@markusthoemmes any objections to the change? :crossed_fingers: 

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Move warning handler from `main()` to `RestConfig()`


