### PR TITLE
Fixing bug when looking up plugins on path with slash in argument

### DIFF
--- a/pkg/kn/plugin/manager.go
+++ b/pkg/kn/plugin/manager.go
@@ -401,6 +401,10 @@ func findMostSpecificPluginInPath(dir string, parts []string, lookupInPath bool)
 		var nameParts []string
 		var commandParts []string
 		for _, p := range parts[0:i] {
+			// skip arguments with slashes
+			if strings.Contains(p, "/") || strings.Contains(p, "\\") {
+				continue
+			}
 			// Subcommands with "-" are translated to "_"
 			// (e.g. a command  "kn log-all" is translated to a plugin "kn-log_all")
 			nameParts = append(nameParts, convertDashToUnderscore(p))

--- a/pkg/kn/plugin/manager.go
+++ b/pkg/kn/plugin/manager.go
@@ -401,9 +401,10 @@ func findMostSpecificPluginInPath(dir string, parts []string, lookupInPath bool)
 		var nameParts []string
 		var commandParts []string
 		for _, p := range parts[0:i] {
-			// skip arguments with slashes
-			if strings.Contains(p, "/") || strings.Contains(p, "\\") {
-				continue
+			// for arguments that contain the path separator,
+			// stop the loop once the separator appears
+			if strings.Contains(p, string(os.PathSeparator)) {
+				break
 			}
 			// Subcommands with "-" are translated to "_"
 			// (e.g. a command  "kn log-all" is translated to a plugin "kn-log_all")

--- a/pkg/kn/plugin/manager_test.go
+++ b/pkg/kn/plugin/manager_test.go
@@ -301,6 +301,33 @@ func TestPluginList(t *testing.T) {
 	}
 }
 
+func TestNoSlashInPlugin(t *testing.T) {
+	ctx := setup(t)
+	defer cleanup(t, ctx)
+
+	// Prepare PATH
+	tmpPathDir, cleanupFunc := preparePathDirectory(t)
+	defer cleanupFunc()
+
+	fmt.Println(tmpPathDir)
+
+	createTestPluginInDirectory(t, "kn-path-test", tmpPathDir)
+	pluginCommands := []string{"path", "test", "/withslash"}
+
+	// args with slash are not returned
+	ctx.pluginManager.lookupInPath = true
+	plugin, err := ctx.pluginManager.FindPlugin(pluginCommands)
+	assert.NilError(t, err)
+	assert.Assert(t, plugin != nil)
+	desc, err := plugin.Description()
+	name := plugin.Name()
+	fmt.Println(plugin.Name())
+	assert.NilError(t, err)
+	assert.Assert(t, desc != "")
+	assert.Equal(t, plugin.Path(), filepath.Join(tmpPathDir, "kn-path-test"))
+	assert.Assert(t, !strings.Contains(name, "/"))
+}
+
 // ====================================================================
 // Private
 


### PR DESCRIPTION
## Description

Per discussion in [PR 1412](https://github.com/knative/client/pull/1412#issuecomment-892857273), found a bug where we fail to look up in path when there's slash in arguments. (This bug was also causing the service import test to fail). 

## Changes

* fixing bug when looking up plugins on path with slash in argument

(changelog entry to follow)

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

/lint
