### PR TITLE
Fix `domain describe` reference

### DIFF
--- a/pkg/kn/commands/domain/describe.go
+++ b/pkg/kn/commands/domain/describe.go
@@ -88,15 +88,13 @@ func describe(w io.Writer, domainMapping *v1alpha1.DomainMapping, printDetails b
 	commands.WriteMetadata(dw, &domainMapping.ObjectMeta, printDetails)
 	dw.WriteLine()
 	dw.WriteAttribute("URL", domainMapping.Status.URL.String())
+	dw.WriteLine()
 	ref := dw.WriteAttribute("Reference", "")
 	ref.WriteAttribute("APIVersion", domainMapping.Spec.Ref.APIVersion)
 	ref.WriteAttribute("Kind", domainMapping.Spec.Ref.Kind)
 	ref.WriteAttribute("Name", domainMapping.Spec.Ref.Name)
 	if domainMapping.Namespace != domainMapping.Spec.Ref.Namespace {
 		ref.WriteAttribute("Namespace", domainMapping.Spec.Ref.Namespace)
-	}
-	if err := ref.Flush(); err != nil {
-		return err
 	}
 	dw.WriteLine()
 	commands.WriteConditions(dw, domainMapping.Status.Conditions, printDetails)

--- a/pkg/kn/commands/domain/describe_test.go
+++ b/pkg/kn/commands/domain/describe_test.go
@@ -54,7 +54,27 @@ func TestDomainMappingDescribe(t *testing.T) {
 			lineCounter++
 		}
 	}
-	assert.Equal(t, lineCounter, 2)
+	assert.Equal(t, lineCounter, 3)
+
+	servingRecorder.Validate()
+}
+
+func TestDomainMappingDescribeDiffNamespace(t *testing.T) {
+	client := v1alpha1.NewMockKnServiceClient(t)
+
+	servingRecorder := client.Recorder()
+	servingRecorder.GetDomainMapping("foo.bar", getDomainMapping("otherNS"), nil)
+
+	out, err := executeDomainCommand(client, nil, "describe", "foo.bar")
+	assert.NilError(t, err)
+	assert.Assert(t, cmp.Regexp("Name:\\s+foo.bar", out))
+	assert.Assert(t, cmp.Regexp("Namespace:\\s+default", out))
+	assert.Assert(t, util.ContainsAll(out, "URL:", "http://foo.bar"))
+	assert.Assert(t, cmp.Regexp("Reference:", out))
+	assert.Assert(t, cmp.Regexp("Kind:\\s+Service", out))
+	assert.Assert(t, cmp.Regexp("Name:\\s+foo", out))
+	assert.Assert(t, cmp.Regexp("Namespace:\\s+otherNS", out))
+	assert.Assert(t, util.ContainsAll(out, "Conditions:", "Ready"))
 
 	servingRecorder.Validate()
 }
@@ -67,6 +87,24 @@ func TestDomainMappingDescribeError(t *testing.T) {
 
 	_, err := executeDomainCommand(client, nil, "describe", "foo.bar")
 	assert.ErrorContains(t, err, "foo", "not found")
+
+	servingRecorder.Validate()
+}
+
+func TestDomainMappingDescribeNameError(t *testing.T) {
+	client := v1alpha1.NewMockKnServiceClient(t)
+
+	servingRecorder := client.Recorder()
+
+	_, err := executeDomainCommand(client, nil, "describe")
+	assert.Assert(t, err != nil)
+	assert.Assert(t, util.ContainsAll(err.Error(), "name", "single", "argument"))
+
+	servingRecorder.Validate()
+
+	_, err = executeDomainCommand(client, nil, "describe", "foo", "bar")
+	assert.Assert(t, err != nil)
+	assert.Assert(t, util.ContainsAll(err.Error(), "name", "single", "argument"))
 
 	servingRecorder.Validate()
 }
@@ -97,11 +135,15 @@ func TestDomainMappingDescribeYAML(t *testing.T) {
 	servingRecorder.Validate()
 }
 
-func getDomainMapping() *servingv1alpha1.DomainMapping {
-	dm := createDomainMapping("foo.bar", createServiceRef("foo", "default"), "")
+func getDomainMapping(ns ...string) *servingv1alpha1.DomainMapping {
+	serviceNamespace := "default"
+	if len(ns) == 1 {
+		serviceNamespace = ns[0]
+	}
+	dm := createDomainMapping("foo.bar", createServiceRef("foo", serviceNamespace), "")
 	dm.TypeMeta = v1.TypeMeta{
 		Kind:       "DomainMapping",
-		APIVersion: "serving.knative.dev/v1alpha1",
+		APIVersion: servingv1alpha1.SchemeGroupVersion.String(),
 	}
 	dm.Status = servingv1alpha1.DomainMappingStatus{
 		Status: duckv1.Status{


### PR DESCRIPTION
## Description

```
➜  client git:(pr/fix-domain-describe) kn domain describe hello.nip.io        
Name:       hello.nip.io
Namespace:  default
Age:        2h

URL:           http://hello.nip.io

Reference:     
  APIVersion:  serving.knative.dev/v1
  Kind:        Route
  Name:        hello

Conditions:  
  OK TYPE                      AGE REASON
  !! Ready                      2h DomainAlreadyClaimed
  ?? CertificateProvisioned     2h 
  !! DomainClaimed              2h DomainAlreadyClaimed
  ?? IngressReady               2h IngressNotConfigured
  ?? ReferenceResolved          2h 
```

/cc @rhuss 
Is too verbove, I can't make up my mind if `APIVersion` should be part of the output?


## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Fix domain describe reference

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #1450 

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
