### PR TITLE
Fix assertion in ping source unit tests

### DIFF
--- a/pkg/kn/commands/source/ping/delete_test.go
+++ b/pkg/kn/commands/source/ping/delete_test.go
@@ -45,7 +45,7 @@ func TestDeleteWithError(t *testing.T) {
 
 	out, err := executePingSourceCommand(pingClient, nil, "delete", "testsource")
 	assert.ErrorContains(t, err, "testsource")
-	util.ContainsAll(out, "Usage", "no such", "testsource")
+	assert.Assert(t, util.ContainsAll(out, "Usage", "no such", "testsource"))
 
 	pingRecorder.Validate()
 }


### PR DESCRIPTION
## Description

Fixed the bug of `util.ContainsAll` of file https://github.com/knative/client/blob/main/pkg/kn/commands/source/ping/delete_test.go
/kind good-first-issue
/kind-bug

## Changes

- Updating test case of TestDeleteWithError for covering the `util.ContainsAll` 

## Reference 
#1469
Test case has been changed to 
assert.Assert(t, util.ContainsAll(out, "Usage", "no such", "testsource"))
- 🐛 Bug fix
