### PR TITLE
Adding base64 data handling to ping update command

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,11 @@
 |===
 | | Description | PR
 
+
+| 🎁
+| Adding base64 data handling to ping update command
+| https://github.com/knative/client/pull/1392[#1392], https://github.com/knative/client/pull/1388[#1388]
+
 | ✨
 | make --cmd flag as an array instead of string
 | https://github.com/knative/client/pull/1380[#1380]

--- a/docs/cmd/kn_source_ping_create.md
+++ b/docs/cmd/kn_source_ping_create.md
@@ -18,8 +18,8 @@ kn source ping create NAME --sink SINK
 
 ```
       --ce-override stringArray   Cloud Event overrides to apply before sending event to sink. Example: '--ce-override key=value' You may be provide this flag multiple times. To unset, append "-" to the key (e.g. --ce-override key-).
-  -d, --data string               Json data to send
-  -e, --encoding string           Preferred encoding format. Valid values: text/base64
+  -d, --data string               Data to send in JSON format. This flag can implicitly determine the encoding of the supplied data (text | base64).
+  -e, --encoding string           Data encoding format. One of: text | base64
   -h, --help                      help for create
   -n, --namespace string          Specify the namespace to operate in.
       --schedule string           Optional schedule specification in crontab format (e.g. '*/2 * * * *' for every two minutes. By default fire every minute.

--- a/docs/cmd/kn_source_ping_update.md
+++ b/docs/cmd/kn_source_ping_update.md
@@ -18,8 +18,8 @@ kn source ping update NAME
 
 ```
       --ce-override stringArray   Cloud Event overrides to apply before sending event to sink. Example: '--ce-override key=value' You may be provide this flag multiple times. To unset, append "-" to the key (e.g. --ce-override key-).
