### PR TITLE
WIP: Set client-go timeout explicitly

### DIFF
--- a/pkg/kn/commands/types.go
+++ b/pkg/kn/commands/types.go
@@ -17,6 +17,7 @@ package commands
 import (
 	"fmt"
 	"io"
+	"time"
 
 	"os"
 	"path/filepath"
@@ -199,6 +200,8 @@ func (params *KnParams) RestConfig() (*rest.Config, error) {
 		// only print a given warning the first time we receive it
 		Deduplicate: true,
 	})
+
+	config.Timeout = time.Minute
 
 	return config, nil
 }

--- a/pkg/kn/commands/types.go
+++ b/pkg/kn/commands/types.go
@@ -201,7 +201,7 @@ func (params *KnParams) RestConfig() (*rest.Config, error) {
 		Deduplicate: true,
 	})
 
-	config.Timeout = time.Minute
+	config.Timeout = 3 * time.Minute
 
 	return config, nil
 }

--- a/pkg/kn/commands/types.go
+++ b/pkg/kn/commands/types.go
@@ -192,9 +192,9 @@ func (params *KnParams) RestConfig() (*rest.Config, error) {
 	if err != nil {
 		return nil, knerrors.GetError(err)
 	}
-	if params.LogHTTP {
+	//if params.LogHTTP {
 		config.Wrap(util.NewLoggingTransport)
-	}
+	//}
 	// Override client-go's warning handler to give us nicely printed warnings.
 	config.WarningHandler = rest.NewWarningWriter(os.Stderr, rest.WarningWriterOptions{
 		// only print a given warning the first time we receive it

--- a/pkg/kn/commands/types.go
+++ b/pkg/kn/commands/types.go
@@ -193,7 +193,7 @@ func (params *KnParams) RestConfig() (*rest.Config, error) {
 		return nil, knerrors.GetError(err)
 	}
 	//if params.LogHTTP {
-		config.Wrap(util.NewLoggingTransport)
+	config.Wrap(util.NewLoggingTransport)
 	//}
 	// Override client-go's warning handler to give us nicely printed warnings.
 	config.WarningHandler = rest.NewWarningWriter(os.Stderr, rest.WarningWriterOptions{

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -37,7 +37,7 @@ export PATH=$PATH:${REPO_ROOT_DIR}
 
 run() {
   # Create cluster
-  initialize $@ --skip-istio-addon --cluster-version=1.20
+  initialize $@ --skip-istio-addon --cluster-version=1.20 --min-nodes=3
 
   # Smoke test
   eval smoke_test || fail_test


### PR DESCRIPTION
## Description

Trigger the E2E tests with explicit timeout in `client-go`.

https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_client/1477/pull-knative-client-integration-tests-latest-release/1448618195819696128

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

*
*
*

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
