### PR TITLE
Move away from grpc-ping test image as symlink

### DIFF
--- a/test/test_images/grpc-ping
+++ b/test/test_images/grpc-ping
@@ -1,1 +1,0 @@
-./../../vendor/knative.dev/serving/test/test_images/grpc-ping

--- a/test/test_images/grpc-ping/release.yaml
+++ b/test/test_images/grpc-ping/release.yaml
@@ -1,0 +1,16 @@
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- image: ko://knative.dev/serving/test/test_images/grpc-ping
+


### PR DESCRIPTION
## Description

The former setup seems to break builds on Golang 1.17 with missing go dependencies. 
And on pair with https://github.com/knative/client/blob/main/test/test_images/multicontainer/release.yaml

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Move away from grpc-ping test image as symlink


## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->

/cc @markusthoemmes 
