### PR TITLE
Do not cleanup on failure in Tekton tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -37,13 +37,14 @@ export PATH=$PATH:${REPO_ROOT_DIR}
 
 run() {
   # Create cluster
-  initialize $@ --skip-istio-addon
-
-  # Smoke test
-  eval smoke_test || fail_test
-
-  # Integration test
-  eval integration_test || fail_test
+  $(dirname $0)/tekton-tests.sh
+#  initialize $@ --skip-istio-addon
+#
+#  # Smoke test
+#  eval smoke_test || fail_test
+#
+#  # Integration test
+#  eval integration_test || fail_test
 
   success
 }

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -37,14 +37,13 @@ export PATH=$PATH:${REPO_ROOT_DIR}
 
 run() {
   # Create cluster
-  $(dirname $0)/tekton-tests.sh
-#  initialize $@ --skip-istio-addon
-#
-#  # Smoke test
-#  eval smoke_test || fail_test
-#
-#  # Integration test
-#  eval integration_test || fail_test
+  initialize $@ --skip-istio-addon
+
+  # Smoke test
+  eval smoke_test || fail_test
+
+  # Integration test
+  eval integration_test || fail_test
 
   success
 }

--- a/test/e2e/tekton_test.go
+++ b/test/e2e/tekton_test.go
@@ -40,9 +40,6 @@ const (
 func TestTektonPipeline(t *testing.T) {
 	it, err := test.NewKnTest()
 	assert.NilError(t, err)
-	defer func() {
-		assert.NilError(t, it.Teardown())
-	}()
 
 	kubectl := test.NewKubectl(it.Namespace())
 	basedir := test.CurrentDir(t) + "/../resources/tekton"
@@ -89,6 +86,7 @@ func TestTektonPipeline(t *testing.T) {
 	r.AssertNoError(out)
 	assert.Assert(t, util.ContainsAll(out.Stdout, serviceName, it.Kn().Namespace()))
 	assert.Assert(t, util.ContainsAll(out.Stdout, "Conditions", "ConfigurationsReady", "Ready", "RoutesReady"))
+	assert.NilError(t, it.Teardown())
 }
 
 func waitForPipelineSuccess(k test.Kubectl) error {

--- a/test/tekton-tests.sh
+++ b/test/tekton-tests.sh
@@ -26,7 +26,7 @@ source $(dirname $0)/common.sh
 export PATH=$PATH:${REPO_ROOT_DIR}
 
 # Script entry point.
-initialize $@
+initialize $@ --skip-istio-addon
 
 export TEKTON_VERSION=${TEKTON_VERSION:-v0.11.1}
 export KN_E2E_NAMESPACE=tkn-kn


### PR DESCRIPTION
## Description

Trying to fix the failures in nightly Tekton tests such as https://prow.knative.dev/view/gs/knative-prow/logs/ci-knative-client-tekton/1412758478874742784
Testgrid view: https://testgrid.k8s.io/r/knative-own-testgrid/client#tekton.

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Skip using Istio addon in Tekton tests
* Do not cleanup the test namespace when the test fails (for debugging purposes)

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
