### PR TITLE
Look up plugins on $PATH by default

### DIFF
--- a/pkg/kn/config/config.go
+++ b/pkg/kn/config/config.go
@@ -178,7 +178,7 @@ func initDefaults() *defaultConfig {
 	return &defaultConfig{
 		configFile:          defaultConfigLocation("config.yaml"),
 		pluginsDir:          defaultConfigLocation("plugins"),
-		lookupPluginsInPath: false,
+		lookupPluginsInPath: true,
 	}
 }
 


### PR DESCRIPTION
## Description

Look for knative plugins on the user's $PATH by default

## Changes

* Set default value of `lookupPluginsInPath` to `true`

This results in the following behavior (copying from [Roland's comment](https://github.com/knative/client/issues/1399#issuecomment-888182293)):

    * Lookup plugins from both, the path and `~/.config/kn/plugins`.
    * Same named plugin in `~/.config/kn/plugins` take precedence over plugins found on the PATH.

This would also allow for system-wide plugins as installed by brew in `/usr/local/bin`, but allow individual users to override plugins in their `~/.config/kn/plugins` directory. Also, for people that currently collect their plugins in `~/.config/kn/plugins` nothing would change. It's just as if you would add this directory to the front of your $PATH.

## Reference

Fixes #1399 

/lint

