### PR TITLE
Fixed panic when traffic split to unavailable revision

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,6 +21,10 @@
 | Fixed panic in kn service describe
 | https://github.com/knative/client/pull/1529[#1529]
 
+| 🐛
+| Fixed panic in kn service update
+| https://github.com/knative/client/pull/1533[#1533]
+
 |===
 
 ## v1.0.0 (2021-11-02)

--- a/pkg/serving/config_changes.go
+++ b/pkg/serving/config_changes.go
@@ -145,7 +145,7 @@ func PinImageToDigest(currentRevisionTemplate *servingv1.RevisionTemplateSpec, b
 	}
 
 	containerStatus := ContainerStatus(baseRevision)
-	if containerStatus.ImageDigest != "" {
+	if containerStatus != nil && containerStatus.ImageDigest != "" {
 		return flags.UpdateImage(&currentRevisionTemplate.Spec.PodSpec, containerStatus.ImageDigest)
 	}
 	return nil

--- a/pkg/serving/config_changes_test.go
+++ b/pkg/serving/config_changes_test.go
@@ -141,6 +141,16 @@ func TestPinImageToDigestInvalidImages(t *testing.T) {
 	assert.ErrorContains(t, err, "unexpected image")
 }
 
+func TestPinImageToDigestNilContainerStatus(t *testing.T) {
+	template, _ := getRevisionTemplate()
+	revision := &servingv1.Revision{}
+	revision.Spec = template.Spec
+	revision.ObjectMeta = template.ObjectMeta
+	revision.Status.ContainerStatuses = nil
+	err := PinImageToDigest(template, revision)
+	assert.NilError(t, err)
+}
+
 func TestUpdateTimestampAnnotation(t *testing.T) {
 	template, _ := getRevisionTemplate()
 	UpdateTimestampAnnotation(template)

--- a/pkg/serving/revision_template.go
+++ b/pkg/serving/revision_template.go
@@ -65,7 +65,7 @@ func ContainerIndexOfRevisionSpec(revisionSpec *servingv1.RevisionSpec) int {
 // such status could be found
 func ContainerStatus(r *servingv1.Revision) *servingv1.ContainerStatus {
 	idx := ContainerIndexOfRevisionSpec(&r.Spec)
-	if idx == -1 {
+	if idx < 0 || idx >= len(r.Status.ContainerStatuses) {
 		return nil
 	}
 	return &r.Status.ContainerStatuses[idx]

--- a/pkg/serving/revision_template_test.go
+++ b/pkg/serving/revision_template_test.go
@@ -151,3 +151,89 @@ func TestPort(t *testing.T) {
 	revisionSpec.PodSpec.Containers[0].Ports = []corev1.ContainerPort{port}
 	assert.Equal(t, (int32)(42), *Port(revisionSpec))
 }
+
+func TestContainerStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		rev  *servingv1.Revision
+		want *servingv1.ContainerStatus
+	}{
+		{
+			"no container",
+			&servingv1.Revision{
+				Spec: servingv1.RevisionSpec{},
+			},
+			nil,
+		},
+		{
+			"no container",
+			&servingv1.Revision{
+				Spec: servingv1.RevisionSpec{},
+			},
+			nil,
+		},
+		{
+			"1 container",
+			&servingv1.Revision{
+				Spec: servingv1.RevisionSpec{
+					PodSpec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "user-container",
+								Ports: []corev1.ContainerPort{{ContainerPort: 80}},
+							},
+						},
+					},
+				},
+				Status: servingv1.RevisionStatus{ContainerStatuses: []servingv1.ContainerStatus{
+					{
+						Name: "user-container",
+					},
+				}},
+			},
+			&servingv1.ContainerStatus{
+				Name: "user-container",
+			},
+		},
+		{
+			"3 containers",
+			&servingv1.Revision{
+				Spec: servingv1.RevisionSpec{
+					PodSpec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "sidecar-container-1",
+							},
+							{
+								Name:  "user-container",
+								Ports: []corev1.ContainerPort{{ContainerPort: 80}},
+							},
+							{
+								Name: "sidecar-container-2",
+							},
+						}}},
+				Status: servingv1.RevisionStatus{
+					ContainerStatuses: []servingv1.ContainerStatus{
+						{
+							Name: "sidecar-container-1",
+						},
+						{
+							Name: "user-container",
+						},
+						{
+							Name: "sidecar-container-2",
+						},
+					},
+				}},
+			&servingv1.ContainerStatus{
+				Name: "user-container",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ContainerStatus(tt.rev)
+			assert.DeepEqual(t, got, tt.want)
+		})
+	}
+}

--- a/pkg/serving/revision_template_test.go
+++ b/pkg/serving/revision_template_test.go
@@ -162,13 +162,11 @@ func TestContainerStatus(t *testing.T) {
 			"no container",
 			&servingv1.Revision{
 				Spec: servingv1.RevisionSpec{},
-			},
-			nil,
-		},
-		{
-			"no container",
-			&servingv1.Revision{
-				Spec: servingv1.RevisionSpec{},
+				Status: servingv1.RevisionStatus{ContainerStatuses: []servingv1.ContainerStatus{
+					{
+						Name: "user-container",
+					},
+				}},
 			},
 			nil,
 		},


### PR DESCRIPTION
## Description
Panic during updating traffic to a revision that is not ready

<!-- Please add a short summary about what the pull request is going to bring on the table -->
Before:

```
$ kn service update hello-example-3 --env TARGET="pqr" --traffic abcd=50,hello-example-3-00002=50

E1130 00:13:13.786017   76154 runtime.go:78] Observed a panic: runtime.boundsError{x:0, y:0, signed:true, code:0x0} (runtime error: index out of range [0] with length 0)
goroutine 1 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x246a6a0, 0xc0006ac570})
	/home/prow/go/src/knative.dev/client/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x85
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x5a0})
	/home/prow/go/src/knative.dev/client/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x75
panic({0x246a6a0, 0xc0006ac570})
	/root/.gvm/gos/go1.17.2/src/runtime/panic.go:1038 +0x215
knative.dev/client/pkg/serving.ContainerStatus(...)
	/home/prow/go/src/knative.dev/client/pkg/serving/revision_template.go:71
knative.dev/client/pkg/serving.PinImageToDigest(0xc00011a118, 0xc000192700)
	/home/prow/go/src/knative.dev/client/pkg/serving/config_changes.go:147 +0x293
knative.dev/client/pkg/kn/commands/service.(*ConfigurationEditFlags).Apply(0xc00012e780, 0xc00011a000, 0x23376a0, 0xc00069cb00)
	/home/prow/go/src/knative.dev/client/pkg/kn/commands/service/configuration_edit_flags.go:242 +0x252
knative.dev/client/pkg/kn/commands/service.NewServiceUpdateCommand.func1.1(0xc00011a000)
	/home/prow/go/src/knative.dev/client/pkg/kn/commands/service/update.go:100 +0x1d9
```
Now:
```
$ ./kn service update hello-example-3 --env TARGET="pqr" --traffic abcd=50,hello-example-3-00002=50

Updating Service 'hello-example-3' in namespace 'default':

  0.033s Revision "hello-example-3-00002" failed to become ready.
  0.093s ...
Error: RevisionMissing: Revision "hello-example-3-00002" failed to become ready.
```
## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Added nil pointed check
* Added array length check


## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
