### PR TITLE
Changing the Default retry value

### DIFF
--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -1,0 +1,37 @@
+// Copyright © 2021 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+var (
+	// DefaultRetry is the default set of rules
+	// to be followed when retrying for conflicts during
+	// resource update. Values are the same as
+	// k8s.io/client-go/util/retry/util.go
+	// except where commented on
+	DefaultRetry = wait.Backoff{
+		// Start retries with 20ms instead of 10ms
+		Duration: 20 * time.Millisecond,
+		// Increase the retry duration by 50%
+		Factor: 1.5,
+		Jitter: 0.1,
+		Steps:  5,
+	}
+)

--- a/pkg/eventing/v1/client.go
+++ b/pkg/eventing/v1/client.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"time"
 
+	"knative.dev/client/pkg/config"
+
 	"k8s.io/client-go/util/retry"
 
 	apis_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -148,7 +150,7 @@ func (c *knEventingClient) UpdateTriggerWithRetry(ctx context.Context, name stri
 }
 
 func updateTriggerWithRetry(ctx context.Context, c KnEventingClient, name string, updateFunc TriggerUpdateFunc, nrRetries int) error {
-	b := util.DefaultRetry
+	b := config.DefaultRetry
 	b.Steps = nrRetries
 	updateTriggerFunc := func() error {
 		return updateTrigger(ctx, c, name, updateFunc)

--- a/pkg/eventing/v1/client.go
+++ b/pkg/eventing/v1/client.go
@@ -148,7 +148,7 @@ func (c *knEventingClient) UpdateTriggerWithRetry(ctx context.Context, name stri
 }
 
 func updateTriggerWithRetry(ctx context.Context, c KnEventingClient, name string, updateFunc TriggerUpdateFunc, nrRetries int) error {
-	b := retry.DefaultRetry
+	b := util.DefaultRetry
 	b.Steps = nrRetries
 	updateTriggerFunc := func() error {
 		return updateTrigger(ctx, c, name, updateFunc)

--- a/pkg/kn/commands/domain/update.go
+++ b/pkg/kn/commands/domain/update.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 
+	"knative.dev/client/pkg/config"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 
 	"github.com/spf13/cobra"
@@ -25,8 +26,6 @@ import (
 	knerrors "knative.dev/client/pkg/errors"
 	"knative.dev/client/pkg/kn/commands"
 )
-
-const MaxUpdateRetries = 5
 
 // NewDomainMappingUpdateCommand to create event channels
 func NewDomainMappingUpdateCommand(p *commands.KnParams) *cobra.Command {
@@ -70,7 +69,7 @@ func NewDomainMappingUpdateCommand(p *commands.KnParams) *cobra.Command {
 				return toUpdate, nil
 			}
 
-			err = client.UpdateDomainMappingWithRetry(cmd.Context(), name, updateFunc, MaxUpdateRetries)
+			err = client.UpdateDomainMappingWithRetry(cmd.Context(), name, updateFunc, config.DefaultRetry.Steps)
 			if err != nil {
 				return knerrors.GetError(err)
 			}

--- a/pkg/kn/commands/domain/update.go
+++ b/pkg/kn/commands/domain/update.go
@@ -26,7 +26,7 @@ import (
 	"knative.dev/client/pkg/kn/commands"
 )
 
-const MaxUpdateRetries = 3
+const MaxUpdateRetries = 5
 
 // NewDomainMappingUpdateCommand to create event channels
 func NewDomainMappingUpdateCommand(p *commands.KnParams) *cobra.Command {

--- a/pkg/kn/commands/service/create.go
+++ b/pkg/kn/commands/service/create.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 
+	"knative.dev/client/pkg/config"
 	"knative.dev/client/pkg/kn/commands"
 	servinglib "knative.dev/client/pkg/serving"
 
@@ -208,7 +209,7 @@ func prepareAndUpdateService(ctx context.Context, client clientservingv1.KnServi
 		changed, err := client.UpdateService(ctx, service)
 		if err != nil {
 			// Retry to update when a resource version conflict exists
-			if apierrors.IsConflict(err) && retries < MaxUpdateRetries {
+			if apierrors.IsConflict(err) && retries < config.DefaultRetry.Steps {
 				retries++
 				continue
 			}

--- a/pkg/kn/commands/service/create.go
+++ b/pkg/kn/commands/service/create.go
@@ -178,12 +178,7 @@ func waitIfRequested(ctx context.Context, client clientservingv1.KnServingClient
 }
 
 func prepareAndUpdateService(ctx context.Context, client clientservingv1.KnServingClient, service *servingv1.Service) (bool, error) {
-	var retries = 0
-	for {
-		existingService, err := client.GetService(ctx, service.Name)
-		if err != nil {
-			return false, err
-		}
+	updateFunc := func(origService *servingv1.Service) (*servingv1.Service, error) {
 
 		// Copy over some annotations that we want to keep around. Erase others
 		copyList := []string{
@@ -200,23 +195,16 @@ func prepareAndUpdateService(ctx context.Context, client clientservingv1.KnServi
 
 		// Do the actual copy now, but only if it's in the source annotation
 		for _, k := range copyList {
-			if v, ok := existingService.Annotations[k]; ok {
+			if v, ok := origService.Annotations[k]; ok {
 				service.Annotations[k] = v
 			}
 		}
 
-		service.ResourceVersion = existingService.ResourceVersion
-		changed, err := client.UpdateService(ctx, service)
-		if err != nil {
-			// Retry to update when a resource version conflict exists
-			if apierrors.IsConflict(err) && retries < config.DefaultRetry.Steps {
-				retries++
-				continue
-			}
-			return changed, err
-		}
-		return changed, nil
+		service.ResourceVersion = origService.ResourceVersion
+		return service, nil
 	}
+	return client.UpdateServiceWithRetry(ctx, service.Name, updateFunc, config.DefaultRetry.Steps)
+
 }
 
 func waitForServiceToGetReady(ctx context.Context, client clientservingv1.KnServingClient, name string, timeout int, verbDone string, out io.Writer) error {

--- a/pkg/kn/commands/service/service.go
+++ b/pkg/kn/commands/service/service.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	// How often to retry in case of an optimistic lock error when replacing a service (--force)
-	MaxUpdateRetries = 3
+	MaxUpdateRetries = 5
 )
 
 func NewServiceCommand(p *commands.KnParams) *cobra.Command {

--- a/pkg/kn/commands/service/service.go
+++ b/pkg/kn/commands/service/service.go
@@ -27,11 +27,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	// How often to retry in case of an optimistic lock error when replacing a service (--force)
-	MaxUpdateRetries = 5
-)
-
 func NewServiceCommand(p *commands.KnParams) *cobra.Command {
 	serviceCmd := &cobra.Command{
 		Use:     "service",

--- a/pkg/kn/commands/service/update.go
+++ b/pkg/kn/commands/service/update.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"knative.dev/client/pkg/config"
 
 	"knative.dev/client/pkg/kn/commands/flags"
 	"knative.dev/client/pkg/kn/traffic"
@@ -109,7 +110,7 @@ func NewServiceUpdateCommand(p *commands.KnParams) *cobra.Command {
 			}
 
 			// Do the actual update with retry in case of conflicts
-			changed, err := client.UpdateServiceWithRetry(cmd.Context(), name, updateFunc, MaxUpdateRetries)
+			changed, err := client.UpdateServiceWithRetry(cmd.Context(), name, updateFunc, config.DefaultRetry.Steps)
 			if err != nil {
 				return err
 			}

--- a/pkg/kn/commands/source/container/update.go
+++ b/pkg/kn/commands/source/container/update.go
@@ -30,7 +30,7 @@ import (
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 )
 
-const MaxUpdateRetries = 3
+const MaxUpdateRetries = 5
 
 // NewContainerUpdateCommand for managing source update
 func NewContainerUpdateCommand(p *commands.KnParams) *cobra.Command {

--- a/pkg/kn/commands/source/container/update.go
+++ b/pkg/kn/commands/source/container/update.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"knative.dev/client/pkg/config"
 	"knative.dev/client/pkg/kn/commands/flags"
 	knflags "knative.dev/client/pkg/kn/flags"
 
@@ -29,8 +30,6 @@ import (
 	v1 "knative.dev/client/pkg/sources/v1"
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 )
-
-const MaxUpdateRetries = 5
 
 // NewContainerUpdateCommand for managing source update
 func NewContainerUpdateCommand(p *commands.KnParams) *cobra.Command {
@@ -86,7 +85,7 @@ func NewContainerUpdateCommand(p *commands.KnParams) *cobra.Command {
 				return b.Build(), nil
 			}
 
-			err = srcClient.UpdateContainerSourceWithRetry(cmd.Context(), name, updateFunc, MaxUpdateRetries)
+			err = srcClient.UpdateContainerSourceWithRetry(cmd.Context(), name, updateFunc, config.DefaultRetry.Steps)
 			if err == nil {
 				fmt.Fprintf(cmd.OutOrStdout(), "Container source '%s' updated in namespace '%s'.\n", args[0], namespace)
 			}

--- a/pkg/kn/commands/source/ping/ping.go
+++ b/pkg/kn/commands/source/ping/ping.go
@@ -24,10 +24,6 @@ import (
 	sourcesv1beta2 "knative.dev/eventing/pkg/client/clientset/versioned/typed/sources/v1beta2"
 )
 
-const (
-	MaxUpdateRetries = 5
-)
-
 // NewPingCommand is the root command for all Ping source related commands
 func NewPingCommand(p *commands.KnParams) *cobra.Command {
 	pingImporterCmd := &cobra.Command{

--- a/pkg/kn/commands/source/ping/ping.go
+++ b/pkg/kn/commands/source/ping/ping.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	MaxUpdateRetries = 3
+	MaxUpdateRetries = 5
 )
 
 // NewPingCommand is the root command for all Ping source related commands

--- a/pkg/kn/commands/source/ping/update.go
+++ b/pkg/kn/commands/source/ping/update.go
@@ -94,9 +94,8 @@ func NewPingUpdateCommand(p *commands.KnParams) *cobra.Command {
 				updatedSource := b.Build()
 				return updatedSource, nil
 			}
-			backoff := config.DefaultRetry
-			backoff.Steps = MaxUpdateRetries
-			err = pingSourceClient.UpdatePingSourceWithRetry(cmd.Context(), name, updateFunc, MaxUpdateRetries)
+
+			err = pingSourceClient.UpdatePingSourceWithRetry(cmd.Context(), name, updateFunc, config.DefaultRetry.Steps)
 
 			if err == nil {
 				fmt.Fprintf(cmd.OutOrStdout(), "Ping source '%s' updated in namespace '%s'.\n", name, pingSourceClient.Namespace())

--- a/pkg/kn/commands/source/ping/update.go
+++ b/pkg/kn/commands/source/ping/update.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/util/retry"
 
 	"knative.dev/client/pkg/kn/commands"
 	"knative.dev/client/pkg/kn/commands/flags"
@@ -93,7 +92,7 @@ func NewPingUpdateCommand(p *commands.KnParams) *cobra.Command {
 				updatedSource := b.Build()
 				return updatedSource, nil
 			}
-			backoff := retry.DefaultRetry
+			backoff := util.DefaultRetry
 			backoff.Steps = MaxUpdateRetries
 			err = pingSourceClient.UpdatePingSourceWithRetry(cmd.Context(), name, updateFunc, MaxUpdateRetries)
 

--- a/pkg/kn/commands/source/ping/update.go
+++ b/pkg/kn/commands/source/ping/update.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 	"fmt"
 
+	"knative.dev/client/pkg/config"
+
 	"github.com/spf13/cobra"
 
 	"knative.dev/client/pkg/kn/commands"
@@ -92,7 +94,7 @@ func NewPingUpdateCommand(p *commands.KnParams) *cobra.Command {
 				updatedSource := b.Build()
 				return updatedSource, nil
 			}
-			backoff := util.DefaultRetry
+			backoff := config.DefaultRetry
 			backoff.Steps = MaxUpdateRetries
 			err = pingSourceClient.UpdatePingSourceWithRetry(cmd.Context(), name, updateFunc, MaxUpdateRetries)
 

--- a/pkg/kn/commands/subscription/update.go
+++ b/pkg/kn/commands/subscription/update.go
@@ -30,7 +30,7 @@ import (
 	knmessagingv1 "knative.dev/client/pkg/messaging/v1"
 )
 
-const MaxUpdateRetries = 3
+const MaxUpdateRetries = 5
 
 // NewSubscriptionUpdateCommand to update event subscriptions
 func NewSubscriptionUpdateCommand(p *commands.KnParams) *cobra.Command {

--- a/pkg/kn/commands/subscription/update.go
+++ b/pkg/kn/commands/subscription/update.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 
+	"knative.dev/client/pkg/config"
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 
 	"github.com/spf13/cobra"
@@ -29,8 +30,6 @@ import (
 	"knative.dev/client/pkg/kn/commands/flags"
 	knmessagingv1 "knative.dev/client/pkg/messaging/v1"
 )
-
-const MaxUpdateRetries = 5
 
 // NewSubscriptionUpdateCommand to update event subscriptions
 func NewSubscriptionUpdateCommand(p *commands.KnParams) *cobra.Command {
@@ -88,7 +87,7 @@ func NewSubscriptionUpdateCommand(p *commands.KnParams) *cobra.Command {
 				sb.DeadLetterSink(ds)
 				return sb.Build(), nil
 			}
-			err = client.UpdateSubscriptionWithRetry(cmd.Context(), name, updateFunc, MaxUpdateRetries)
+			err = client.UpdateSubscriptionWithRetry(cmd.Context(), name, updateFunc, config.DefaultRetry.Steps)
 			if err != nil {
 				return knerrors.GetError(err)
 			}

--- a/pkg/kn/commands/trigger/trigger.go
+++ b/pkg/kn/commands/trigger/trigger.go
@@ -20,11 +20,6 @@ import (
 	"knative.dev/client/pkg/kn/commands"
 )
 
-const (
-	// How often to retry in case of an optimistic lock error when replacing a trigger (--force)
-	MaxUpdateRetries = 5
-)
-
 // NewTriggerCommand to create trigger command group
 func NewTriggerCommand(p *commands.KnParams) *cobra.Command {
 	triggerCmd := &cobra.Command{

--- a/pkg/kn/commands/trigger/trigger.go
+++ b/pkg/kn/commands/trigger/trigger.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	// How often to retry in case of an optimistic lock error when replacing a trigger (--force)
-	MaxUpdateRetries = 3
+	MaxUpdateRetries = 5
 )
 
 // NewTriggerCommand to create trigger command group

--- a/pkg/kn/commands/trigger/update.go
+++ b/pkg/kn/commands/trigger/update.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 
+	"knative.dev/client/pkg/config"
 	clientv1beta1 "knative.dev/client/pkg/eventing/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
@@ -96,7 +97,7 @@ func NewTriggerUpdateCommand(p *commands.KnParams) *cobra.Command {
 				}
 				return b.Build(), nil
 			}
-			err = eventingClient.UpdateTriggerWithRetry(cmd.Context(), name, updateFunc, MaxUpdateRetries)
+			err = eventingClient.UpdateTriggerWithRetry(cmd.Context(), name, updateFunc, config.DefaultRetry.Steps)
 			if err == nil {
 				fmt.Fprintf(cmd.OutOrStdout(), "Trigger '%s' updated in namespace '%s'.\n", name, namespace)
 			}

--- a/pkg/messaging/v1/subscriptions_client.go
+++ b/pkg/messaging/v1/subscriptions_client.go
@@ -29,6 +29,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	knerrors "knative.dev/client/pkg/errors"
+	"knative.dev/client/pkg/util"
 )
 
 type SubscriptionUpdateFunc func(origSub *messagingv1.Subscription) (*messagingv1.Subscription, error)
@@ -107,7 +108,7 @@ func (c *subscriptionsClient) UpdateSubscriptionWithRetry(ctx context.Context, n
 }
 
 func updateSubscriptionWithRetry(ctx context.Context, c KnSubscriptionsClient, name string, updateFunc SubscriptionUpdateFunc, nrRetries int) error {
-	b := retry.DefaultRetry
+	b := util.DefaultRetry
 	b.Steps = nrRetries
 	err := retry.RetryOnConflict(b, func() error {
 		return updateSubscription(ctx, c, name, updateFunc)

--- a/pkg/messaging/v1/subscriptions_client.go
+++ b/pkg/messaging/v1/subscriptions_client.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"knative.dev/client/pkg/config"
+
 	"k8s.io/client-go/util/retry"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +31,6 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	knerrors "knative.dev/client/pkg/errors"
-	"knative.dev/client/pkg/util"
 )
 
 type SubscriptionUpdateFunc func(origSub *messagingv1.Subscription) (*messagingv1.Subscription, error)
@@ -108,7 +109,7 @@ func (c *subscriptionsClient) UpdateSubscriptionWithRetry(ctx context.Context, n
 }
 
 func updateSubscriptionWithRetry(ctx context.Context, c KnSubscriptionsClient, name string, updateFunc SubscriptionUpdateFunc, nrRetries int) error {
-	b := util.DefaultRetry
+	b := config.DefaultRetry
 	b.Steps = nrRetries
 	err := retry.RetryOnConflict(b, func() error {
 		return updateSubscription(ctx, c, name, updateFunc)

--- a/pkg/serving/v1/client.go
+++ b/pkg/serving/v1/client.go
@@ -259,7 +259,7 @@ func (cl *knServingClient) UpdateServiceWithRetry(ctx context.Context, name stri
 func updateServiceWithRetry(ctx context.Context, cl KnServingClient, name string, updateFunc ServiceUpdateFunc, nrRetries int) (bool, error) {
 	var changed bool
 	var err error
-	b := retry.DefaultRetry
+	b := util.DefaultRetry
 	b.Steps = nrRetries
 	err = retry.RetryOnConflict(b, func() error {
 		service, err := cl.GetService(ctx, name)

--- a/pkg/serving/v1/client.go
+++ b/pkg/serving/v1/client.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"time"
 
+	"knative.dev/client/pkg/config"
+
 	"k8s.io/client-go/util/retry"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -259,7 +261,7 @@ func (cl *knServingClient) UpdateServiceWithRetry(ctx context.Context, name stri
 func updateServiceWithRetry(ctx context.Context, cl KnServingClient, name string, updateFunc ServiceUpdateFunc, nrRetries int) (bool, error) {
 	var changed bool
 	var err error
-	b := util.DefaultRetry
+	b := config.DefaultRetry
 	b.Steps = nrRetries
 	err = retry.RetryOnConflict(b, func() error {
 		service, err := cl.GetService(ctx, name)

--- a/pkg/serving/v1alpha1/client.go
+++ b/pkg/serving/v1alpha1/client.go
@@ -111,7 +111,7 @@ func (cl *knServingClient) UpdateDomainMappingWithRetry(ctx context.Context, nam
 }
 
 func updateDomainMappingWithRetry(ctx context.Context, cl KnServingClient, name string, updateFunc DomainUpdateFunc, nrRetries int) error {
-	b := retry.DefaultRetry
+	b := util.DefaultRetry
 	b.Steps = nrRetries
 	err := retry.RetryOnConflict(b, func() error {
 		return updateDomain(ctx, cl, name, updateFunc)

--- a/pkg/serving/v1alpha1/client.go
+++ b/pkg/serving/v1alpha1/client.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 
+	"knative.dev/client/pkg/config"
+
 	"k8s.io/client-go/util/retry"
 
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -111,7 +113,7 @@ func (cl *knServingClient) UpdateDomainMappingWithRetry(ctx context.Context, nam
 }
 
 func updateDomainMappingWithRetry(ctx context.Context, cl KnServingClient, name string, updateFunc DomainUpdateFunc, nrRetries int) error {
-	b := util.DefaultRetry
+	b := config.DefaultRetry
 	b.Steps = nrRetries
 	err := retry.RetryOnConflict(b, func() error {
 		return updateDomain(ctx, cl, name, updateFunc)

--- a/pkg/sources/v1/container_client.go
+++ b/pkg/sources/v1/container_client.go
@@ -73,7 +73,7 @@ func (c *containerSourcesClient) UpdateContainerSourceWithRetry(ctx context.Cont
 }
 
 func updateContainerSourceWithRetry(ctx context.Context, c KnContainerSourcesClient, name string, updateFunc ContainerUpdateFunc, nrRetries int) error {
-	b := retry.DefaultRetry
+	b := util.DefaultRetry
 	b.Steps = nrRetries
 	err := retry.RetryOnConflict(b, func() error {
 		return updateContainerSource(ctx, c, name, updateFunc)

--- a/pkg/sources/v1/container_client.go
+++ b/pkg/sources/v1/container_client.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"knative.dev/client/pkg/config"
+
 	"k8s.io/client-go/util/retry"
 
 	corev1 "k8s.io/api/core/v1"
@@ -73,7 +75,7 @@ func (c *containerSourcesClient) UpdateContainerSourceWithRetry(ctx context.Cont
 }
 
 func updateContainerSourceWithRetry(ctx context.Context, c KnContainerSourcesClient, name string, updateFunc ContainerUpdateFunc, nrRetries int) error {
-	b := util.DefaultRetry
+	b := config.DefaultRetry
 	b.Steps = nrRetries
 	err := retry.RetryOnConflict(b, func() error {
 		return updateContainerSource(ctx, c, name, updateFunc)

--- a/pkg/sources/v1beta2/ping_client.go
+++ b/pkg/sources/v1beta2/ping_client.go
@@ -106,7 +106,7 @@ func (c *pingSourcesClient) UpdatePingSourceWithRetry(ctx context.Context, name 
 }
 
 func updatePingSourceWithRetry(ctx context.Context, c KnPingSourcesClient, name string, updateFunc PingSourceUpdateFunc, nrRetries int) error {
-	b := retry.DefaultRetry
+	b := util.DefaultRetry
 	b.Steps = nrRetries
 	err := retry.RetryOnConflict(b, func() error {
 		return updatePingSource(ctx, c, name, updateFunc)

--- a/pkg/sources/v1beta2/ping_client.go
+++ b/pkg/sources/v1beta2/ping_client.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 
+	"knative.dev/client/pkg/config"
+
 	"k8s.io/client-go/util/retry"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -106,7 +108,7 @@ func (c *pingSourcesClient) UpdatePingSourceWithRetry(ctx context.Context, name 
 }
 
 func updatePingSourceWithRetry(ctx context.Context, c KnPingSourcesClient, name string, updateFunc PingSourceUpdateFunc, nrRetries int) error {
-	b := util.DefaultRetry
+	b := config.DefaultRetry
 	b.Steps = nrRetries
 	err := retry.RetryOnConflict(b, func() error {
 		return updatePingSource(ctx, c, name, updateFunc)

--- a/pkg/util/compare.go
+++ b/pkg/util/compare.go
@@ -17,23 +17,8 @@ package util
 import (
 	"fmt"
 	"strings"
-	"time"
-
-	"k8s.io/apimachinery/pkg/util/wait"
 
 	"gotest.tools/v3/assert/cmp"
-)
-
-var (
-	// DefaultRetry is the default set of rules
-	// to be followed when retrying for conflicts during
-	// resource update
-	DefaultRetry = wait.Backoff{
-		Duration: 20 * time.Millisecond,
-		Factor:   1.5,
-		Jitter:   0.1,
-		Steps:    5,
-	}
 )
 
 // ContainsAll is a comparison utility, compares given substrings against

--- a/pkg/util/compare.go
+++ b/pkg/util/compare.go
@@ -17,8 +17,23 @@ package util
 import (
 	"fmt"
 	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"gotest.tools/v3/assert/cmp"
+)
+
+var (
+	// DefaultRetry is the default set of rules
+	// to be followed when retrying for conflicts during
+	// resource update
+	DefaultRetry = wait.Backoff{
+		Duration: 20 * time.Millisecond,
+		Factor:   1.5,
+		Jitter:   0.1,
+		Steps:    5,
+	}
 )
 
 // ContainsAll is a comparison utility, compares given substrings against


### PR DESCRIPTION
## Description

<!-- Please add a short summary about what the pull request is going to bring on the table -->
Modifying default retry value for backoff during resource updates
## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Changing the factor to 1.5 
* Changing MaxUpdateRetries to 5


## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
