### PR TITLE
Automatically set the proper version for the serving and eventing dependencies

### DIFF
--- a/hack/build-flags.sh
+++ b/hack/build-flags.sh
@@ -25,6 +25,9 @@ function build_flags() {
     [[ -n "${commit}" ]] || abort "error getting the current commit"
     version="v$(date +%Y%m%d)-local-${commit}"
   fi
+  # Extract Eventing and Serving versions from go.mod
+  local version_serving=$(cat go.mod | grep "knative.dev/serving " | sed -s 's/.* \(v.[\.0-9]*\).*/\1/')
+  local version_eventing=$(cat go.mod | grep "knative.dev/eventing " | sed -s 's/.* \(v.[\.0-9]*\).*/\1/')
 
-  echo "-X '${pkg}.BuildDate=${now}' -X ${pkg}.Version=${version} -X ${pkg}.GitRevision=${rev}"
+  echo "-X '${pkg}.BuildDate=${now}' -X ${pkg}.Version=${version} -X ${pkg}.GitRevision=${rev} -X ${pkg}.VersionServing=${version_serving} -X ${pkg}.VersionEventing=${version_eventing}"
 }

--- a/pkg/kn/commands/version/version.go
+++ b/pkg/kn/commands/version/version.go
@@ -27,15 +27,17 @@ import (
 var Version string
 var BuildDate string
 var GitRevision string
+var VersionServing string
+var VersionEventing string
 
 // update this var as we add more deps
 var apiVersions = map[string][]string{
 	"serving": {
-		"serving.knative.dev/v1 (knative-serving v0.26.0)",
+		fmt.Sprintf("serving.knative.dev/v1 (knative-serving %s)", VersionServing),
 	},
 	"eventing": {
-		"sources.knative.dev/v1 (knative-eventing v0.26.0)",
-		"eventing.knative.dev/v1 (knative-eventing v0.26.0)",
+		fmt.Sprintf("sources.knative.dev/v1 (knative-eventing %s)", VersionEventing),
+		fmt.Sprintf("eventing.knative.dev/v1 (knative-eventing %s)", VersionEventing),
 	},
 }
 
@@ -98,7 +100,7 @@ func printVersionMachineReadable(cmd *cobra.Command) error {
 		}
 		fmt.Fprint(out, string(b))
 	default:
-		return fmt.Errorf("Invalid value for output flag, choose one among 'json' or 'yaml'.")
+		return fmt.Errorf("invalid value for output flag, choose one among 'json' or 'yaml'")
 	}
 	return nil
 }

--- a/pkg/kn/commands/version/version_test.go
+++ b/pkg/kn/commands/version/version_test.go
@@ -108,7 +108,7 @@ func TestVersion(t *testing.T) {
 		t.Run("invalid format", func(t *testing.T) {
 			err := runVersionCmd([]string{"-o", "jsonpath"})
 			assert.Assert(t, err != nil)
-			assert.ErrorContains(t, err, "Invalid", "output", "flag", "choose", "among")
+			assert.ErrorContains(t, err, "invalid", "output", "flag", "choose", "among")
 		})
 	})
 


### PR DESCRIPTION
for `kn version`. This is now directly extracted from go.mod and
saves one manual step when doing the release.