### PR TITLE
fix kn trigger list command to show correct v1/service sink output

### DIFF
--- a/pkg/kn/commands/flags/sink.go
+++ b/pkg/kn/commands/flags/sink.go
@@ -149,7 +149,7 @@ func parseSink(sink string) (string, string, string) {
 // SinkToString prepares a sink for list output
 func SinkToString(sink duckv1.Destination) string {
 	if sink.Ref != nil {
-		if sink.Ref.Kind == "Service" && strings.Contains(sink.Ref.APIVersion, sinkMappings["ksvc"].Group) {
+		if sink.Ref.Kind == "Service" && strings.HasPrefix(sink.Ref.APIVersion, sinkMappings["ksvc"].Group) {
 			return fmt.Sprintf("ksvc:%s", sink.Ref.Name)
 		} else {
 			return fmt.Sprintf("%s:%s", strings.ToLower(sink.Ref.Kind), sink.Ref.Name)

--- a/pkg/kn/commands/flags/sink.go
+++ b/pkg/kn/commands/flags/sink.go
@@ -149,7 +149,7 @@ func parseSink(sink string) (string, string, string) {
 // SinkToString prepares a sink for list output
 func SinkToString(sink duckv1.Destination) string {
 	if sink.Ref != nil {
-		if sink.Ref.Kind == "Service" {
+		if sink.Ref.Kind == "Service" && strings.Contains(sink.Ref.APIVersion, sinkMappings["ksvc"].Group) {
 			return fmt.Sprintf("ksvc:%s", sink.Ref.Name)
 		} else {
 			return fmt.Sprintf("%s:%s", strings.ToLower(sink.Ref.Kind), sink.Ref.Name)

--- a/pkg/kn/commands/flags/sink_test.go
+++ b/pkg/kn/commands/flags/sink_test.go
@@ -194,6 +194,13 @@ func TestSinkToString(t *testing.T) {
 			Name:       "default"}}
 	expected = "broker:default"
 	assert.Equal(t, expected, SinkToString(sink))
+	sink = duckv1.Destination{
+		Ref: &duckv1.KReference{Kind: "Service",
+			APIVersion: "v1",
+			Namespace:  "my-namespace",
+			Name:       "mysvc"}}
+	expected = "service:mysvc"
+	assert.Equal(t, expected, SinkToString(sink))
 
 	uri := "http://target.example.com"
 	targetExampleCom, err := apis.ParseURL(uri)

--- a/pkg/kn/commands/source/duck/multisourcelist_test.go
+++ b/pkg/kn/commands/source/duck/multisourcelist_test.go
@@ -83,8 +83,9 @@ func newSourceUnstructuredObjWithSink(name, apiVersion, kind string) *unstructur
 			"spec": map[string]interface{}{
 				"sink": map[string]interface{}{
 					"ref": map[string]interface{}{
-						"kind": "Service",
-						"name": "foo",
+						"apiVersion": "serving.knative.dev/v1",
+						"kind":       "Service",
+						"name":       "foo",
 					},
 				},
 			},

--- a/pkg/kn/commands/source/list_test.go
+++ b/pkg/kn/commands/source/list_test.go
@@ -188,8 +188,9 @@ func newSourceUnstructuredObj(name, apiVersion, kind string) *unstructured.Unstr
 			"spec": map[string]interface{}{
 				"sink": map[string]interface{}{
 					"ref": map[string]interface{}{
-						"kind": "Service",
-						"name": "foo",
+						"apiVersion": "serving.knative.dev/v1",
+						"kind":       "Service",
+						"name":       "foo",
 					},
 				},
 			},


### PR DESCRIPTION
## Description
If the sink of the trigger is a normal service, the  `kn trigger list` command will show it as ksvc, which is incorrect
<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

*
*
*

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
