### PR TITLE
Calculate traffic split when N-1 revisions are specified

### DIFF
--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -30,16 +30,14 @@ kn service update NAME
   # Add tag 'test' to echo-v3 revision with 10% traffic and rest to latest ready revision of service
   kn service update svc --tag echo-v3=test --traffic test=10,@latest=90
 
-  # Update the service in offline mode instead of kubernetes cluster
-  kn service update gitopstest -n test-ns --env KEY1=VALUE1 --target=/user/knfiles
-  kn service update gitopstest --env KEY1=VALUE1 --target=/user/knfiles/test.yaml
-  kn service update gitopstest --env KEY1=VALUE1 --target=/user/knfiles/test.json
-
-
   # Split 50% traffic to stable, 40% traffic to staging and the
   # rest will automatically be directed to echo-v3 (the remaining revision)
   kn service update svc --traffic stable=50,staging=45
 
+  # Update the service in offline mode instead of kubernetes cluster
+  kn service update gitopstest -n test-ns --env KEY1=VALUE1 --target=/user/knfiles
+  kn service update gitopstest --env KEY1=VALUE1 --target=/user/knfiles/test.yaml
+  kn service update gitopstest --env KEY1=VALUE1 --target=/user/knfiles/test.json
 ```
 
 ### Options

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -32,7 +32,7 @@ kn service update NAME
 
   # Split 50% traffic to stable, 40% traffic to staging and the
   # rest will automatically be directed to echo-v3 (the remaining revision)
-  kn service update svc --traffic stable=50,staging=45
+  kn service update svc --traffic stable=50,staging=40
 
   # Update the service in offline mode instead of kubernetes cluster
   kn service update gitopstest -n test-ns --env KEY1=VALUE1 --target=/user/knfiles

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -34,6 +34,12 @@ kn service update NAME
   kn service update gitopstest -n test-ns --env KEY1=VALUE1 --target=/user/knfiles
   kn service update gitopstest --env KEY1=VALUE1 --target=/user/knfiles/test.yaml
   kn service update gitopstest --env KEY1=VALUE1 --target=/user/knfiles/test.json
+
+
+  # Split 50% traffic to stable, 40% traffic to staging and the
+  # rest will automatically be directed to echo-v3 (the remaining revision)
+  kn service update svc --traffic stable=50,staging=45
+
 ```
 
 ### Options

--- a/pkg/kn/commands/service/update.go
+++ b/pkg/kn/commands/service/update.go
@@ -53,7 +53,13 @@ var updateExample = `
   # Update the service in offline mode instead of kubernetes cluster
   kn service update gitopstest -n test-ns --env KEY1=VALUE1 --target=/user/knfiles
   kn service update gitopstest --env KEY1=VALUE1 --target=/user/knfiles/test.yaml
-  kn service update gitopstest --env KEY1=VALUE1 --target=/user/knfiles/test.json`
+  kn service update gitopstest --env KEY1=VALUE1 --target=/user/knfiles/test.json
+
+
+  # Split 50% traffic to stable, 40% traffic to staging and the
+  # rest will automatically be directed to echo-v3 (the remaining revision)
+  kn service update svc --traffic stable=50,staging=45
+`
 
 func NewServiceUpdateCommand(p *commands.KnParams) *cobra.Command {
 	var editFlags ConfigurationEditFlags

--- a/pkg/kn/commands/service/update.go
+++ b/pkg/kn/commands/service/update.go
@@ -50,16 +50,14 @@ var updateExample = `
   # Add tag 'test' to echo-v3 revision with 10% traffic and rest to latest ready revision of service
   kn service update svc --tag echo-v3=test --traffic test=10,@latest=90
 
-  # Update the service in offline mode instead of kubernetes cluster
-  kn service update gitopstest -n test-ns --env KEY1=VALUE1 --target=/user/knfiles
-  kn service update gitopstest --env KEY1=VALUE1 --target=/user/knfiles/test.yaml
-  kn service update gitopstest --env KEY1=VALUE1 --target=/user/knfiles/test.json
-
-
   # Split 50% traffic to stable, 40% traffic to staging and the
   # rest will automatically be directed to echo-v3 (the remaining revision)
   kn service update svc --traffic stable=50,staging=45
