### PR TITLE
Introduce -reusenamespace test flag

### DIFF
--- a/lib/test/flags.go
+++ b/lib/test/flags.go
@@ -28,7 +28,7 @@ var Flags = InitializeFlags()
 // ClientFlags define the flags that are needed to run the e2e tests.
 type ClientFlags struct {
 	DockerConfigJSON string
-	ReuseNamespace bool
+	ReuseNamespace   bool
 }
 
 // InitializeFlags initializes the client's flags

--- a/lib/test/flags.go
+++ b/lib/test/flags.go
@@ -28,6 +28,7 @@ var Flags = InitializeFlags()
 // ClientFlags define the flags that are needed to run the e2e tests.
 type ClientFlags struct {
 	DockerConfigJSON string
+	ReuseNamespace bool
 }
 
 // InitializeFlags initializes the client's flags
@@ -37,6 +38,9 @@ func InitializeFlags() *ClientFlags {
 	dockerConfigJSON := os.Getenv("DOCKER_CONFIG_JSON")
 	flag.StringVar(&f.DockerConfigJSON, "dockerconfigjson", dockerConfigJSON,
 		"Provide the path to Docker configuration file in json format. Defaults to $DOCKER_CONFIG_JSON")
+	// Might be useful in restricted environments where namespaces need to be
+	// created by a user with increased privileges (admin).
+	flag.BoolVar(&f.ReuseNamespace, "reusenamespace", false, "Whether to re-use namespace for test if it already exists.")
 
 	return &f
 }

--- a/lib/test/integration.go
+++ b/lib/test/integration.go
@@ -44,9 +44,14 @@ type KnTest struct {
 // NewKnTest creates a new KnTest object
 func NewKnTest() (*KnTest, error) {
 	ns := ""
-	// try next 20 namespace before giving up creating a namespace if it already exists
+	// Try next 20 namespace before giving up creating a namespace if it already exists
 	for i := 0; i < 20; i++ {
 		ns = NextNamespace()
+		if Flags.ReuseNamespace {
+			// Re-using existing namespace, no need to create it.
+			// The namespace is supposed to be created in advance.
+			break
+		}
 		err := CreateNamespace(ns)
 		if err == nil {
 			break
@@ -77,6 +82,10 @@ func NewKnTest() (*KnTest, error) {
 
 // Teardown clean up
 func (test *KnTest) Teardown() error {
+	// If we're reusing existing namespaces leave the deletion to the creator.
+	if Flags.ReuseNamespace {
+		return nil
+	}
 	return DeleteNamespace(test.namespace)
 }
 


### PR DESCRIPTION
* allows for reusing test namespaces that were created in advance
(possibly by a cluster admininstrator)

Fixes one sub-issue from https://github.com/knative/client/issues/1352 which was originally tracked as https://github.com/knative/client/issues/1304

## Description

Introduce -reusenamespace flag which skips creating test namespaces. They're supposed to be created in advance by a user with sufficient privileges (cluster-admin).

This PR has a follow-up here: https://github.com/knative/client/pull/1384

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

*


## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
