### PR TITLE
Run tests as project admin

### DIFF
--- a/lib/test/broker.go
+++ b/lib/test/broker.go
@@ -15,10 +15,11 @@
 package test
 
 import (
-	"gotest.tools/v3/assert"
-	"knative.dev/client/pkg/util"
 	"strings"
 	"time"
+
+	"gotest.tools/v3/assert"
+	"knative.dev/client/pkg/util"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"

--- a/lib/test/broker.go
+++ b/lib/test/broker.go
@@ -15,12 +15,30 @@
 package test
 
 import (
+	"gotest.tools/v3/assert"
+	"knative.dev/client/pkg/util"
 	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 )
+
+func BrokerCreate(r *KnRunResultCollector, name string) {
+	out := r.KnTest().Kn().Run("broker", "create", name)
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "Broker", name, "created", "namespace", r.KnTest().Kn().Namespace()))
+}
+
+func BrokerDelete(r *KnRunResultCollector, name string, wait bool) {
+	args := []string{"broker", "delete", name}
+	if wait {
+		args = append(args, "--wait")
+	}
+	out := r.KnTest().Kn().Run(args...)
+	r.AssertNoError(out)
+	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "Broker", name, "deleted", "namespace", r.KnTest().Kn().Namespace()))
+}
 
 // LabelNamespaceForDefaultBroker adds label 'knative-eventing-injection=enabled' to the configured namespace
 func LabelNamespaceForDefaultBroker(r *KnRunResultCollector) error {

--- a/lib/test/broker.go
+++ b/lib/test/broker.go
@@ -25,12 +25,14 @@ import (
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 )
 
+// BrokerCreate creates a broker with the given name.
 func BrokerCreate(r *KnRunResultCollector, name string) {
 	out := r.KnTest().Kn().Run("broker", "create", name)
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "Broker", name, "created", "namespace", r.KnTest().Kn().Namespace()))
 }
 
