### PR TITLE
Fix sync serviceDelete in test utils

### DIFF
--- a/lib/test/service.go
+++ b/lib/test/service.go
@@ -100,7 +100,7 @@ func ServiceUpdateWithError(r *KnRunResultCollector, serviceName string, args ..
 
 // ServiceDelete verifies service deletion in sync mode
 func ServiceDelete(r *KnRunResultCollector, serviceName string) {
-	out := r.KnTest().Kn().Run("service", "delete", "--wait", serviceName)
+	out := r.KnTest().Kn().Run("service", "delete", serviceName, "--wait")
 	r.AssertNoError(out)
 	assert.Check(r.T(), util.ContainsAll(out.Stdout, "Service", serviceName, "successfully deleted in namespace", r.KnTest().Kn().Namespace()))
 }


### PR DESCRIPTION
## Description

It should prevent `--wait` being considered as name of ksvc in E2E dumps, e.g.:
https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_client/1463/pull-knative-client-integration-tests/1443231012153724928#1:build-log.txt%3A972

## Changes

* Reorder `--wait` flag and `serviceName` in `serviceDelete` util function




