### PR TITLE
Add support to (not) initialize kn config file

### DIFF
--- a/pkg/kn/config/config_test.go
+++ b/pkg/kn/config/config_test.go
@@ -77,7 +77,6 @@ func TestBootstrapConfigWithoutConfigFile(t *testing.T) {
 	assert.Equal(t, GlobalConfig.ConfigFile(), bootstrapDefaults.configFile)
 	assert.Equal(t, GlobalConfig.PluginsDir(), bootstrapDefaults.pluginsDir)
 	assert.Equal(t, GlobalConfig.LookupPluginsInPath(), bootstrapDefaults.lookupPluginsInPath)
-	assert.Equal(t, len(GlobalConfig.SinkMappings()), 0)
 }
 
 func TestBootstrapLegacyConfigFields(t *testing.T) {


### PR DESCRIPTION
## Description

~Add support to initialize kn config file or to skip it.~
Make a default config file with the newest settings if it doesn't exist.

## Changes

* ~Add --init flag~
* ~Add --no-init flag~
* ~By default we read the config file and if it doesn't exist create it~
* Instead of `return null` if config file does not exist, create and populate it with default settings
* Set the default settings to what mentioned here: https://github.com/knative/client/blob/main/docs/README.md#options
*  Use viper to create the config file.

## Reference

Related #1232

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
