### PR TITLE
Fix issue with Windows pathes not being escaped when applying a regexp.

### DIFF
--- a/cmd/kn/main.go
+++ b/cmd/kn/main.go
@@ -193,7 +193,7 @@ func printError(err error) {
 // by checking a pattern like 'kn service' in the error message. If not found, return the
 // base command name.
 func extractCommandPathFromErrorMessage(errorMsg string, arg0 string) string {
-	extractPattern := regexp.MustCompile(fmt.Sprintf("'(%s\\s.+?)'", arg0))
+	extractPattern := regexp.MustCompile(fmt.Sprintf("'(%s\\s.+?)'", regexp.QuoteMeta(arg0)))
 	command := extractPattern.FindSubmatch([]byte(errorMsg))
 	if command != nil {
 		return string(command[1])

--- a/cmd/kn/main_test.go
+++ b/cmd/kn/main_test.go
@@ -335,6 +335,15 @@ func TestRunWithExit(t *testing.T) {
 	}
 }
 
+func TestExtractCommandPathFromErrorMessage(t *testing.T) {
+	for _, d := range []struct{ arg0, errMsg, expected string }{
+		{"kn", "Invalid argument for 'kn service'", "kn service"},
+		{"C:\\Users\\hudson.DESKTOP-T61GB27\\Documents\\foo-with-revisions", "Invalid argument for 'C:\\Users\\hudson.DESKTOP-T61GB27\\Documents\\foo-with-revisions test'", "C:\\Users\\hudson.DESKTOP-T61GB27\\Documents\\foo-with-revisions test"},
+	} {
+		assert.Equal(t, extractCommandPathFromErrorMessage(d.errMsg, d.arg0), d.expected)
+	}
+}
+
 type internalPlugin struct {
 	executeError func() error
 	commandParts []string


### PR DESCRIPTION
## Description

There have been issues when a full Windows path has been inserted literally to create a regexp, since the backslashes used as path separators are confusing the regexp engine. This fix will quote any input coming from the outside.

