### PR TITLE
Prepare changelog and version for 0.25 release

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,7 +12,7 @@
 | https://github.com/knative/client/pull/[#]
 ////
 
-## Unreleased
+## v0.25.0 (2021-08-10)
 [cols="1,10,3", options="header", width="100%"]
 |===
 | | Description | PR
@@ -21,6 +21,13 @@
 | Deprecate `lookup-path` as path lookup will always be enabled in the future
 | https://github.com/knative/client/pull/1422[#1422]
 
+| 🎁
+| Add `--tls` option to domain create command
+| https://github.com/knative/client/pull/1419[#1419]
+
+| 🐛
+| Fix plugin lookup for arguments with slashes
+| https://github.com/knative/client/pull/1415[#1415]
 
 | ✨
 | Lookup plugins in `$PATH` by default
@@ -31,31 +38,31 @@
 | https://github.com/knative/client/pull/1406[#1406]
 
 | 🎁
-| Adding `--tls` option to domain create command
-| https://github.com/knative/client/pull/1419[#1419]
-
-| 🎁
-| Add an `client.knative.dev/updateTimestamp` annotation to trigger a new revision when required
-| https://github.com/knative/client/pull/1364[#1364]
-
-| 🎁
-| Adding `--class` flag to broker create command
+| Add `--class` flag to broker create command
 | https://github.com/knative/client/pull/1402[#1402]
 
 | 🎁
-| Adding `darwin/arm64` support to kn
+| Add `darwin/arm64` support to kn
 | https://github.com/knative/client/pull/1401[#1401]
 
+| 🐛
+| Fix path not being escaped when applying a regex on Windows
+| https://github.com/knative/client/pull/1395[#1395]
+
 | 🎁
-| Adding base64 data handling to ping update command
+| Add `base64` data handling to Ping commands
 | https://github.com/knative/client/pull/1392[#1392], https://github.com/knative/client/pull/1388[#1388]
+
+| 🐛
+| Fix wait for ready to skip non modified event first
+| https://github.com/knative/client/pull/1390[#1390]
 
 | 🎁
 | Add support for multiple containers in Service spec
 | https://github.com/knative/client/pull/1382[#1382]
 
 | ✨
-| make --cmd flag as an array instead of string
+| Make `--cmd` flag as an array instead of string
 | https://github.com/knative/client/pull/1380[#1380]
 
 | 🎁

--- a/pkg/kn/commands/version/version.go
+++ b/pkg/kn/commands/version/version.go
@@ -31,11 +31,11 @@ var GitRevision string
 // update this var as we add more deps
 var apiVersions = map[string][]string{
 	"serving": {
-		"serving.knative.dev/v1 (knative-serving v0.24.0)",
+		"serving.knative.dev/v1 (knative-serving v0.25.0)",
 	},
 	"eventing": {
-		"sources.knative.dev/v1 (knative-eventing v0.24.0)",
-		"eventing.knative.dev/v1 (knative-eventing v0.24.0)",
+		"sources.knative.dev/v1 (knative-eventing v0.25.0)",
+		"eventing.knative.dev/v1 (knative-eventing v0.25.0)",
 	},
 }
 


### PR DESCRIPTION
## Description

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Add missing entries to changelog
* Bump `version` strings to 0.25


/cc @rhuss 

FYI @knative/knative-release-leads, that's part of client release checklist, the remaining items are:
* Version bump in `go.mod`
* Update the version numbers of Serving and Eventing in test/presubmit-integration-tests-latest-release.sh so that the integration test is already running against the just released serving and eventing versions.