### PR TITLE
Fix release script to published darwin/arm64 bits

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -45,7 +45,7 @@ function build_release() {
   GOOS=linux GOARCH=ppc64le go build -mod=vendor -ldflags "${ld_flags}" -o ./kn-linux-ppc64le ./cmd/...
   echo "🚧 🐳 Building the container image"
   ko resolve ${KO_FLAGS} -f config/ > kn-image-location.yaml
-  ARTIFACTS_TO_PUBLISH="kn-darwin-amd64 kn-linux-amd64 kn-linux-arm64 kn-windows-amd64.exe kn-linux-s390x kn-linux-ppc64le kn-image-location.yaml"
+  ARTIFACTS_TO_PUBLISH="kn-darwin-amd64 kn-darwin-arm64 kn-linux-amd64 kn-linux-arm64 kn-windows-amd64.exe kn-linux-s390x kn-linux-ppc64le kn-image-location.yaml"
   sha256sum ${ARTIFACTS_TO_PUBLISH} > checksums.txt
   ARTIFACTS_TO_PUBLISH="${ARTIFACTS_TO_PUBLISH} checksums.txt"
   echo "🧮     Checksum:"


### PR DESCRIPTION

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Fix release script to published darwin/arm64 bits 

We can probably upload the artifact manually to the release, but that'd require updated checksum file as well. Or we could probably release `0.25.1.` once we get a few more bugs to backport?

/cc @rhuss @maximilien 

