### PR TITLE
Fix the most common E2E flakes

### DIFF
--- a/test/e2e/domain_mapping_test.go
+++ b/test/e2e/domain_mapping_test.go
@@ -108,6 +108,16 @@ func domainList(r *test.KnRunResultCollector, domainName string) {
 }
 
 func domainDescribe(r *test.KnRunResultCollector, domainName string, tls bool) {
+	k := test.NewKubectl(r.KnTest().Kn().Namespace())
+	// Wait for Domain Mapping URL to be populated
+	for i := 0; i < 10; i++ {
+		out, err := k.Run("get", "domainmapping", domainName, "-o=jsonpath='{.status.url}'")
+		assert.NilError(r.T(), err)
+		if len(out) > 0 {
+			break
+		}
+		time.Sleep(time.Second)
+	}
 	out := r.KnTest().Kn().Run("domain", "describe", domainName)
 	r.AssertNoError(out)
 	var url string

--- a/test/e2e/sink_test.go
+++ b/test/e2e/sink_test.go
@@ -38,7 +38,7 @@ func TestSink(t *testing.T) {
 
 	// create broker
 	test.BrokerCreate(r, "default")
-	defer test.BrokerDelete(r, "default", true)
+	defer test.BrokerDelete(r, "default", false)
 
 	t.Log("Create Ping source with a sink to the default broker")
 	pingSourceCreate(r, "testpingsource0", "* * * * */1", "ping", "broker:default")

--- a/test/e2e/trigger_test.go
+++ b/test/e2e/trigger_test.go
@@ -38,7 +38,7 @@ func TestBrokerTrigger(t *testing.T) {
 	defer r.DumpIfFailed()
 
 	test.BrokerCreate(r, "default")
-	defer test.BrokerDelete(r, "default", true)
+	defer test.BrokerDelete(r, "default", false)
 
 	test.ServiceCreate(r, "sinksvc0")
 	test.ServiceCreate(r, "sinksvc1")


### PR DESCRIPTION
## Description

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Add simple wait for URL to domain mapping E2E test
* Disable sync delete of brokers used in defer


## Reference
