### PR TITLE
:gift: Allow overriding of `build.sh` for downstream projects

### DIFF
--- a/hack/build-flags.sh
+++ b/hack/build-flags.sh
@@ -14,20 +14,30 @@
 
 function build_flags() {
   local base="${1}"
-  local now="$(date -u '+%Y-%m-%d %H:%M:%S')"
-  local rev="$(git rev-parse --short HEAD)"
+  local now rev
+  now="$(date -u '+%Y-%m-%d %H:%M:%S')"
+  rev="$(git rev-parse --short HEAD)"
   local pkg="knative.dev/client/pkg/kn/commands/version"
   local version="${TAG:-}"
   # Use vYYYYMMDD-local-<hash> for the version string, if not passed.
   if [[ -z "${version}" ]]; then
     # Get the commit, excluding any tags but keeping the "dirty" flag
-    local commit="$(git describe --always --dirty --match '^$')"
+    local commit
+    commit="$(git describe --always --dirty --match '^$')"
     [[ -n "${commit}" ]] || abort "error getting the current commit"
     version="v$(date +%Y%m%d)-local-${commit}"
   fi
   # Extract Eventing and Serving versions from go.mod
-  local version_serving=$(cat go.mod | grep "knative.dev/serving " | sed -s 's/.* \(v.[\.0-9]*\).*/\1/')
-  local version_eventing=$(cat go.mod | grep "knative.dev/eventing " | sed -s 's/.* \(v.[\.0-9]*\).*/\1/')
+  local version_serving version_eventing
+  version_serving=$(grep "knative.dev/serving " "${base}/go.mod" \
+    | sed -s 's/.* \(v.[\.0-9]*\).*/\1/')
+  version_eventing=$(grep "knative.dev/eventing " "${base}/go.mod" \
+    | sed -s 's/.* \(v.[\.0-9]*\).*/\1/')
 
-  echo "-X '${pkg}.BuildDate=${now}' -X ${pkg}.Version=${version} -X ${pkg}.GitRevision=${rev} -X ${pkg}.VersionServing=${version_serving} -X ${pkg}.VersionEventing=${version_eventing}"
+  echo "-X '${pkg}.BuildDate=${now}' \
+  -X ${pkg}.Version=${version} \
+  -X ${pkg}.GitRevision=${rev} \
+  -X ${pkg}.VersionServing=${version_serving} \
+  -X ${pkg}.VersionEventing=${version_eventing}\
+  ${EXTERNAL_LD_FLAGS:-}"
 }

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -128,7 +128,7 @@ source_lint() {
 
 go_build() {
   echo "🚧 Compile"
-  go build -mod=vendor -ldflags "$(build_flags $(basedir))" -o kn ./cmd/...
+  go build -mod=vendor -ldflags "$(build_flags "$(basedir)")" -o kn ./cmd/...
 
   if $(file kn | grep -q -i "Windows"); then
     mv kn kn.exe
@@ -136,7 +136,8 @@ go_build() {
 }
 
 go_test() {
-  local test_output=$(mktemp /tmp/kn-client-test-output.XXXXXX)
+  local test_output
+  test_output="$(mktemp /tmp/kn-client-test-output.XXXXXX)"
 
   local red=""
   local reset=""
@@ -164,7 +165,8 @@ check_license() {
   local required_keywords=("Authors" "Apache License" "LICENSE-2.0")
   local extensions_to_check=("sh" "go" "yaml" "yml" "json")
 
-  local check_output=$(mktemp /tmp/kn-client-licence-check.XXXXXX)
+  local check_output
+  check_output="$(mktemp /tmp/kn-client-licence-check.XXXXXX)"
   for ext in "${extensions_to_check[@]}"; do
     find . -name "*.$ext" -a \! -path "./vendor/*" -a \! -path "./.*" -a \! -path "./third_party/*" -print0 |
       while IFS= read -r -d '' path; do
@@ -242,9 +244,10 @@ basedir() {
         fi
     fi
 
-    local dir=$(dirname "$script")
-    local full_dir=$(cd "${dir}/.." && pwd)
-    echo ${full_dir}
+    local dir full_dir
+    dir=$(dirname "$script")
+    full_dir=$(cd "${dir}/.." && pwd)
+    echo "${full_dir}"
 }
 
 # Checks if a flag is present in the arguments.
@@ -262,8 +265,9 @@ has_flag() {
 }
 
 cross_build() {
-  local basedir=$(basedir)
-  local ld_flags="$(build_flags $basedir)"
+  local basedir ld_flags
+  basedir=$(basedir)
+  ld_flags="$(build_flags $basedir)"
   local failed=0
 
   echo "⚔️ ${S}Compile"
@@ -353,9 +357,12 @@ fi
 source $(basedir)/vendor/knative.dev/hack/library.sh
 
 # Shared funcs with CI
+while IFS= read -r -d '' file; do
+  source "${file}"
+done < <(find "$(basedir)/hack/build.sh.d" -name '*.sh' -print0)
 source $(basedir)/hack/build-flags.sh
 
 # Fixe emoji labels for certain terminals
 apply_emoji_fixes
 
-run $*
+run "$@"

--- a/hack/build.sh.d/README.md
+++ b/hack/build.sh.d/README.md
@@ -1,0 +1,4 @@
+# Extending build.sh directory
+
+This directory contains shell scripts named `*.sh`, that can be sourced by
+build script, and can be used to extend or override the build script.


### PR DESCRIPTION
## Changes

* 🎁 Allow overriding of `build.sh` for downstream projects
* ✨ Clean the scripts a bit, especially with [SC2155](https://github.com/koalaman/shellcheck/wiki/SC2155) issue

## Reference

Fixes #1543

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
