### PR TITLE
TestServiceExport works with images specified by digest

### DIFF
--- a/test/e2e/service_export_test.go
+++ b/test/e2e/service_export_test.go
@@ -55,11 +55,16 @@ func TestServiceExport(t *testing.T) {
 	t.Log("create service with byo revision")
 	serviceCreateWithOptions(r, "hello", "--revision-name", "rev1")
 
+	userImage := pkgtest.ImagePath("helloworld")
+	if strings.Contains(userImage, "@") {
+		// Images specified by digest are not set in user-image annotation.
+		userImage = ""
+	}
 	t.Log("export service-revision1 and compare")
 	serviceExport(r, "hello", test.BuildServiceWithOptions("hello",
 		servingtest.WithConfigSpec(test.BuildConfigurationSpec()),
 		servingtest.WithBYORevisionName("hello-rev1"),
-		test.WithRevisionAnnotations(map[string]string{"client.knative.dev/user-image": pkgtest.ImagePath("helloworld")}),
+		test.WithRevisionAnnotations(map[string]string{"client.knative.dev/user-image": userImage}),
 	), "--mode", "replay", "-o", "json")
 
 	t.Log("update service - add env variable")
@@ -97,7 +102,7 @@ func TestServiceExport(t *testing.T) {
 			servingtest.WithConfigSpec(test.BuildConfigurationSpec()),
 			servingtest.WithBYORevisionName("hello-rev1"),
 			test.WithRevisionAnnotations(map[string]string{
-				"client.knative.dev/user-image": pkgtest.ImagePath("helloworld"),
+				"client.knative.dev/user-image": userImage,
 				"serving.knative.dev/routes":    "hello",
 			}),
 		)),
@@ -117,7 +122,7 @@ func TestServiceExport(t *testing.T) {
 		servingtest.WithEnv(corev1.EnvVar{Name: "a", Value: "mouse"}),
 	), test.BuildKNExportWithOptions(
 		test.WithKNRevision(*(test.BuildRevision("hello-rev1",
-			servingtest.WithRevisionAnn("client.knative.dev/user-image", pkgtest.ImagePath("helloworld")),
+			servingtest.WithRevisionAnn("client.knative.dev/user-image", userImage),
 			servingtest.WithRevisionAnn("serving.knative.dev/routes", "hello"),
 			servingtest.WithRevisionLabel("serving.knative.dev/configuration", "hello"),
 			servingtest.WithRevisionLabel("serving.knative.dev/configurationGeneration", "1"),
@@ -136,7 +141,7 @@ func TestServiceExport(t *testing.T) {
 		test.WithService(test.BuildServiceWithOptions("hello",
 			servingtest.WithConfigSpec(test.BuildConfigurationSpec()),
 			test.WithRevisionAnnotations(map[string]string{
-				"client.knative.dev/user-image": pkgtest.ImagePath("helloworld"),
+				"client.knative.dev/user-image": userImage,
 				"serving.knative.dev/routes":    "hello",
 			}),
 			servingtest.WithBYORevisionName("hello-rev1"),
@@ -167,7 +172,7 @@ func TestServiceExport(t *testing.T) {
 		servingtest.WithEnv(corev1.EnvVar{Name: "a", Value: "mouse"}, corev1.EnvVar{Name: "b", Value: "cat"}),
 	), test.BuildKNExportWithOptions(
 		test.WithKNRevision(*(test.BuildRevision("hello-rev1",
-			servingtest.WithRevisionAnn("client.knative.dev/user-image", pkgtest.ImagePath("helloworld")),
+			servingtest.WithRevisionAnn("client.knative.dev/user-image", userImage),
 			servingtest.WithRevisionAnn("serving.knative.dev/routes", "hello"),
 			servingtest.WithRevisionLabel("serving.knative.dev/configuration", "hello"),
 			servingtest.WithRevisionLabel("serving.knative.dev/configurationGeneration", "1"),

--- a/test/e2e/source_container_test.go
+++ b/test/e2e/source_container_test.go
@@ -81,7 +81,7 @@ func containerSourceList(r *test.KnRunResultCollector, containerSources ...strin
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAll(out.Stdout, "NAME", "IMAGE", "SINK", "READY"))
 	assert.Check(r.T(), util.ContainsAll(out.Stdout, containerSources...))
-	assert.Check(r.T(), util.ContainsAll(out.Stdout, "grpc-ping", "ksvc:testsvc0"))
+	assert.Check(r.T(), util.ContainsAll(out.Stdout, "ksvc:testsvc0"))
 }
 
 func containerSourceCreateMissingSink(r *test.KnRunResultCollector, sourceName string, sink string) {


### PR DESCRIPTION
## Description

Images specified by digest are not set in user-image annotation. This PR corrects the test to work with image digest..

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Do not expect user-image annotation to contain the image if the image is specified by digest.
* Do not expect image name in the output of source list as it might not be available when images are passed as image digest.


## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