-`
+
+  # Update the service in offline mode instead of kubernetes cluster
+  kn service update gitopstest -n test-ns --env KEY1=VALUE1 --target=/user/knfiles
+  kn service update gitopstest --env KEY1=VALUE1 --target=/user/knfiles/test.yaml
+  kn service update gitopstest --env KEY1=VALUE1 --target=/user/knfiles/test.json`
 
 func NewServiceUpdateCommand(p *commands.KnParams) *cobra.Command {
 	var editFlags ConfigurationEditFlags

--- a/pkg/kn/commands/service/update.go
+++ b/pkg/kn/commands/service/update.go
@@ -98,7 +98,11 @@ func NewServiceUpdateCommand(p *commands.KnParams) *cobra.Command {
 				}
 
 				if trafficFlags.Changed(cmd) {
-					traffic, err := traffic.Compute(cmd, service.Spec.Traffic, &trafficFlags, service.Name)
+					revisions, err := client.ListRevisions(cmd.Context(), clientservingv1.WithService(service.Name))
+					if err != nil {
+						return nil, err
+					}
+					traffic, err := traffic.Compute(cmd, service.Spec.Traffic, &trafficFlags, service.Name, revisions.Items)
 					if err != nil {
 						return nil, err
 					}

--- a/pkg/kn/commands/service/update.go
+++ b/pkg/kn/commands/service/update.go
@@ -52,7 +52,7 @@ var updateExample = `
 
   # Split 50% traffic to stable, 40% traffic to staging and the
   # rest will automatically be directed to echo-v3 (the remaining revision)
-  kn service update svc --traffic stable=50,staging=45
+  kn service update svc --traffic stable=50,staging=40
 
   # Update the service in offline mode instead of kubernetes cluster
   kn service update gitopstest -n test-ns --env KEY1=VALUE1 --target=/user/knfiles

--- a/pkg/kn/traffic/compute_test.go
+++ b/pkg/kn/traffic/compute_test.go
@@ -292,13 +292,13 @@ func TestComputeErrMsg(t *testing.T) {
 			name:            "verify error for non integer values given to percent",
 			existingTraffic: append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true)),
 			inputFlags:      []string{"--traffic", "@latest=100p"},
-			errMsg:          "error converting given 100p to integer value for traffic distribution",
+			errMsg:          errorParsingInteger("100p").Error(),
 		},
 		{
 			name:            "verify error for traffic sum not equal to 100",
 			existingTraffic: append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true)),
 			inputFlags:      []string{"--traffic", "@latest=40,echo-v1=70"},
-			errMsg:          "given traffic percents sum to 110, want 100",
+			errMsg:          errorSumGreaterThan100(110).Error(),
 		},
 		{
 			name:            "verify error for values out of range given to percent",

--- a/pkg/kn/traffic/compute_test.go
+++ b/pkg/kn/traffic/compute_test.go
@@ -16,6 +16,7 @@ package traffic
 
 import (
 	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"testing"
@@ -26,19 +27,21 @@ import (
 )
 
 type trafficTestCase struct {
-	name             string
-	existingTraffic  []servingv1.TrafficTarget
-	inputFlags       []string
-	desiredRevisions []string
-	desiredTags      []string
-	desiredPercents  []int64
+	name              string
+	existingTraffic   []servingv1.TrafficTarget
+	inputFlags        []string
+	desiredRevisions  []string
+	desiredTags       []string
+	desiredPercents   []int64
+	existingRevisions []servingv1.Revision
 }
 
 type trafficErrorTestCase struct {
-	name            string
-	existingTraffic []servingv1.TrafficTarget
-	inputFlags      []string
-	errMsg          string
+	name              string
+	existingTraffic   []servingv1.TrafficTarget
+	inputFlags        []string
+	errMsg            string
+	existingRevisions []servingv1.Revision
 }
 
 func newTestTrafficCommand() (*cobra.Command, *flags.Traffic) {
@@ -55,133 +58,163 @@ func newTestTrafficCommand() (*cobra.Command, *flags.Traffic) {
 func TestCompute(t *testing.T) {
 	for _, testCase := range []trafficTestCase{
 		{
-			"assign 'latest' tag to @latest revision",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true)),
-			[]string{"--tag", "@latest=latest"},
-			[]string{"@latest"},
-			[]string{"latest"},
-			[]int64{100},
+			name:             "assign 'latest' tag to @latest revision",
+			existingTraffic:  append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true)),
+			inputFlags:       []string{"--tag", "@latest=latest"},
+			desiredRevisions: []string{"@latest"},
+			desiredTags:      []string{"latest"},
+			desiredPercents:  []int64{100},
 		},
 		{
-			"assign tag to revision",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "echo-v1", 100, false)),
-			[]string{"--tag", "echo-v1=stable"},
-			[]string{"echo-v1"},
-			[]string{"stable"},
-			[]int64{100},
+			name:             "assign tag to revision",
+			existingTraffic:  append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "echo-v1", 100, false)),
+			inputFlags:       []string{"--tag", "echo-v1=stable"},
+			desiredRevisions: []string{"echo-v1"},
+			desiredTags:      []string{"stable"},
+			desiredPercents:  []int64{100},
 		},
 		{
-			"re-assign same tag to same revision (unchanged)",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("current", "", 100, true)),
-			[]string{"--tag", "@latest=current"},
-			[]string{""},
-			[]string{"current"},
-			[]int64{100},
+			name:             "re-assign same tag to same revision (unchanged)",
+			existingTraffic:  append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("current", "", 100, true)),
+			inputFlags:       []string{"--tag", "@latest=current"},
+			desiredRevisions: []string{""},
+			desiredTags:      []string{"current"},
+			desiredPercents:  []int64{100},
 		},
 		{
-			"split traffic to tags",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true), newTarget("", "rev-v1", 0, false)),
-			[]string{"--traffic", "@latest=10,rev-v1=90"},
-			[]string{"@latest", "rev-v1"},
-			[]string{"", ""},
-			[]int64{10, 90},
+			name:             "split traffic to tags",
+			existingTraffic:  append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true), newTarget("", "rev-v1", 0, false)),
+			inputFlags:       []string{"--traffic", "@latest=10,rev-v1=90"},
+			desiredRevisions: []string{"@latest", "rev-v1"},
+			desiredTags:      []string{"", ""},
+			desiredPercents:  []int64{10, 90},
 		},
 		{
-			"split traffic to tags with '%' suffix",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true), newTarget("", "rev-v1", 0, false)),
-			[]string{"--traffic", "@latest=10%,rev-v1=90%"},
-			[]string{"@latest", "rev-v1"},
-			[]string{"", ""},
-			[]int64{10, 90},
+			name:             "split traffic to tags with '%' suffix",
+			existingTraffic:  append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true), newTarget("", "rev-v1", 0, false)),
+			inputFlags:       []string{"--traffic", "@latest=10%,rev-v1=90%"},
+			desiredRevisions: []string{"@latest", "rev-v1"},
+			desiredTags:      []string{"", ""},
+			desiredPercents:  []int64{10, 90},
 		},
 		{
-			"add 2 more tagged revisions without giving them traffic portions",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("latest", "", 100, true)),
-			[]string{"--tag", "echo-v0=stale,echo-v1=old"},
-			[]string{"@latest", "echo-v0", "echo-v1"},
-			[]string{"latest", "stale", "old"},
-			[]int64{100, 0, 0},
+			name:             "add 2 more tagged revisions without giving them traffic portions",
+			existingTraffic:  append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("latest", "", 100, true)),
+			inputFlags:       []string{"--tag", "echo-v0=stale,echo-v1=old"},
+			desiredRevisions: []string{"@latest", "echo-v0", "echo-v1"},
+			desiredTags:      []string{"latest", "stale", "old"},
+			desiredPercents:  []int64{100, 0, 0},
 		},
 		{
-			"re-assign same tag to 'echo-v1' revision",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("latest", "echo-v1", 100, false)),
-			[]string{"--tag", "echo-v1=latest"},
-			[]string{"echo-v1"},
-			[]string{"latest"},
-			[]int64{100},
+			name:             "re-assign same tag to 'echo-v1' revision",
+			existingTraffic:  append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("latest", "echo-v1", 100, false)),
+			inputFlags:       []string{"--tag", "echo-v1=latest"},
+			desiredRevisions: []string{"echo-v1"},
+			desiredTags:      []string{"latest"},
+			desiredPercents:  []int64{100},
 		},
 		{
-			"set 2% traffic to latest revision by appending it in traffic block",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("latest", "echo-v1", 100, false)),
-			[]string{"--traffic", "@latest=2,echo-v1=98"},
-			[]string{"echo-v1", "@latest"},
-			[]string{"latest", ""},
-			[]int64{98, 2},
+			name:             "set 2% traffic to latest revision by appending it in traffic block",
+			existingTraffic:  append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("latest", "echo-v1", 100, false)),
+			inputFlags:       []string{"--traffic", "@latest=2,echo-v1=98"},
+			desiredRevisions: []string{"echo-v1", "@latest"},
+			desiredTags:      []string{"latest", ""},
+			desiredPercents:  []int64{98, 2},
 		},
 		{
-			"set 2% to @latest with tag (append it in traffic block)",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("latest", "echo-v1", 100, false)),
-			[]string{"--traffic", "@latest=2,echo-v1=98", "--tag", "@latest=testing"},
-			[]string{"echo-v1", "@latest"},
-			[]string{"latest", "testing"},
-			[]int64{98, 2},
+			name:             "set 2% to @latest with tag (append it in traffic block)",
+			existingTraffic:  append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("latest", "echo-v1", 100, false)),
+			inputFlags:       []string{"--traffic", "@latest=2,echo-v1=98", "--tag", "@latest=testing"},
+			desiredRevisions: []string{"echo-v1", "@latest"},
+			desiredTags:      []string{"latest", "testing"},
+			desiredPercents:  []int64{98, 2},
 		},
 		{
-			"change traffic percent of an existing revision in traffic block, add new revision with traffic share",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("v1", "echo-v1", 100, false)),
-			[]string{"--tag", "echo-v2=v2", "--traffic", "v1=10,v2=90"},
-			[]string{"echo-v1", "echo-v2"},
-			[]string{"v1", "v2"},
-			[]int64{10, 90}, //default value,
+			name:             "change traffic percent of an existing revision in traffic block, add new revision with traffic share",
+			existingTraffic:  append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("v1", "echo-v1", 100, false)),
+			inputFlags:       []string{"--tag", "echo-v2=v2", "--traffic", "v1=10,v2=90"},
+			desiredRevisions: []string{"echo-v1", "echo-v2"},
+			desiredTags:      []string{"v1", "v2"},
+			desiredPercents:  []int64{10, 90}, //default value,
 		},
 		{
-			"untag 'latest' tag from 'echo-v1' revision",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("latest", "echo-v1", 100, false)),
-			[]string{"--untag", "latest"},
-			[]string{"echo-v1"},
-			[]string{""},
-			[]int64{100},
+			name:             "untag 'latest' tag from 'echo-v1' revision",
+			existingTraffic:  append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("latest", "echo-v1", 100, false)),
+			inputFlags:       []string{"--untag", "latest"},
+			desiredRevisions: []string{"echo-v1"},
+			desiredTags:      []string{""},
+			desiredPercents:  []int64{100},
 		},
 		{
-			"replace revision pointing to 'latest' tag from 'echo-v1' to 'echo-v2' revision",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("latest", "echo-v1", 50, false), newTarget("", "echo-v2", 50, false)),
-			[]string{"--untag", "latest", "--tag", "echo-v1=old,echo-v2=latest"},
-			[]string{"echo-v1", "echo-v2"},
-			[]string{"old", "latest"},
-			[]int64{50, 50},
+			name:             "replace revision pointing to 'latest' tag from 'echo-v1' to 'echo-v2' revision",
+			existingTraffic:  append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("latest", "echo-v1", 50, false), newTarget("", "echo-v2", 50, false)),
+			inputFlags:       []string{"--untag", "latest", "--tag", "echo-v1=old,echo-v2=latest"},
+			desiredRevisions: []string{"echo-v1", "echo-v2"},
+			desiredTags:      []string{"old", "latest"},
+			desiredPercents:  []int64{50, 50},
 		},
 		{
-			"have multiple tags for a revision, revision present in traffic block",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("latest", "echo-v1", 50, false), newTarget("", "echo-v2", 50, false)),
-			[]string{"--tag", "echo-v1=latest,echo-v1=current"},
-			[]string{"echo-v1", "echo-v2", "echo-v1"}, // appends a new target
-			[]string{"latest", "", "current"},         // with new tag requested
-			[]int64{50, 50, 0},                        // and assign 0% to it
+			name:             "have multiple tags for a revision, revision present in traffic block",
+			existingTraffic:  append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("latest", "echo-v1", 50, false), newTarget("", "echo-v2", 50, false)),
+			inputFlags:       []string{"--tag", "echo-v1=latest,echo-v1=current"},
+			desiredRevisions: []string{"echo-v1", "echo-v2", "echo-v1"}, // appends a new target
+			desiredTags:      []string{"latest", "", "current"},         // with new tag requested
+			desiredPercents:  []int64{50, 50, 0},                        // and assign 0% to it
 		},
 
 		{
-			"have multiple tags for a revision, revision absent in traffic block",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "echo-v2", 100, false)),
-			[]string{"--tag", "echo-v1=latest,echo-v1=current"},
-			[]string{"echo-v2", "echo-v1", "echo-v1"}, // appends two new targets
-			[]string{"", "latest", "current"},         // with new tags requested
-			[]int64{100, 0, 0},                        // and assign 0% to each
+			name:             "have multiple tags for a revision, revision absent in traffic block",
+			existingTraffic:  append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "echo-v2", 100, false)),
+			inputFlags:       []string{"--tag", "echo-v1=latest,echo-v1=current"},
+			desiredRevisions: []string{"echo-v2", "echo-v1", "echo-v1"}, // appends two new targets
+			desiredTags:      []string{"", "latest", "current"},         // with new tags requested
+			desiredPercents:  []int64{100, 0, 0},                        // and assign 0% to each
 		},
 		{
-			"re-assign same tag 'current' to @latest",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("current", "", 100, true)),
-			[]string{"--tag", "@latest=current"},
-			[]string{""},
-			[]string{"current"}, // since no change, no error
-			[]int64{100},
+			name:             "re-assign same tag 'current' to @latest",
+			existingTraffic:  append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("current", "", 100, true)),
+			inputFlags:       []string{"--tag", "@latest=current"},
+			desiredRevisions: []string{""},
+			desiredTags:      []string{"current"}, // since no change, no error
+			desiredPercents:  []int64{100},
 		},
 		{
-			"assign echo-v1 10% traffic adjusting rest to @latest, echo-v1 isn't present in existing traffic block",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true)),
-			[]string{"--traffic", "echo-v1=10,@latest=90"},
-			[]string{"", "echo-v1"},
-			[]string{"", ""}, // since no change, no error
-			[]int64{90, 10},
+			name:             "assign echo-v1 10% traffic adjusting rest to @latest, echo-v1 isn't present in existing traffic block",
+			existingTraffic:  append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true)),
+			inputFlags:       []string{"--traffic", "echo-v1=10,@latest=90"},
+			desiredRevisions: []string{"", "echo-v1"},
+			desiredTags:      []string{"", ""}, // since no change, no error
+			desiredPercents:  []int64{90, 10},
+		},
+		{
+			name:             "traffic split with sum < 100 should work for n-1 revisions",
+			existingTraffic:  append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "rev-00001", 0, false), newTarget("", "rev-00002", 0, false), newTarget("", "rev-00003", 100, false)),
+			inputFlags:       []string{"--traffic", "rev-00001=10,rev-00002=10"},
+			desiredRevisions: []string{"rev-00001", "rev-00002", "rev-00003"},
+			desiredPercents:  []int64{10, 10, 80},
+			desiredTags:      []string{"", "", ""},
+			existingRevisions: []servingv1.Revision{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rev-00001",
+					Labels: map[string]string{
+						"serving.knative.dev/service": "serviceName",
+					},
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rev-00002",
+					Labels: map[string]string{
+						"serving.knative.dev/service": "serviceName",
+					},
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rev-00003",
+					Labels: map[string]string{
+						"serving.knative.dev/service": "serviceName",
+					},
+				},
+			}},
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -193,7 +226,7 @@ func TestCompute(t *testing.T) {
 			testCmd, tFlags := newTestTrafficCommand()
 			testCmd.SetArgs(testCase.inputFlags)
 			testCmd.Execute()
-			targets, err := Compute(testCmd, testCase.existingTraffic, tFlags, "serviceName", nil)
+			targets, err := Compute(testCmd, testCase.existingTraffic, tFlags, "serviceName", testCase.existingRevisions)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -213,89 +246,145 @@ func TestCompute(t *testing.T) {
 func TestComputeErrMsg(t *testing.T) {
 	for _, testCase := range []trafficErrorTestCase{
 		{
-			"invalid format for --traffic option",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true)),
-			[]string{"--traffic", "@latest=100=latest"},
-			"expecting the value format in value1=value2, given @latest=100=latest",
+			name:            "invalid format for --traffic option",
+			existingTraffic: append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true)),
+			inputFlags:      []string{"--traffic", "@latest=100=latest"},
+			errMsg:          "expecting the value format in value1=value2, given @latest=100=latest",
 		},
 		{
-			"invalid format for --tag option",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true)),
-			[]string{"--tag", "@latest="},
-			"expecting the value format in value1=value2, given @latest=",
+			name:            "invalid format for --tag option",
+			existingTraffic: append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true)),
+			inputFlags:      []string{"--tag", "@latest="},
+			errMsg:          "expecting the value format in value1=value2, given @latest=",
 		},
 		{
-			"repeatedly splitting traffic to @latest revision",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true)),
-			[]string{"--traffic", "@latest=90,@latest=10"},
-			"repetition of identifier @latest is not allowed, use only once with --traffic flag",
+			name:            "repeatedly splitting traffic to @latest revision",
+			existingTraffic: append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true)),
+			inputFlags:      []string{"--traffic", "@latest=90,@latest=10"},
+			errMsg:          "repetition of identifier @latest is not allowed, use only once with --traffic flag",
 		},
 		{
-			"repeatedly tagging to @latest revision not allowed",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true)),
-			[]string{"--tag", "@latest=latest,@latest=2"},
-			"repetition of identifier @latest is not allowed, use only once with --tag flag",
+			name:            "repeatedly tagging to @latest revision not allowed",
+			existingTraffic: append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true)),
+			inputFlags:      []string{"--tag", "@latest=latest,@latest=2"},
+			errMsg:          "repetition of identifier @latest is not allowed, use only once with --tag flag",
 		},
 		{
-			"overwriting tag not allowed, to @latest from other revision",
-			append(append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("latest", "", 2, true)), newTarget("stable", "echo-v2", 98, false)),
-			[]string{"--tag", "@latest=stable"},
-			"refusing to overwrite existing tag in service, add flag '--untag stable' in command to untag it",
+			name:            "overwriting tag not allowed, to @latest from other revision",
+			existingTraffic: append(append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("latest", "", 2, true)), newTarget("stable", "echo-v2", 98, false)),
+			inputFlags:      []string{"--tag", "@latest=stable"},
+			errMsg:          "refusing to overwrite existing tag in service, add flag '--untag stable' in command to untag it",
 		},
 		{
-			"overwriting tag not allowed, to a revision from other revision",
-			append(append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("latest", "", 2, true)), newTarget("stable", "echo-v2", 98, false)),
-			[]string{"--tag", "echo-v2=latest"},
-			"refusing to overwrite existing tag in service, add flag '--untag latest' in command to untag it",
+			name:            "overwriting tag not allowed, to a revision from other revision",
+			existingTraffic: append(append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("latest", "", 2, true)), newTarget("stable", "echo-v2", 98, false)),
+			inputFlags:      []string{"--tag", "echo-v2=latest"},
+			errMsg:          "refusing to overwrite existing tag in service, add flag '--untag latest' in command to untag it",
 		},
 		{
-			"overwriting tag of @latest not allowed, existing != requested",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("candidate", "", 100, true)),
-			[]string{"--tag", "@latest=current"},
-			"tag 'candidate' exists on latest ready revision of service, refusing to overwrite existing tag with 'current', add flag '--untag candidate' in command to untag it",
+			name:            "overwriting tag of @latest not allowed, existing != requested",
+			existingTraffic: append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("candidate", "", 100, true)),
+			inputFlags:      []string{"--tag", "@latest=current"},
+			errMsg:          "tag 'candidate' exists on latest ready revision of service, refusing to overwrite existing tag with 'current', add flag '--untag candidate' in command to untag it",
 		},
 		{
-			"verify error for non integer values given to percent",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true)),
-			[]string{"--traffic", "@latest=100p"},
-			"error converting given 100p to integer value for traffic distribution",
+			name:            "verify error for non integer values given to percent",
+			existingTraffic: append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true)),
+			inputFlags:      []string{"--traffic", "@latest=100p"},
+			errMsg:          "error converting given 100p to integer value for traffic distribution",
 		},
 		{
-			"verify error for traffic sum not equal to 100",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true)),
-			[]string{"--traffic", "@latest=40,echo-v1=70"},
-			"given traffic percents sum to 110, want 100",
+			name:            "verify error for traffic sum not equal to 100",
+			existingTraffic: append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true)),
+			inputFlags:      []string{"--traffic", "@latest=40,echo-v1=70"},
+			errMsg:          "given traffic percents sum to 110, want 100",
 		},
 		{
-			"verify error for values out of range given to percent",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true)),
-			[]string{"--traffic", "@latest=-100"},
-			"invalid value for traffic percent -100, expected 0 <= percent <= 100",
+			name:            "verify error for values out of range given to percent",
+			existingTraffic: append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true)),
+			inputFlags:      []string{"--traffic", "@latest=-100"},
+			errMsg:          "invalid value for traffic percent -100, expected 0 <= percent <= 100",
 		},
 		{
-			"repeatedly splitting traffic to the same revision",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true)),
-			[]string{"--traffic", "echo-v1=40", "--traffic", "echo-v1=60"},
-			"repetition of revision reference echo-v1 is not allowed, use only once with --traffic flag",
+			name:            "repeatedly splitting traffic to the same revision",
+			existingTraffic: append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true)),
+			inputFlags:      []string{"--traffic", "echo-v1=40", "--traffic", "echo-v1=60"},
+			errMsg:          "repetition of revision reference echo-v1 is not allowed, use only once with --traffic flag",
 		},
 		{
-			"untag single tag that does not exist",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("latest", "echo-v1", 100, false)),
-			[]string{"--untag", "foo"},
-			"tag(s) foo not present for any revisions of service serviceName",
+			name:            "untag single tag that does not exist",
+			existingTraffic: append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("latest", "echo-v1", 100, false)),
+			inputFlags:      []string{"--untag", "foo"},
+			errMsg:          "tag(s) foo not present for any revisions of service serviceName",
 		},
 		{
-			"untag multiple tags that do not exist",
-			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("latest", "echo-v1", 100, false)),
-			[]string{"--untag", "foo", "--untag", "bar"},
-			"tag(s) foo, bar not present for any revisions of service serviceName",
+			name:            "untag multiple tags that do not exist",
+			existingTraffic: append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("latest", "echo-v1", 100, false)),
+			inputFlags:      []string{"--untag", "foo", "--untag", "bar"},
+			errMsg:          "tag(s) foo, bar not present for any revisions of service serviceName",
+		},
+		{
+			name:            "traffic split sum < 100 should have N-1 revisions specified",
+			existingTraffic: append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "rev-00001", 0, false), newTarget("", "rev-00002", 0, false), newTarget("", "rev-00003", 100, false)),
+			inputFlags:      []string{"--traffic", "rev-00001=10"},
+			errMsg:          "given traffic percents sum to 10 and number of revs is 1 but should be 3 - 1",
+			existingRevisions: []servingv1.Revision{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rev-00001",
+					Labels: map[string]string{
+						"serving.knative.dev/service": "serviceName",
+					},
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rev-00002",
+					Labels: map[string]string{
+						"serving.knative.dev/service": "serviceName",
+					},
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rev-00003",
+					Labels: map[string]string{
+						"serving.knative.dev/service": "serviceName",
+					},
+				},
+			}},
+		},
+		{
+			name:            "traffic split sum < 100 should not have @latest specified",
+			existingTraffic: append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "rev-00001", 0, false), newTarget("", "rev-00002", 0, false), newTarget("", "rev-00003", 100, true)),
+			inputFlags:      []string{"--traffic", "rev-00001=10,@latest=20"},
+			errMsg:          errorTrafficDistribution().Error(),
+			existingRevisions: []servingv1.Revision{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rev-00001",
+					Labels: map[string]string{
+						"serving.knative.dev/service": "serviceName",
+					},
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rev-00002",
+					Labels: map[string]string{
+						"serving.knative.dev/service": "serviceName",
+					},
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rev-00003",
+					Labels: map[string]string{
+						"serving.knative.dev/service": "serviceName",
+					},
+				},
+			}},
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			testCmd, tFlags := newTestTrafficCommand()
 			testCmd.SetArgs(testCase.inputFlags)
 			testCmd.Execute()
-			_, err := Compute(testCmd, testCase.existingTraffic, tFlags, "serviceName", nil)
+			_, err := Compute(testCmd, testCase.existingTraffic, tFlags, "serviceName", testCase.existingRevisions)
 			assert.Error(t, err, testCase.errMsg)
 		})
 	}

--- a/pkg/kn/traffic/compute_test.go
+++ b/pkg/kn/traffic/compute_test.go
@@ -193,7 +193,7 @@ func TestCompute(t *testing.T) {
 			testCmd, tFlags := newTestTrafficCommand()
 			testCmd.SetArgs(testCase.inputFlags)
 			testCmd.Execute()
-			targets, err := Compute(testCmd, testCase.existingTraffic, tFlags, "serviceName")
+			targets, err := Compute(testCmd, testCase.existingTraffic, tFlags, "serviceName", nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -263,8 +263,8 @@ func TestComputeErrMsg(t *testing.T) {
 		{
 			"verify error for traffic sum not equal to 100",
 			append(newServiceTraffic([]servingv1.TrafficTarget{}), newTarget("", "", 100, true)),
-			[]string{"--traffic", "@latest=19,echo-v1=71"},
-			"given traffic percents sum to 90, want 100",
+			[]string{"--traffic", "@latest=40,echo-v1=70"},
+			"given traffic percents sum to 110, want 100",
 		},
 		{
 			"verify error for values out of range given to percent",
@@ -295,7 +295,7 @@ func TestComputeErrMsg(t *testing.T) {
 			testCmd, tFlags := newTestTrafficCommand()
 			testCmd.SetArgs(testCase.inputFlags)
 			testCmd.Execute()
-			_, err := Compute(testCmd, testCase.existingTraffic, tFlags, "serviceName")
+			_, err := Compute(testCmd, testCase.existingTraffic, tFlags, "serviceName", nil)
 			assert.Error(t, err, testCase.errMsg)
 		})
 	}


### PR DESCRIPTION
## Description

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Determine traffic split when N-1 revisions are specified
* In case `@latest` is specified, cannot determine the split unless it sums to 100


## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
