### PR TITLE
Skip non modified event first while waiting for ready

### DIFF
--- a/pkg/wait/test_wait_helper.go
+++ b/pkg/wait/test_wait_helper.go
@@ -17,10 +17,8 @@ package wait
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"knative.dev/pkg/apis"
-	duck "knative.dev/pkg/apis/duck/v1"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
@@ -63,8 +61,15 @@ func (f *FakeWatch) fireEvents() {
 	}
 }
 
-// Create a service skeleton with a given ConditionReady status and all other statuses set to otherReadyStatus. Optionally a single generation can be added.
-func CreateTestServiceWithConditions(name string, readyStatus corev1.ConditionStatus, otherReadyStatus corev1.ConditionStatus, reason string, message string, generations ...int64) runtime.Object {
+// CreateTestServiceWithConditions create a service skeleton with a given
+// ConditionReady status and all other statuses set to otherReadyStatus.
+// Optionally a single generation can be added.
+func CreateTestServiceWithConditions(
+	name string,
+	readyStatus, otherReadyStatus corev1.ConditionStatus,
+	reason, message string,
+	generations ...int64,
+) *servingv1.Service {
 	service := servingv1.Service{ObjectMeta: metav1.ObjectMeta{Name: name}}
 	if len(generations) == 2 {
 		service.Generation = generations[0]
@@ -73,10 +78,10 @@ func CreateTestServiceWithConditions(name string, readyStatus corev1.ConditionSt
 		service.Generation = 1
 		service.Status.ObservedGeneration = 1
 	}
-	service.Status.Conditions = duck.Conditions([]apis.Condition{
+	service.Status.Conditions = []apis.Condition{
 		{Type: "RoutesReady", Status: otherReadyStatus},
 		{Type: apis.ConditionReady, Status: readyStatus, Reason: reason, Message: message},
 		{Type: "ConfigurationsReady", Status: otherReadyStatus},
-	})
+	}
 	return &service
 }

--- a/pkg/wait/wait_for_ready.go
+++ b/pkg/wait/wait_for_ready.go
@@ -180,18 +180,6 @@ func (w *waitForReadyConfig) waitForReadyCondition(ctx context.Context, name str
 				return true, false, nil
 			}
 
-			// Check whether resource is in sync already (meta.generation == status.observedGeneration)
-			inSync, err := generationCheck(event.Object)
-			if err != nil {
-				return false, false, err
-			}
-
-			// Skip events if generations has not yet been consolidated, regardless of type.
-			// Wait for the next event to come in until the generations align
-			if !inSync {
-				continue
-			}
-
 			// Skip event if its not a MODIFIED event, as only MODIFIED events update the condition
 			// we are looking for.
 			// This will filter out all synthetic ADDED events that created bt the API server for
@@ -203,6 +191,18 @@ func (w *waitForReadyConfig) waitForReadyCondition(ctx context.Context, name str
 			//  resource version. All following watch events are for all changes that occurred after the resource
 			//  version the watch started at."
 			if event.Type != watch.Modified {
+				continue
+			}
+
+			// Check whether resource is in sync already (meta.generation == status.observedGeneration)
+			inSync, err := generationCheck(event.Object)
+			if err != nil {
+				return false, false, err
+			}
+
+			// Skip events if generations has not yet been consolidated, regardless of type.
+			// Wait for the next event to come in until the generations align
+			if !inSync {
 				continue
 			}
 


### PR DESCRIPTION
## Description

Allow using wait for ready with dynamic kube client, as before this change, an error was received on _Added_ event with unstructured object, which by default doesn't have `.status` field.

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* 🐛 Bug fix of #1389 - Skipping on non-modified event while waiting for ready

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #1389 

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
