### PR TITLE
Fix unit tests clash with local kubeconfig

### DIFF
--- a/pkg/kn/commands/namespaced_test.go
+++ b/pkg/kn/commands/namespaced_test.go
@@ -153,6 +153,24 @@ func TestGetNamespaceFallback(t *testing.T) {
 	actual, err := kp.GetNamespace(testCmd)
 	assert.NilError(t, err)
 	assert.Assert(t, actual == "default")
+
+	tempFile = filepath.Join(tempDir, "empty")
+	err = ioutil.WriteFile(tempFile, []byte(""), test.FileModeReadWrite)
+	assert.NilError(t, err)
+
+	testCmd = testCommandGenerator(true)
+	kp = &KnParams{KubeCfgPath: tempFile}
+	testCmd.Execute()
+	actual, err = kp.GetNamespace(testCmd)
+	assert.NilError(t, err)
+	assert.Assert(t, actual == "default")
+
+	testCmd = testCommandGenerator(true)
+	kp = &KnParams{KubeCfgPath: filepath.Join(tempDir, "missing")}
+	testCmd.Execute()
+	actual, err = kp.GetNamespace(testCmd)
+	assert.ErrorContains(t, err, "can not be found")
+	assert.Assert(t, actual == "")
 }
 
 func TestCurrentNamespace(t *testing.T) {

--- a/pkg/kn/commands/namespaced_test.go
+++ b/pkg/kn/commands/namespaced_test.go
@@ -17,6 +17,8 @@ package commands
 import (
 	"testing"
 
+	"k8s.io/client-go/tools/clientcmd"
+
 	"github.com/spf13/cobra"
 	"gotest.tools/v3/assert"
 )
@@ -47,6 +49,8 @@ func TestGetNamespaceSample(t *testing.T) {
 		t.Fatalf("Incorrect namespace retrieved: %v, expected: %v", actualNamespace, expectedNamespace)
 	}
 	kp = &KnParams{}
+	// Mock ClientConfig to avoid clash with real kubeconfig on host OS
+	kp.ClientConfig, _ = clientcmd.NewClientConfigFromBytes([]byte(BASIC_KUBECONFIG))
 	testCmd = testCommandGenerator(false)
 	actualNamespace, err = kp.GetNamespace(testCmd)
 	assert.NilError(t, err)

--- a/pkg/kn/commands/namespaced_test.go
+++ b/pkg/kn/commands/namespaced_test.go
@@ -16,10 +16,11 @@ package commands
 
 import (
 	"io/ioutil"
-	"knative.dev/client/lib/test"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"knative.dev/client/lib/test"
 
 	"k8s.io/client-go/tools/clientcmd"
 

--- a/pkg/kn/commands/revision/revision_test.go
+++ b/pkg/kn/commands/revision/revision_test.go
@@ -33,6 +33,29 @@ import (
 // Helper methods
 var blankConfig clientcmd.ClientConfig
 
+const kubeConfig = `kind: Config
+version: v1
+users:
+- name: u
+clusters:
+- name: c
+  cluster:
+    server: example.com
+contexts:
+- name: x
+  context:
+    user: u
+    cluster: c
+current-context: x`
+
+func init() {
+	var err error
+	blankConfig, err = clientcmd.NewClientConfigFromBytes([]byte(kubeConfig))
+	if err != nil {
+		panic(err)
+	}
+}
+
 func TestExtractTrafficAndTag(t *testing.T) {
 
 	service := &servingv1.Service{

--- a/pkg/kn/commands/types_test.go
+++ b/pkg/kn/commands/types_test.go
@@ -55,9 +55,7 @@ current-context: a
 
 func TestPrepareConfig(t *testing.T) {
 	basic, err := clientcmd.NewClientConfigFromBytes([]byte(BASIC_KUBECONFIG))
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NilError(t, err)
 	for i, tc := range []configTestCase{
 		{
 			clientcmd.NewDefaultClientConfig(clientcmdapi.Config{}, &clientcmd.ConfigOverrides{}),
@@ -96,7 +94,10 @@ func TestPrepareConfig(t *testing.T) {
 			}
 		}
 	}
-	_, err = (&KnParams{}).RestConfig()
+	kpEmptyConfig := &KnParams{}
+	kpEmptyConfig.ClientConfig, err = clientcmd.NewClientConfigFromBytes([]byte(""))
+	assert.NilError(t, err)
+	_, err = kpEmptyConfig.RestConfig()
 	assert.ErrorContains(t, err, "no kubeconfig")
 
 }

--- a/pkg/kn/commands/types_test.go
+++ b/pkg/kn/commands/types_test.go
@@ -16,9 +16,13 @@ package commands
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"knative.dev/client/lib/test"
 
 	"gotest.tools/v3/assert"
 	"k8s.io/client-go/tools/clientcmd"
@@ -100,6 +104,10 @@ func TestPrepareConfig(t *testing.T) {
 	_, err = kpEmptyConfig.RestConfig()
 	assert.ErrorContains(t, err, "no kubeconfig")
 
+	kpEmptyConfig = &KnParams{}
+	kpEmptyConfig.KubeCfgPath = filepath.Join("non", "existing", "file")
+	_, err = kpEmptyConfig.RestConfig()
+	assert.ErrorContains(t, err, "can not be found")
 }
 
 type typeTestCase struct {
@@ -112,12 +120,27 @@ type typeTestCase struct {
 
 func TestGetClientConfig(t *testing.T) {
 	multiConfigs := fmt.Sprintf("%s%s%s", "/testing/assets/kube-config-01.yml", string(os.PathListSeparator), "/testing/assets/kube-config-02.yml")
+
+	tempDir, err := ioutil.TempDir("", "kn-unit-tests")
+	defer os.RemoveAll(tempDir)
+	assert.NilError(t, err)
+	tempFile := filepath.Join(tempDir, "mock")
+	err = ioutil.WriteFile(tempFile, []byte(BASIC_KUBECONFIG), test.FileModeReadWrite)
+	assert.NilError(t, err)
+
 	for _, tc := range []typeTestCase{
 		{
 			"",
 			"",
 			"",
 			clientcmd.NewDefaultClientConfigLoadingRules().ExplicitPath,
+			"",
+		},
+		{
+			tempFile,
+			"",
+			"",
+			tempFile,
 			"",
 		},
 		{
@@ -138,6 +161,7 @@ func TestGetClientConfig(t *testing.T) {
 		p := &KnParams{
 			KubeCfgPath: tc.kubeCfgPath,
 			KubeContext: tc.kubeContext,
+			KubeCluster: tc.kubeCluster,
 		}
 
 		clientConfig, err := p.GetClientConfig()


### PR DESCRIPTION
## Description

This PR is fixing several cases, when local/hosts `kubeconfig` might clash with actual tests. That should be handled by mocked or empty configs instead.

E.g.: having namespace point to `knative-serving` instead of `default` was causing test failures.

```
 === RUN   TestGetNamespaceSample
    namespaced_test.go:53: assertion failed: default (string) != knative-serving (actualNamespace string) 
```

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Fix unit tests clash with local kubeconfig


