### PR TITLE
Use namespaced kubectl for sa,role,rolebinding in tests

### DIFF
--- a/test/e2e/source_apiserver_test.go
+++ b/test/e2e/source_apiserver_test.go
@@ -110,13 +110,14 @@ func apiServerSourceDelete(r *test.KnRunResultCollector, sourceName string) {
 }
 
 func setupForSourceAPIServer(t *testing.T, it *test.KnTest) {
-	_, err := test.NewKubectl(it.Kn().Namespace()).Run("create", "serviceaccount", testServiceAccount)
+	kubectl := test.NewKubectl(it.Kn().Namespace())
+	_, err := kubectl.Run("create", "serviceaccount", testServiceAccount)
 	assert.NilError(t, err)
 
-	_, err = test.Kubectl{}.Run("create", "role", clusterRolePrefix+it.Kn().Namespace(), "--verb=get,list,watch", "--resource=events,namespaces")
+	_, err = kubectl.Run("create", "role", clusterRolePrefix+it.Kn().Namespace(), "--verb=get,list,watch", "--resource=events,namespaces")
 	assert.NilError(t, err)
 
-	_, err = test.Kubectl{}.Run(
+	_, err = kubectl.Run(
 		"create",
 		"rolebinding",
 		clusterRoleBindingPrefix+it.Kn().Namespace(),
@@ -126,20 +127,21 @@ func setupForSourceAPIServer(t *testing.T, it *test.KnTest) {
 }
 
 func tearDownForSourceAPIServer(t *testing.T, it *test.KnTest) error {
+	kubectl := test.NewKubectl(it.Kn().Namespace())
 	saCmd := []string{"delete", "serviceaccount", testServiceAccount}
-	_, err := test.NewKubectl(it.Kn().Namespace()).Run(saCmd...)
+	_, err := kubectl.Run(saCmd...)
 	if err != nil {
 		return fmt.Errorf("Error executing %q: %w", strings.Join(saCmd, " "), err)
 	}
 
 	crCmd := []string{"delete", "role", clusterRolePrefix + it.Kn().Namespace()}
-	_, err = test.Kubectl{}.Run(crCmd...)
+	_, err = kubectl.Run(crCmd...)
 	if err != nil {
 		return fmt.Errorf("Error executing %q: %w", strings.Join(saCmd, " "), err)
 	}
 
 	crbCmd := []string{"delete", "rolebinding", clusterRoleBindingPrefix + it.Kn().Namespace()}
-	_, err = test.Kubectl{}.Run(crbCmd...)
+	_, err = kubectl.Run(crbCmd...)
 	if err != nil {
 		return fmt.Errorf("Error executing %q: %w", strings.Join(saCmd, " "), err)
 	}


### PR DESCRIPTION
## Description

The resources are now namespaced-scoped so we should be using a kubectl with configured namespace

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

*
*
*

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
