### PR TITLE
Server errors should not be tainted by client error messages

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,10 @@
 |===
 | | Description | PR
 
+| 🐛
+| Show server error messages without any taints
+| https://github.com/knative/client/pull/1406[#1406]
+
 | 🎁
 | Add an `client.knative.dev/updateTimestamp` annotation to trigger a new revision when required
 | https://github.com/knative/client/pull/1364[#1364]

--- a/pkg/errors/factory.go
+++ b/pkg/errors/factory.go
@@ -69,10 +69,10 @@ func GetError(err error) error {
 	}
 
 	switch {
-	case isEmptyConfigError(err):
-		return newNoKubeConfig(err.Error())
 	case isStatusError(err):
 		return newStatusError(err)
+	case isEmptyConfigError(err):
+		return newNoKubeConfig(err.Error())
 	case isNoRouteToHostError(err):
 		return newNoRouteToHost(err.Error())
 	default:

--- a/pkg/errors/factory.go
+++ b/pkg/errors/factory.go
@@ -47,16 +47,11 @@ func GetError(err error) error {
 		return nil
 	}
 
+	var errAPIStatus api_errors.APIStatus
 	switch {
 	case isEmptyConfigError(err):
 		return newNoKubeConfig(err.Error())
-	case isNoRouteToHostError(err):
-		return newNoRouteToHost(err.Error())
-	default:
-		var errAPIStatus api_errors.APIStatus
-		if !errors.As(err, &errAPIStatus) {
-			return err
-		}
+	case errors.As(err, &errAPIStatus):
 		if errAPIStatus.Status().Details == nil {
 			return err
 		}
@@ -66,8 +61,12 @@ func GetError(err error) error {
 			knerr.Status = errAPIStatus
 			return knerr
 		}
+	case isNoRouteToHostError(err):
+		return newNoRouteToHost(err.Error())
+	default:
 		return err
 	}
+	return err
 }
 
 // IsForbiddenError returns true if given error can be converted to API status and of type forbidden access else false


### PR DESCRIPTION
## Description
In some cases, if an error  is from server but contains a substring that matches a client side error condition, the error returned by the server is being accompanied by the client side error message. This should not be the case.

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Moved the server error parsing case up so it gets processed before we breakdown the error string for client level message.
* Added test cases.

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #1342 

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