-  -d, --data string               Json data to send
-  -e, --encoding string           Preferred encoding format. Valid values: text/base64
+  -d, --data string               Data to send in JSON format. This flag can implicitly determine the encoding of the supplied data (text | base64).
+  -e, --encoding string           Data encoding format. One of: text | base64
   -h, --help                      help for update
   -n, --namespace string          Specify the namespace to operate in.
       --schedule string           Optional schedule specification in crontab format (e.g. '*/2 * * * *' for every two minutes. By default fire every minute.

--- a/pkg/kn/commands/source/ping/describe.go
+++ b/pkg/kn/commands/source/ping/describe.go
@@ -117,7 +117,11 @@ func NewPingDescribeCommand(p *commands.KnParams) *cobra.Command {
 func writePingSource(dw printers.PrefixWriter, source *clientsourcesv1beta2.PingSource, printDetails bool) {
 	commands.WriteMetadata(dw, &source.ObjectMeta, printDetails)
 	dw.WriteAttribute("Schedule", source.Spec.Schedule)
-	dw.WriteAttribute("Data", source.Spec.Data)
+	if source.Spec.DataBase64 != "" {
+		dw.WriteAttribute("DataBase64", source.Spec.DataBase64)
+	} else {
+		dw.WriteAttribute("Data", source.Spec.Data)
+	}
 }
 
 func writeCeOverrides(dw printers.PrefixWriter, ceOverrides map[string]string) {

--- a/pkg/kn/commands/source/ping/describe_test.go
+++ b/pkg/kn/commands/source/ping/describe_test.go
@@ -37,8 +37,16 @@ func TestDescribeRef(t *testing.T) {
 
 	out, err := executePingSourceCommand(pingClient, nil, "describe", "testping")
 	assert.NilError(t, err)
-	assert.Assert(t, util.ContainsAll(out, "*/2 * * * *", "test", "testsvc", "Service", "Overrides", "foo", "bar", "Conditions"))
+	assert.Assert(t, util.ContainsAll(out, "*/2 * * * *", "test", "testsvc", "Service", "Overrides", "foo", "bar", "Conditions", "Data:"))
+	assert.Assert(t, util.ContainsNone(out, "DataBase64"))
+	pingRecorder.Validate()
 
+	pingRecorder.GetPingSource("testping",
+		createPingSource("testping", "*/2 * * * *", "", "cGluZw==", "testsvc", map[string]string{"foo": "bar"}), nil)
+	out, err = executePingSourceCommand(pingClient, nil, "describe", "testping")
+	assert.NilError(t, err)
+	assert.Assert(t, util.ContainsAll(out, "*/2 * * * *", "test", "testsvc", "Service", "Overrides", "foo", "bar", "Conditions", "DataBase64"))
+	assert.Assert(t, util.ContainsNone(out, "Data:"))
 	pingRecorder.Validate()
 }
 

--- a/pkg/kn/commands/source/ping/ping_test.go
+++ b/pkg/kn/commands/source/ping/ping_test.go
@@ -16,6 +16,9 @@ package ping
 
 import (
 	"bytes"
+	"testing"
+
+	"gotest.tools/v3/assert"
 
 	"k8s.io/client-go/tools/clientcmd"
 	sourcesv1beta2 "knative.dev/eventing/pkg/apis/sources/v1beta2"
@@ -51,6 +54,22 @@ current-context: x
 	if err != nil {
 		panic(err)
 	}
+}
+
+func TestPingBuilder(t *testing.T) {
+	name := "mockName"
+	schedule := "* * * * *"
+	data := "mockData"
+	dataBase64 := "mockDataBase64"
+	sink := "mockService"
+	ceOverrideMap := map[string]string{}
+	ps := createPingSource(name, schedule, data, dataBase64, sink, ceOverrideMap)
+	assert.Equal(t, name, ps.Name)
+	assert.Equal(t, schedule, ps.Spec.Schedule)
+	assert.Equal(t, data, ps.Spec.Data)
+	assert.Equal(t, dataBase64, ps.Spec.DataBase64)
+	assert.Equal(t, sink, ps.Spec.Sink.Ref.Name)
+	assert.DeepEqual(t, ceOverrideMap, ps.Spec.CloudEventOverrides.Extensions)
 }
 
 func executePingSourceCommand(pingSourceClient clientv1beta2.KnPingSourcesClient, dynamicClient kndynamic.KnDynamicClient, args ...string) (string, error) {

--- a/pkg/kn/commands/source/ping/update.go
+++ b/pkg/kn/commands/source/ping/update.go
@@ -70,8 +70,15 @@ func NewPingUpdateCommand(p *commands.KnParams) *cobra.Command {
 			if cmd.Flags().Changed("schedule") {
 				b.Schedule(updateFlags.schedule)
 			}
+
+			data, dataBase64, err := getDataFields(&updateFlags)
+			if err != nil {
+				return fmt.Errorf("cannot update PingSource %q in namespace "+
+					"%q because: %s", name, namespace, err)
+			}
+
 			if cmd.Flags().Changed("data") {
-				b.Data(updateFlags.data)
+				b.Data(data).DataBase64(dataBase64)
 			}
 			if cmd.Flags().Changed("sink") {
 				destination, err := sinkFlags.ResolveSink(cmd.Context(), dynamicClient, namespace)

--- a/pkg/kn/commands/source/ping/update_test.go
+++ b/pkg/kn/commands/source/ping/update_test.go
@@ -43,6 +43,28 @@ func TestSimplePingUpdate(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, util.ContainsAll(out, "updated", "default", "testsource"))
 
+	pingRecorder.GetPingSource("testsource", createPingSource("testsource", "* * * * */1", "maxwell", "", "mysvc", nil), nil)
+	pingRecorder.UpdatePingSource(createPingSource("testsource", "* * * * */3", "", "hello", "mysvc", nil), nil)
+	out, err = executePingSourceCommand(pingSourceClient, dynamicClient, "update", "--schedule", "* * * * */3", "testsource", "--data", "hello", "--encoding", "base64")
+	assert.NilError(t, err)
+	assert.Assert(t, util.ContainsAll(out, "updated", "default", "testsource"))
+
+	pingRecorder.GetPingSource("testsource", createPingSource("testsource", "* * * * */1", "maxwell", "", "mysvc", nil), nil)
+	pingRecorder.UpdatePingSource(createPingSource("testsource", "* * * * */3", "hello", "", "mysvc", nil), nil)
+	out, err = executePingSourceCommand(pingSourceClient, dynamicClient, "update", "--schedule", "* * * * */3", "testsource", "--data", "hello", "--encoding", "text")
+	assert.NilError(t, err)
+	assert.Assert(t, util.ContainsAll(out, "updated", "default", "testsource"))
+
+	pingRecorder.GetPingSource("testsource", createPingSource("testsource", "* * * * */1", "maxwell", "", "mysvc", nil), nil)
+	pingRecorder.UpdatePingSource(createPingSource("testsource", "* * * * */3", "", "aGVsbG8=", "mysvc", nil), nil)
+	out, err = executePingSourceCommand(pingSourceClient, dynamicClient, "update", "--schedule", "* * * * */3", "testsource", "--data", "aGVsbG8=")
+	assert.NilError(t, err)
+	assert.Assert(t, util.ContainsAll(out, "updated", "default", "testsource"))
+
+	pingRecorder.GetPingSource("testsource", createPingSource("testsource", "* * * * */1", "maxwell", "", "mysvc", nil), nil)
+	_, err = executePingSourceCommand(pingSourceClient, dynamicClient, "update", "--schedule", "* * * * */3", "testsource", "--data", "aGVsbG8=", "--encoding", "mockencoding")
+	assert.ErrorContains(t, err, "invalid value")
+
 	pingRecorder.Validate()
 }
 


### PR DESCRIPTION
## Description

Adding base64 data handling to ping update command. Handling comments from #1388 

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Adding a test case to test builder functions
* Handling base64 data in update command
* Modified usage/error strings for more clarity

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #1204 

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
