### PR TITLE
Add --tag flag to service create and allow traffic split <100 when @latest is specified

### DIFF
--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -92,6 +92,7 @@ kn service create NAME --image IMAGE
       --scale-utilization int             Percentage of concurrent requests utilization before scaling up. (default 70)
       --scale-window string               Duration to look back for making auto-scaling decisions. The service is scaled to zero if no request was received in during that time. (eg: 10s)
       --service-account string            Service account name to set. An empty argument ("") clears the service account. The referenced service account must exist in the service's namespace.
+      --tag strings                       Set tag (format: --tag revisionRef=tagName) where revisionRef can be a revision or '@latest' string representing latest ready revision. This flag can be specified multiple times.
       --target string                     Work on local directory instead of a remote cluster (experimental)
       --user int                          The user ID to run the container (e.g., 1001).
       --volume stringArray                Add a volume from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret: or sc:). Example: --volume myvolume=cm:myconfigmap or --volume myvolume=secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --volume myvolume-.

--- a/pkg/kn/commands/flags/traffic.go
+++ b/pkg/kn/commands/flags/traffic.go
@@ -25,22 +25,34 @@ type Traffic struct {
 }
 
 func (t *Traffic) Add(cmd *cobra.Command) {
-	cmd.Flags().StringSliceVar(&t.RevisionsPercentages,
-		"traffic",
-		nil,
-		"Set traffic distribution (format: --traffic revisionRef=percent) where revisionRef can be a revision or a tag or '@latest' string "+
-			"representing latest ready revision. This flag can be given multiple times with percent summing up to 100%.")
+	t.AddTrafficFlag(cmd)
 
+	t.AddTagFlag(cmd)
+
+	t.AddUntagFlag(cmd)
+}
+
+func (t *Traffic) AddUntagFlag(cmd *cobra.Command) {
+	cmd.Flags().StringSliceVar(&t.UntagRevisions,
+		"untag",
+		nil,
+		"Untag revision (format: --untag tagName). This flag can be specified multiple times.")
+}
+
+func (t *Traffic) AddTagFlag(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&t.RevisionsTags,
 		"tag",
 		nil,
 		"Set tag (format: --tag revisionRef=tagName) where revisionRef can be a revision or '@latest' string representing latest ready revision. "+
 			"This flag can be specified multiple times.")
+}
 
