### PR TITLE
Use revision-name flag in kn service apply

### DIFF
--- a/pkg/kn/commands/service/apply.go
+++ b/pkg/kn/commands/service/apply.go
@@ -66,7 +66,6 @@ func NewServiceApplyCommand(p *commands.KnParams) *cobra.Command {
 			}
 
 			var service *servingv1.Service
-			applyFlags.RevisionName = ""
 			if applyFlags.Filename == "" {
 				service, err = constructService(cmd, applyFlags, name, namespace)
 			} else {


### PR DESCRIPTION
## Description
`kn service apply --revision-name ` should use the revision name argument to generate revision name.

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Removed the line setting the revision name to empty in apply flag.
* Tested that applying the same revision name to the service would not result in error as follows:
```
No changes to apply to service 'xyzsvc'.
Service 'xyzsvc' with latest revision 'xyzsvc-abcde' (unchanged) is available at URL:
http://xyzsvc.knativetutorial.192.168.49.2.nip.io

```


## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #1184 

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
