### PR TITLE
Renaming COC doc to ALLCAPS

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -73,4 +73,4 @@ This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 1.4, available at
 https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
-[homepage]: https://www.contributor-covenant.orgdd
+[homepage]: https://www.contributor-covenant.org

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -73,3 +73,4 @@ This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 1.4, available at
 https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
+[homepage]: https://www.contributor-covenant.orgdd

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,5 +1,6 @@
 # Contributor Covenant Code of Conduct
 
+
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as
@@ -33,11 +34,11 @@ Examples of unacceptable behavior by participants include:
 
 ## Our Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+Members of the Technical Oversight Committee are responsible for clarifying the
+standards of acceptable behavior and are expected to take appropriate and fair
+corrective action in response to any instances of unacceptable behavior.
 
-Project maintainers have the right and responsibility to remove, edit, or reject
+TOC members have the right and responsibility to remove, edit, or reject
 comments, commits, code, wiki edits, issues, and other contributions that are
 not aligned to this Code of Conduct, or to ban temporarily or permanently any
 contributor for other behaviors that they deem inappropriate, threatening,
@@ -55,16 +56,16 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at
+reported by contacting the Technical Oversight Committee at
 knative-code-of-conduct@googlegroups.com. All complaints will be reviewed and
 investigated and will result in a response that is deemed necessary and
 appropriate to the circumstances. The project team is obligated to maintain
 confidentiality with regard to the reporter of an incident. Further details of
 specific enforcement policies may be posted separately.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+TOC members who do not follow or enforce the Code of Conduct in good faith may
+face temporary or permanent repercussions as determined by other members of the
+project's leadership.
 
 ## Attribution
 
@@ -72,4 +73,3 @@ This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 1.4, available at
 https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
-[homepage]: https://www.contributor-covenant.org


### PR DESCRIPTION
# Changes

- Renaming COC doc to ALLCAPS as part of [GA](https://github.com/knative/community/issues/680)

/kind documentation

(using an updated COC from the [community repo](https://github.com/knative/community/blob/main/CODE-OF-CONDUCT.md), which substitutes the TOC for project maintainers in several spots)

/assign @rhuss  @omerbensaadon 