-	cmd.Flags().StringSliceVar(&t.UntagRevisions,
-		"untag",
+func (t *Traffic) AddTrafficFlag(cmd *cobra.Command) {
+	cmd.Flags().StringSliceVar(&t.RevisionsPercentages,
+		"traffic",
 		nil,
-		"Untag revision (format: --untag tagName). This flag can be specified multiple times.")
+		"Set traffic distribution (format: --traffic revisionRef=percent) where revisionRef can be a revision or a tag or '@latest' string "+
+			"representing latest ready revision. This flag can be given multiple times with percent summing up to 100%.")
 }
 
 func (t *Traffic) PercentagesChanged(cmd *cobra.Command) bool {

--- a/pkg/kn/commands/flags/traffic.go
+++ b/pkg/kn/commands/flags/traffic.go
@@ -32,6 +32,7 @@ func (t *Traffic) Add(cmd *cobra.Command) {
 	t.AddUntagFlag(cmd)
 }
 
+// AddUntagFlag adds the flag --untag to the command
 func (t *Traffic) AddUntagFlag(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&t.UntagRevisions,
 		"untag",
@@ -39,6 +40,7 @@ func (t *Traffic) AddUntagFlag(cmd *cobra.Command) {
 		"Untag revision (format: --untag tagName). This flag can be specified multiple times.")
 }
 
+// AddTagFlag adds the flag --tag to the command
 func (t *Traffic) AddTagFlag(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&t.RevisionsTags,
 		"tag",
@@ -47,6 +49,7 @@ func (t *Traffic) AddTagFlag(cmd *cobra.Command) {
 			"This flag can be specified multiple times.")
 }
 
+// AddTrafficFlag adds the flag --traffic to the command
 func (t *Traffic) AddTrafficFlag(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&t.RevisionsPercentages,
 		"traffic",

--- a/pkg/kn/commands/service/create.go
+++ b/pkg/kn/commands/service/create.go
@@ -124,7 +124,7 @@ func NewServiceCreateCommand(p *commands.KnParams) *cobra.Command {
 			if trafficFlags.TagsChanged(cmd) {
 				trafficFlags.RevisionsPercentages = []string{"@latest=100"}
 
-				traffic, err := traffic.Compute(cmd, service.Spec.Traffic, &trafficFlags, service.Name, nil)
+				traffic, err := traffic.Compute(cmd, service, &trafficFlags, nil, editFlags.AnyMutation(cmd))
 				if err != nil {
 					return err
 				}

--- a/pkg/kn/commands/service/create.go
+++ b/pkg/kn/commands/service/create.go
@@ -23,6 +23,8 @@ import (
 
 	"knative.dev/client/pkg/config"
 	"knative.dev/client/pkg/kn/commands"
+	"knative.dev/client/pkg/kn/commands/flags"
+	"knative.dev/client/pkg/kn/traffic"
 	servinglib "knative.dev/client/pkg/serving"
 
 	"knative.dev/serving/pkg/apis/serving"
@@ -82,6 +84,7 @@ var create_example = `
 func NewServiceCreateCommand(p *commands.KnParams) *cobra.Command {
 	var editFlags ConfigurationEditFlags
 	var waitFlags commands.WaitFlags
+	var trafficFlags flags.Traffic
 
 	serviceCreateCommand := &cobra.Command{
 		Use:     "create NAME --image IMAGE",
@@ -118,6 +121,15 @@ func NewServiceCreateCommand(p *commands.KnParams) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if trafficFlags.TagsChanged(cmd) {
+				trafficFlags.RevisionsPercentages = []string{"@latest=100"}
+
+				traffic, err := traffic.Compute(cmd, service.Spec.Traffic, &trafficFlags, service.Name, nil)
+				if err != nil {
+					return err
+				}
+				service.Spec.Traffic = traffic
+			}
 			serviceExists, err := serviceExists(cmd.Context(), client, service.Name)
 			if err != nil {
 				return err
@@ -143,6 +155,7 @@ func NewServiceCreateCommand(p *commands.KnParams) *cobra.Command {
 	commands.AddNamespaceFlags(serviceCreateCommand.Flags(), false)
 	commands.AddGitOpsFlags(serviceCreateCommand.Flags())
 	editFlags.AddCreateFlags(serviceCreateCommand)
+	trafficFlags.AddTagFlag(serviceCreateCommand)
 	waitFlags.AddConditionWaitFlags(serviceCreateCommand, commands.WaitDefaultTimeout, "create", "service", "ready")
 	return serviceCreateCommand
 }

--- a/pkg/kn/commands/service/create_test.go
+++ b/pkg/kn/commands/service/create_test.go
@@ -1091,3 +1091,9 @@ func TestServiceCreateTag(t *testing.T) {
 	assert.Equal(t, len(created.Spec.Traffic), 1)
 	assert.Equal(t, created.Spec.Traffic[0].Tag, "foo")
 }
+
+func TestServiceCreateTagWithError(t *testing.T) {
+	_, _, _, err := fakeServiceCreate([]string{
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--tag", "foo,bar"}, false)
+	assert.Error(t, err, "repetition of identifier @latest is not allowed, use only once with --tag flag")
+}

--- a/pkg/kn/commands/service/create_test.go
+++ b/pkg/kn/commands/service/create_test.go
@@ -1082,3 +1082,12 @@ func TestServiceCreateFromYAMLWithOverrideError(t *testing.T) {
 	assert.Assert(t, err != nil)
 	assert.Assert(t, util.ContainsAll(err.Error(), "expected", "0", "<=", "2147483647", "autoscaling.knative.dev/maxScale"))
 }
+
+func TestServiceCreateTag(t *testing.T) {
+	action, created, _, err := fakeServiceCreate([]string{
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--tag", "foo"}, false)
+	assert.NilError(t, err)
+	assert.Assert(t, action.Matches("create", "services"))
+	assert.Equal(t, len(created.Spec.Traffic), 1)
+	assert.Equal(t, created.Spec.Traffic[0].Tag, "foo")
+}

--- a/pkg/kn/commands/service/update.go
+++ b/pkg/kn/commands/service/update.go
@@ -107,7 +107,7 @@ func NewServiceUpdateCommand(p *commands.KnParams) *cobra.Command {
 					if err != nil {
 						return nil, err
 					}
-					traffic, err := traffic.Compute(cmd, service.Spec.Traffic, &trafficFlags, service.Name, revisions.Items)
+					traffic, err := traffic.Compute(cmd, service, &trafficFlags, revisions.Items, editFlags.AnyMutation(cmd))
 					if err != nil {
 						return nil, err
 					}

--- a/pkg/kn/traffic/compute.go
+++ b/pkg/kn/traffic/compute.go
@@ -44,6 +44,9 @@ func newServiceTraffic(traffic []servingv1.TrafficTarget) ServiceTraffic {
 
 func splitByEqualSign(pair string) (string, string, error) {
 	parts := strings.Split(pair, "=")
+	if len(parts) == 1 {
+		return latestRevisionRef, parts[0], nil
+	}
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return "", "", fmt.Errorf("expecting the value format in value1=value2, given %s", pair)
 	}
@@ -416,7 +419,7 @@ func Compute(cmd *cobra.Command, targets []servingv1.TrafficTarget,
 		traffic = traffic.TagRevision(tag, revision)
 	}
 
-	if cmd.Flags().Changed("traffic") {
+	if cmd.Flags().Changed("traffic") || (cmd.Name() == "create" && len(trafficFlags.RevisionsTags) > 0) {
 		// reset existing traffic portions as what's on CLI is desired state of traffic split portions
 		traffic.ResetAllTargetPercent()
 

--- a/pkg/kn/traffic/compute.go
+++ b/pkg/kn/traffic/compute.go
@@ -229,7 +229,7 @@ func errorTrafficDistribution(sum int, reason int) error {
 	case errorDistributionRevisionNotFound:
 		errMsg = "cannot determine the missing revision"
 	}
-	return fmt.Errorf("unable to allocate the remaining traffic: %d%%: %s", 100-sum, errMsg)
+	return fmt.Errorf("unable to allocate the remaining traffic: %d%%. Reason: %s", 100-sum, errMsg)
 }
 
 func errorSumGreaterThan100(sum int) error {
@@ -279,10 +279,10 @@ func verifyInput(trafficFlags *flags.Traffic, svc *servingv1.Service, revisions 
 		return errorTrafficDistribution(sum, errorDistributionRevisionCount)
 	}
 	if specRevPercentCount == revisionCount-1 {
-		if latestRefTraffic && mutation {
-			return errorTrafficDistribution(sum, errorDistributionRevisionNotFound)
-		}
 		if latestRefTraffic {
+			if mutation {
+				return errorTrafficDistribution(sum, errorDistributionRevisionCount)
+			}
 			revisionRefMap[svc.Status.LatestReadyRevisionName] = 0
 		}
 		for _, rev := range revisions {
@@ -296,7 +296,7 @@ func verifyInput(trafficFlags *flags.Traffic, svc *servingv1.Service, revisions 
 
 	if specRevPercentCount == revisionCount && latestRefTraffic {
 		if !mutation {
-			return errorTrafficDistribution(sum, errorDistributionRevisionNotFound)
+			return errorTrafficDistribution(sum, errorDistributionRevisionCount)
 		}
 		for _, rev := range revisions {
 			if !checkRevisionPresent(revisionRefMap, rev) {

--- a/test/e2e/traffic_split_test.go
+++ b/test/e2e/traffic_split_test.go
@@ -503,7 +503,6 @@ func TestTrafficSplit(t *testing.T) {
 
 func verifyTargets(r *test.KnRunResultCollector, serviceName string, expectedTargets []TargetFields, expectErr bool) {
 	out := test.ServiceDescribeWithJSONPath(r, serviceName, targetsJsonPath)
-	r.T().Log(out)
 	assert.Check(r.T(), out != "")
 	actualTargets, err := splitTargets(out, targetsSeparator, len(expectedTargets))
 	if !expectErr {


### PR DESCRIPTION
## Description

Add `--tag` flag to service create and interpret just value arguments to the flag as `@latest=value`
When `@latest` is specified as argument to `--traffic` and sum < 100, calculate the remaining revision

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* The arguments that don't follow `key=value` format and just `value` format will be treated as `@latest=value`
* `service create` will have a `--tag` flag so revision is created with a tag
* Updating traffic split for a service when `@latest` is specified and the total sum is less than 100 for a service with N revisions will work as follows:
     * If the update leads to a new revision creation, total N `key=value` arguments need to be specified for `--traffic`
     *  If the update does not create a new revision, total N-1 `key=value` arguments need to be specified for `--traffic`

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
