### PR TITLE
Remove `DeprecatedImageDigest` field

### DIFF
--- a/pkg/kn/commands/revision/describe.go
+++ b/pkg/kn/commands/revision/describe.go
@@ -162,7 +162,7 @@ func WriteImage(dw printers.PrefixWriter, revision *servingv1.Revision) {
 	// Check if the user image is likely a more user-friendly description
 	pinnedDesc := "at"
 	userImage := clientserving.UserImage(&revision.ObjectMeta)
-	imageDigest := revision.Status.DeprecatedImageDigest
+	imageDigest := revision.Status.ContainerStatuses[0].ImageDigest
 	if userImage != "" && imageDigest != "" {
 		var parts []string
 		if strings.Contains(image, "@") {

--- a/pkg/kn/commands/revision/describe_test.go
+++ b/pkg/kn/commands/revision/describe_test.go
@@ -182,9 +182,11 @@ func createTestRevision(revision string, gen int64, replicas *int32) servingv1.R
 			},
 		},
 		Status: servingv1.RevisionStatus{
-			ActualReplicas:        replicas,
-			DesiredReplicas:       replicas,
-			DeprecatedImageDigest: "gcr.io/test/image@" + imageDigest,
+			ActualReplicas:  replicas,
+			DesiredReplicas: replicas,
+			ContainerStatuses: []servingv1.ContainerStatus{
+				{Name: "gcr.io/test/image", ImageDigest: imageDigest},
+			},
 			Status: duckv1.Status{
 				Conditions: goodConditions(),
 			},

--- a/pkg/kn/commands/service/describe_test.go
+++ b/pkg/kn/commands/service/describe_test.go
@@ -400,7 +400,9 @@ func TestServiceDescribeUserImageVsImage(t *testing.T) {
 	rev3.Annotations[client_serving.UserImageAnnotationKey] = "gcr.io/test/image:latest"
 	rev3.Spec.Containers[0].Image = "gcr.io/a/b"
 	// rev4 is without the annotation at all and no hash
-	rev4.Status.DeprecatedImageDigest = ""
+	rev4.Status.ContainerStatuses = []servingv1.ContainerStatus{
+		{Name: "gcr.io/x/y", ImageDigest: ""},
+	}
 	rev4.Spec.Containers[0].Image = "gcr.io/x/y"
 
 	// Fetch the revisions
@@ -763,9 +765,11 @@ func createTestRevision(revision string, gen int64, conditions duckv1.Conditions
 			},
 		},
 		Status: servingv1.RevisionStatus{
-			ActualReplicas:        ptr.Int32(0),
-			DesiredReplicas:       ptr.Int32(1),
-			DeprecatedImageDigest: "gcr.io/test/image@" + imageDigest,
+			ActualReplicas:  ptr.Int32(0),
+			DesiredReplicas: ptr.Int32(1),
+			ContainerStatuses: []servingv1.ContainerStatus{
+				{Name: "gcr.io/test/image", ImageDigest: imageDigest},
+			},
 			Status: duckv1.Status{
 				Conditions: conditions,
 			},

--- a/pkg/kn/commands/service/update_test.go
+++ b/pkg/kn/commands/service/update_test.go
@@ -96,8 +96,6 @@ func fakeServiceUpdate(original *servingv1.Service, args []string) (
 			rev.Status.ContainerStatuses = []servingv1.ContainerStatus{
 				{ImageDigest: exampleImageByDigest, Name: "user-container"},
 			}
-
-			rev.Status.DeprecatedImageDigest = exampleImageByDigest
 			return true, rev, nil
 		})
 


### PR DESCRIPTION
## Description

Note to the reviewers: I'll open new issue to handle multi-container Revisions. Hence the PR uses only `ContainerStatus[0]` that should be equal to `DeprecatedImageDigest` by the following:
>// If multiple containers specified then DeprecatedImageDigest holds the digest
	// for serving container.

https://github.com/knative/serving/blob/d2461492bea18cde5f9aa0419c8fee24570782aa/pkg/apis/serving/v1/revision_types.go#L139-L151

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* 🐣 Remove `DeprecatedImageDigest` field


## Reference
Fixes failing auto update PR #1452.