+// BrokerDelete deletes a broker with the given name.
 func BrokerDelete(r *KnRunResultCollector, name string, wait bool) {
 	args := []string{"broker", "delete", name}
 	if wait {

--- a/test/README.md
+++ b/test/README.md
@@ -66,6 +66,29 @@ mode, use
 ```bash
 test/local-e2e-tests.sh -short
 ```
+
+### Running E2E tests as a project admin
+
+It is possible to run the E2E tests by a user with reduced privileges, e.g. project admin.
+Some tests require cluster-admin privileges and those tests are excluded from execution in this case.
+Running the E2E tests then consists of these steps:
+1. The cluster admin creates test namespaces. Each test requires a separate namespace.
+By default, the namespace names consist of `kne2etests` prefix and numeric suffix starting from 0:
+ `kne2etests0`, `kne2etests1`, etc. The prefix can be configured using the KN_E2E_NAMESPACE env
+  variable. The namespace can be created as follows:
+    ```bash
+    for i in $(seq 0 40); do kubectl create ns "${KN_E2E_NAMESPACE}${i}"; done
+    ```
+   Note: There are currently slightly over 30 tests but the number will grow so the number of created
+   namespaces need to be adjusted.
+1. The project admin runs the test suite with specific flags:
+    ```bash
+    E2E_TAGS="project_admin" test/local-e2e-tests.sh --reusenamespace
+    ```
+   It is expected that the current user is a project admin for all test namespaces
+   and their KUBECONFIG is located at `$HOME/.kube/config` or the env
+   variable `$KUBECONFIG` points to it.
+
 ### E2E tests prow jobs
 
 Two e2e tests prow jobs are run in CI:

--- a/test/e2e/broker_test.go
+++ b/test/e2e/broker_test.go
@@ -38,46 +38,30 @@ func TestBroker(t *testing.T) {
 	defer r.DumpIfFailed()
 
 	t.Log("create broker, list and describe it")
-	brokerCreate(r, "foo1")
+	test.BrokerCreate(r, "foo1")
 	verifyBrokerList(r, "foo1")
 	verifyBrokerListOutputName(r, "foo1")
 	verifyBrokerDescribe(r, "foo1")
-	brokerDelete(r, "foo1", false)
+	test.BrokerDelete(r, "foo1", false)
 
 	t.Log("create broker and delete it")
-	brokerCreate(r, "foo2")
+	test.BrokerCreate(r, "foo2")
 	verifyBrokerList(r, "foo2")
-	brokerDelete(r, "foo2", true)
+	test.BrokerDelete(r, "foo2", true)
 	verifyBrokerNotfound(r, "foo2")
 
 	t.Log("create multiple brokers and list them")
-	brokerCreate(r, "foo3")
-	brokerCreate(r, "foo4")
+	test.BrokerCreate(r, "foo3")
+	test.BrokerCreate(r, "foo4")
 	verifyBrokerList(r, "foo3", "foo4")
 	verifyBrokerListOutputName(r, "foo3", "foo4")
-	brokerDelete(r, "foo3", true)
-	brokerDelete(r, "foo4", true)
+	test.BrokerDelete(r, "foo3", true)
+	test.BrokerDelete(r, "foo4", true)
 	verifyBrokerNotfound(r, "foo3")
 	verifyBrokerNotfound(r, "foo4")
 }
 
 // Private functions
-
-func brokerCreate(r *test.KnRunResultCollector, name string) {
-	out := r.KnTest().Kn().Run("broker", "create", name)
-	r.AssertNoError(out)
-	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "Broker", name, "created", "namespace", r.KnTest().Kn().Namespace()))
-}
-
-func brokerDelete(r *test.KnRunResultCollector, name string, wait bool) {
-	args := []string{"broker", "delete", name}
-	if wait {
-		args = append(args, "--wait")
-	}
-	out := r.KnTest().Kn().Run(args...)
-	r.AssertNoError(out)
-	assert.Check(r.T(), util.ContainsAllIgnoreCase(out.Stdout, "Broker", name, "deleted", "namespace", r.KnTest().Kn().Namespace()))
-}
 
 func verifyBrokerList(r *test.KnRunResultCollector, brokers ...string) {
 	out := r.KnTest().Kn().Run("broker", "list")

--- a/test/e2e/sink_test.go
+++ b/test/e2e/sink_test.go
@@ -37,9 +37,8 @@ func TestSink(t *testing.T) {
 	defer r.DumpIfFailed()
 
 	// create broker
-	err = test.LabelNamespaceForDefaultBroker(r)
-	assert.NilError(t, err)
-	defer test.UnlabelNamespaceForDefaultBroker(r)
+	test.BrokerCreate(r, "default")
+	defer test.BrokerDelete(r, "default", true)
 
 	t.Log("Create Ping source with a sink to the default broker")
 	pingSourceCreate(r, "testpingsource0", "* * * * */1", "ping", "broker:default")

--- a/test/e2e/source_apiserver_test.go
+++ b/test/e2e/source_apiserver_test.go
@@ -113,14 +113,14 @@ func setupForSourceAPIServer(t *testing.T, it *test.KnTest) {
 	_, err := test.NewKubectl(it.Kn().Namespace()).Run("create", "serviceaccount", testServiceAccount)
 	assert.NilError(t, err)
 
-	_, err = test.Kubectl{}.Run("create", "clusterrole", clusterRolePrefix+it.Kn().Namespace(), "--verb=get,list,watch", "--resource=events,namespaces")
+	_, err = test.Kubectl{}.Run("create", "role", clusterRolePrefix+it.Kn().Namespace(), "--verb=get,list,watch", "--resource=events,namespaces")
 	assert.NilError(t, err)
 
 	_, err = test.Kubectl{}.Run(
 		"create",
-		"clusterrolebinding",
+		"rolebinding",
 		clusterRoleBindingPrefix+it.Kn().Namespace(),
-		"--clusterrole="+clusterRolePrefix+it.Kn().Namespace(),
+		"--role="+clusterRolePrefix+it.Kn().Namespace(),
 		"--serviceaccount="+it.Kn().Namespace()+":"+testServiceAccount)
 	assert.NilError(t, err)
 }
@@ -132,13 +132,13 @@ func tearDownForSourceAPIServer(t *testing.T, it *test.KnTest) error {
 		return fmt.Errorf("Error executing %q: %w", strings.Join(saCmd, " "), err)
 	}
 
-	crCmd := []string{"delete", "clusterrole", clusterRolePrefix + it.Kn().Namespace()}
+	crCmd := []string{"delete", "role", clusterRolePrefix + it.Kn().Namespace()}
 	_, err = test.Kubectl{}.Run(crCmd...)
 	if err != nil {
 		return fmt.Errorf("Error executing %q: %w", strings.Join(saCmd, " "), err)
 	}
 
-	crbCmd := []string{"delete", "clusterrolebinding", clusterRoleBindingPrefix + it.Kn().Namespace()}
+	crbCmd := []string{"delete", "rolebinding", clusterRoleBindingPrefix + it.Kn().Namespace()}
 	_, err = test.Kubectl{}.Run(crbCmd...)
 	if err != nil {
 		return fmt.Errorf("Error executing %q: %w", strings.Join(saCmd, " "), err)

--- a/test/e2e/source_list_crd_test.go
+++ b/test/e2e/source_list_crd_test.go
@@ -1,0 +1,45 @@
+// Copyright 2019 The Knative Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or im
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build e2e
+// +build !serving
+// +build !project_admin
+
+package e2e
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"knative.dev/client/lib/test"
+	"knative.dev/client/pkg/util"
+)
+
+func TestSourceListTypesCRD(t *testing.T) {
+	t.Parallel()
+	it, err := test.NewKnTest()
+	assert.NilError(t, err)
+	defer func() {
+		assert.NilError(t, it.Teardown())
+	}()
+
+	r := test.NewKnRunResultCollector(t, it)
+	defer r.DumpIfFailed()
+
+	t.Log("List available source types in YAML format")
+
+	output = sourceListTypes(r, "-oyaml")
+	assert.Check(t, util.ContainsAll(output, "apiextensions.k8s.io/v1", "CustomResourceDefinition", "Ping", "ApiServer"))
+}

--- a/test/e2e/source_list_crd_test.go
+++ b/test/e2e/source_list_crd_test.go
@@ -27,6 +27,9 @@ import (
 	"knative.dev/client/pkg/util"
 )
 
+// This test requires cluster admin permissions due to working with CustomResourceDefinitions.
+// It can be excluded from test execution by using the project_admin build tag.
+// See https://github.com/knative/client/issues/1385
 func TestSourceListTypesCRD(t *testing.T) {
 	t.Parallel()
 	it, err := test.NewKnTest()

--- a/test/e2e/source_list_crd_test.go
+++ b/test/e2e/source_list_crd_test.go
@@ -40,6 +40,6 @@ func TestSourceListTypesCRD(t *testing.T) {
 
 	t.Log("List available source types in YAML format")
 
-	output = sourceListTypes(r, "-oyaml")
+	output := sourceListTypes(r, "-oyaml")
 	assert.Check(t, util.ContainsAll(output, "apiextensions.k8s.io/v1", "CustomResourceDefinition", "Ping", "ApiServer"))
 }

--- a/test/e2e/source_list_test.go
+++ b/test/e2e/source_list_test.go
@@ -40,11 +40,6 @@ func TestSourceListTypes(t *testing.T) {
 	t.Log("List available source types")
 	output := sourceListTypes(r)
 	assert.Check(t, util.ContainsAll(output, "TYPE", "S", "NAME", "DESCRIPTION", "Ping", "ApiServer"))
-
-	t.Log("List available source types in YAML format")
-
-	output = sourceListTypes(r, "-oyaml")
-	assert.Check(t, util.ContainsAll(output, "apiextensions.k8s.io/v1", "CustomResourceDefinition", "Ping", "ApiServer"))
 }
 
 func TestSourceList(t *testing.T) {

--- a/test/e2e/trigger_test.go
+++ b/test/e2e/trigger_test.go
@@ -37,9 +37,8 @@ func TestBrokerTrigger(t *testing.T) {
 	r := test.NewKnRunResultCollector(t, it)
 	defer r.DumpIfFailed()
 
-	err = test.LabelNamespaceForDefaultBroker(r)
-	assert.NilError(t, err)
-	defer test.UnlabelNamespaceForDefaultBroker(r)
+	test.BrokerCreate(r, "default")
+	defer test.BrokerDelete(r, "default", true)
 
 	test.ServiceCreate(r, "sinksvc0")
 	test.ServiceCreate(r, "sinksvc1")


### PR DESCRIPTION
## Description

This is a follow up to https://github.com/knative/client/pull/1383 (this PR depends on it) and fixes the remaining sub-issues from https://github.com/knative/client/issues/1304
As a result, it will be possible to run the test suite as a project admin (vs. cluster-admin).

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Create Broker explicitly rather than by labeling namespace
* Use Role instead of ClusterRole to work with Sources
* Separate SourceList test for cluster admin and regular user
* Instructions for running E2E as project admin

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes https://github.com/knative/client/issues/1352

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
