### PR TITLE
Add config command to mange configuration file

### DIFF
--- a/docs/cmd/kn.md
+++ b/docs/cmd/kn.md
@@ -24,6 +24,7 @@ Find more information about Knative at: https://knative.dev
 * [kn broker](kn_broker.md)	 - Manage message brokers
 * [kn channel](kn_channel.md)	 - Manage event channels
 * [kn completion](kn_completion.md)	 - Output shell completion code
+* [kn config](kn_config.md)	 - Manage Knative configuration file
 * [kn container](kn_container.md)	 - Manage service's containers (experimental)
 * [kn domain](kn_domain.md)	 - Manage domain mappings
 * [kn eventtype](kn_eventtype.md)	 - Manage eventtypes

--- a/docs/cmd/kn_config.md
+++ b/docs/cmd/kn_config.md
@@ -1,0 +1,33 @@
+## kn config
+
+Manage Knative configuration file
+
+```
+kn config COMMAND
+```
+
+### Options
+
+```
+  -h, --help   help for config
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string      name of the kubeconfig cluster to use
+      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
+      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
+      --log-http            log http traffic
+```
+
+### SEE ALSO
+
+* [kn](kn.md)	 - kn manages Knative Serving and Eventing resources
+* [kn config channel-type-mapping](kn_config_channel-type-mapping.md)	 - Manage channel type mapping list
+* [kn config get](kn_config_get.md)	 - Get configuration settings
+* [kn config set](kn_config_set.md)	 - Set configuration settings that are scalar
+* [kn config show](kn_config_show.md)	 - Show configuration settings
+* [kn config sink-mapping](kn_config_sink-mapping.md)	 - Manage sink mapping list
+

--- a/docs/cmd/kn_config_channel-type-mapping.md
+++ b/docs/cmd/kn_config_channel-type-mapping.md
@@ -1,0 +1,32 @@
+## kn config channel-type-mapping
+
+Manage channel type mapping list
+
+```
+kn config channel-type-mapping
+```
+
+### Options
+
+```
+  -h, --help   help for channel-type-mapping
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string      name of the kubeconfig cluster to use
+      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
+      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
+      --log-http            log http traffic
+```
+
+### SEE ALSO
+
+* [kn config](kn_config.md)	 - Manage Knative configuration file
+* [kn config channel-type-mapping add](kn_config_channel-type-mapping_add.md)	 - Add a new channel type mapping
+* [kn config channel-type-mapping delete](kn_config_channel-type-mapping_delete.md)	 - Delete a channel type mapping by its alias
+* [kn config channel-type-mapping list](kn_config_channel-type-mapping_list.md)	 - Show a channel type mapping list
+* [kn config channel-type-mapping update](kn_config_channel-type-mapping_update.md)	 - Update channel type mapping by its alias
+

--- a/docs/cmd/kn_config_channel-type-mapping_add.md
+++ b/docs/cmd/kn_config_channel-type-mapping_add.md
@@ -1,0 +1,31 @@
+## kn config channel-type-mapping add
+
+Add a new channel type mapping
+
+```
+kn config channel-type-mapping add
+```
+
+### Options
+
+```
+      --group string     The API group of the Kubernetes resource
+  -h, --help             help for add
+      --kind string      The kind of Channel, such as InMemoryChannel or KafkaChannel, based on the default ConfigMap
+      --version string   The version of the Kubernetes resource
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string      name of the kubeconfig cluster to use
+      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
+      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
+      --log-http            log http traffic
+```
+
+### SEE ALSO
+
+* [kn config channel-type-mapping](kn_config_channel-type-mapping.md)	 - Manage channel type mapping list
+

--- a/docs/cmd/kn_config_channel-type-mapping_delete.md
+++ b/docs/cmd/kn_config_channel-type-mapping_delete.md
@@ -1,0 +1,28 @@
+## kn config channel-type-mapping delete
+
+Delete a channel type mapping by its alias
+
+```
+kn config channel-type-mapping delete
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string      name of the kubeconfig cluster to use
+      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
+      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
+      --log-http            log http traffic
+```
+
+### SEE ALSO
+
+* [kn config channel-type-mapping](kn_config_channel-type-mapping.md)	 - Manage channel type mapping list
+

--- a/docs/cmd/kn_config_channel-type-mapping_list.md
+++ b/docs/cmd/kn_config_channel-type-mapping_list.md
@@ -1,0 +1,28 @@
+## kn config channel-type-mapping list
+
+Show a channel type mapping list
+
+```
+kn config channel-type-mapping list
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string      name of the kubeconfig cluster to use
+      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
+      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
+      --log-http            log http traffic
+```
+
+### SEE ALSO
+
+* [kn config channel-type-mapping](kn_config_channel-type-mapping.md)	 - Manage channel type mapping list
+

--- a/docs/cmd/kn_config_channel-type-mapping_update.md
+++ b/docs/cmd/kn_config_channel-type-mapping_update.md
@@ -1,0 +1,31 @@
+## kn config channel-type-mapping update
+
+Update channel type mapping by its alias
+
+```
+kn config channel-type-mapping update
+```
+
+### Options
+
+```
+      --group string     The API group of the Kubernetes resource
+  -h, --help             help for update
+      --kind string      The kind of Channel, such as InMemoryChannel or KafkaChannel, based on the default ConfigMap
+      --version string   The version of the Kubernetes resource
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string      name of the kubeconfig cluster to use
+      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
+      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
+      --log-http            log http traffic
+```
+
+### SEE ALSO
+
+* [kn config channel-type-mapping](kn_config_channel-type-mapping.md)	 - Manage channel type mapping list
+

--- a/docs/cmd/kn_config_get.md
+++ b/docs/cmd/kn_config_get.md
@@ -1,0 +1,28 @@
+## kn config get
+
+Get configuration settings
+
+```
+kn config get
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string      name of the kubeconfig cluster to use
+      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
+      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
+      --log-http            log http traffic
+```
+
+### SEE ALSO
+
+* [kn config](kn_config.md)	 - Manage Knative configuration file
+

--- a/docs/cmd/kn_config_set.md
+++ b/docs/cmd/kn_config_set.md
@@ -1,0 +1,28 @@
+## kn config set
+
+Set configuration settings that are scalar
+
+```
+kn config set
+```
+
+### Options
+
+```
+  -h, --help   help for set
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string      name of the kubeconfig cluster to use
+      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
+      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
+      --log-http            log http traffic
+```
+
+### SEE ALSO
+
+* [kn config](kn_config.md)	 - Manage Knative configuration file
+

--- a/docs/cmd/kn_config_show.md
+++ b/docs/cmd/kn_config_show.md
@@ -1,0 +1,28 @@
+## kn config show
+
+Show configuration settings
+
+```
+kn config show
+```
+
+### Options
+
+```
+  -h, --help   help for show
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string      name of the kubeconfig cluster to use
+      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
+      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
+      --log-http            log http traffic
+```
+
+### SEE ALSO
+
+* [kn config](kn_config.md)	 - Manage Knative configuration file
+

--- a/docs/cmd/kn_config_sink-mapping.md
+++ b/docs/cmd/kn_config_sink-mapping.md
@@ -1,0 +1,32 @@
+## kn config sink-mapping
+
+Manage sink mapping list
+
+```
+kn config sink-mapping
+```
+
+### Options
+
+```
+  -h, --help   help for sink-mapping
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string      name of the kubeconfig cluster to use
+      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
+      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
+      --log-http            log http traffic
+```
+
+### SEE ALSO
+
+* [kn config](kn_config.md)	 - Manage Knative configuration file
+* [kn config sink-mapping add](kn_config_sink-mapping_add.md)	 - Add a new sink mapping
+* [kn config sink-mapping delete](kn_config_sink-mapping_delete.md)	 - Delete a sink mapping by its prefix
+* [kn config sink-mapping list](kn_config_sink-mapping_list.md)	 - Show a sink mapping list
+* [kn config sink-mapping update](kn_config_sink-mapping_update.md)	 - Update sink mapping by its prefix
+

--- a/docs/cmd/kn_config_sink-mapping_add.md
+++ b/docs/cmd/kn_config_sink-mapping_add.md
@@ -1,0 +1,31 @@
+## kn config sink-mapping add
+
+Add a new sink mapping
+
+```
+kn config sink-mapping add
+```
+
+### Options
+
+```
+      --group string      The API group of the Kubernetes resource
+  -h, --help              help for add
+      --resource string   The lowercased, plural name of the Kubernetes resource type. For example, services or brokers
+      --version string    The version of the Kubernetes resource
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string      name of the kubeconfig cluster to use
+      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
+      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
+      --log-http            log http traffic
+```
+
+### SEE ALSO
+
+* [kn config sink-mapping](kn_config_sink-mapping.md)	 - Manage sink mapping list
+

--- a/docs/cmd/kn_config_sink-mapping_delete.md
+++ b/docs/cmd/kn_config_sink-mapping_delete.md
@@ -1,0 +1,28 @@
+## kn config sink-mapping delete
+
+Delete a sink mapping by its prefix
+
+```
+kn config sink-mapping delete
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string      name of the kubeconfig cluster to use
+      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
+      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
+      --log-http            log http traffic
+```
+
+### SEE ALSO
+
+* [kn config sink-mapping](kn_config_sink-mapping.md)	 - Manage sink mapping list
+

--- a/docs/cmd/kn_config_sink-mapping_list.md
+++ b/docs/cmd/kn_config_sink-mapping_list.md
@@ -1,0 +1,28 @@
+## kn config sink-mapping list
+
+Show a sink mapping list
+
+```
+kn config sink-mapping list
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string      name of the kubeconfig cluster to use
+      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
+      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
+      --log-http            log http traffic
+```
+
+### SEE ALSO
+
+* [kn config sink-mapping](kn_config_sink-mapping.md)	 - Manage sink mapping list
+

--- a/docs/cmd/kn_config_sink-mapping_update.md
+++ b/docs/cmd/kn_config_sink-mapping_update.md
@@ -1,0 +1,31 @@
+## kn config sink-mapping update
+
+Update sink mapping by its prefix
+
+```
+kn config sink-mapping update
+```
+
+### Options
+
+```
+      --group string      The API group of the Kubernetes resource
+  -h, --help              help for update
+      --resource string   The lowercased, plural name of the Kubernetes resource type. For example, services or brokers
+      --version string    The version of the Kubernetes resource
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string      name of the kubeconfig cluster to use
+      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string      name of the kubeconfig context to use
+      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
+      --log-http            log http traffic
+```
+
+### SEE ALSO
+
+* [kn config sink-mapping](kn_config_sink-mapping.md)	 - Manage sink mapping list
+

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.17
 require (
 	github.com/emicklei/go-restful v2.15.0+incompatible // indirect
 	github.com/google/go-cmp v0.5.7
-	github.com/hashicorp/golang-lru v0.5.4
-	github.com/hashicorp/hcl v1.0.0
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/afero v1.8.0 // indirect
 	github.com/spf13/cobra v1.3.0
@@ -28,6 +28,8 @@ require (
 	knative.dev/serving v0.32.1-0.20220621141822-357316355d00
 	sigs.k8s.io/yaml v1.3.0
 )
+
+require gopkg.in/yaml.v2 v2.4.0
 
 require (
 	cloud.google.com/go/compute v1.5.0 // indirect
@@ -126,7 +128,6 @@ require (
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/gengo v0.0.0-20220307231824-4627b89bbf1b // indirect
 	k8s.io/klog/v2 v2.60.1-0.20220317184644-43cc75f9ae89 // indirect

--- a/pkg/kn/commands/config/channel/add.go
+++ b/pkg/kn/commands/config/channel/add.go
@@ -1,0 +1,60 @@
+// Copyright © 2022 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package channel
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"knative.dev/client/pkg/kn/config"
+)
+
+const ChannelTypeAliasExistsErrorMsg = "Channel type alias %q already exists in the configuration file"
+
+// NewAddCommand defines and processes `kn config channel-type-mapping add`
+func NewAddCommand() *cobra.Command {
+	ctmf := ChannelTypeMappingFlags{}
+	addChannelTypeMapCmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add a new channel type mapping",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			items := []config.ChannelTypeMapping{}
+			if err := viper.UnmarshalKey(config.KeyChannelTypeMappings, &items); err != nil {
+				return err
+			}
+			channelHash := map[string]bool{}
+			for _, item := range items {
+				channelHash[item.Alias] = true
+			}
+			for _, alias := range args {
+				if _, ok := channelHash[alias]; ok {
+					return fmt.Errorf(ChannelTypeAliasExistsErrorMsg, alias)
+				}
+				ctmf.Alias = alias
+			}
+			newList := append(items, ctmf.ChannelTypeMapping)
+			viper.Set(config.KeyChannelTypeMappings, newList)
+			if err := viper.WriteConfig(); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Channel type mapping with alias '%s' was added\n", args[0])
+			return nil
+		},
+	}
+	ctmf.AddFlags(addChannelTypeMapCmd)
+	return addChannelTypeMapCmd
+}

--- a/pkg/kn/commands/config/channel/delete.go
+++ b/pkg/kn/commands/config/channel/delete.go
@@ -1,0 +1,57 @@
+// Copyright © 2022 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package channel
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"knative.dev/client/pkg/kn/config"
+)
+
+// NewDeleteCommand defines and processes `kn config channel-type-mapping delete`
+func NewDeleteCommand() *cobra.Command {
+	deleteChannelTypeMapCmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete a channel type mapping by its alias",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			channelTypeMappings := []config.ChannelTypeMapping{}
+			if err := viper.UnmarshalKey(config.KeyChannelTypeMappings, &channelTypeMappings); err != nil {
+				return err
+			}
+
+			aliasHash := map[string]bool{}
+			for _, alias := range args {
+				aliasHash[alias] = true
+			}
+
+			newList := []config.ChannelTypeMapping{}
+			for _, channelTypeMap := range channelTypeMappings {
+				if _, ok := aliasHash[channelTypeMap.Alias]; !ok {
+					newList = append(newList, channelTypeMap)
+				}
+			}
+			viper.Set(config.KeyChannelTypeMappings, newList)
+			if err := viper.WriteConfig(); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Channel type mapping with alias '%s' was deleted\n", args[0])
+			return nil
+		},
+	}
+	return deleteChannelTypeMapCmd
+}

--- a/pkg/kn/commands/config/channel/flags.go
+++ b/pkg/kn/commands/config/channel/flags.go
@@ -1,0 +1,30 @@
+// Copyright © 2022 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package channel
+
+import (
+	"github.com/spf13/cobra"
+	"knative.dev/client/pkg/kn/config"
+)
+
+type ChannelTypeMappingFlags struct {
+	config.ChannelTypeMapping
+}
+
+func (ctmf *ChannelTypeMappingFlags) AddFlags(c *cobra.Command) {
+	c.Flags().StringVar(&ctmf.Kind, "kind", "", "The kind of Channel, such as InMemoryChannel or KafkaChannel, based on the default ConfigMap")
+	c.Flags().StringVar(&ctmf.Group, "group", "", "The API group of the Kubernetes resource")
+	c.Flags().StringVar(&ctmf.Version, "version", "", "The version of the Kubernetes resource")
+}

--- a/pkg/kn/commands/config/channel/list.go
+++ b/pkg/kn/commands/config/channel/list.go
@@ -1,0 +1,48 @@
+// Copyright © 2022 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package channel
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
+	"knative.dev/client/pkg/kn/config"
+)
+
+// NewListCommand defines and processes `kn config channel-type-mapping list`
+func NewListCommand() *cobra.Command {
+	listChannelTypeMappingsCmd := &cobra.Command{
+		Use:   "list",
+		Short: "Show a channel type mapping list",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			items := []config.ChannelTypeMapping{}
+			if err := viper.UnmarshalKey(config.KeyChannelTypeMappings, &items); err != nil {
+				return err
+			}
+			b, err := yaml.Marshal(items)
+			if err != nil {
+				return err
+			}
+			if _, err := fmt.Fprint(cmd.OutOrStdout(), string(b)); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	return listChannelTypeMappingsCmd
+}

--- a/pkg/kn/commands/config/channel/update.go
+++ b/pkg/kn/commands/config/channel/update.go
@@ -1,0 +1,73 @@
+// Copyright © 2022 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package channel
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"knative.dev/client/pkg/kn/config"
+)
+
+const ChannelTypeAliasNotFoundErrorMsg = "Channel type alias %q was not found in the configuration file"
+
+// NewUpdateCommand defines and processes `kn config channel-type-mapping update`
+func NewUpdateCommand() *cobra.Command {
+	ctmf := ChannelTypeMappingFlags{}
+	updateChannelTypeMapCmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update channel type mapping by its alias",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			items := []config.ChannelTypeMapping{}
+			if err := viper.UnmarshalKey(config.KeyChannelTypeMappings, &items); err != nil {
+				return err
+			}
+			aliasHash := map[string]int{}
+			for _, alias := range args {
+				aliasHash[alias] = -1
+			}
+
+			for ix, item := range items {
+				if _, ok := aliasHash[item.Alias]; ok {
+					aliasHash[item.Alias] = ix
+				}
+			}
+			for prefix, index := range aliasHash {
+				if index == -1 {
+					return fmt.Errorf(ChannelTypeAliasNotFoundErrorMsg, prefix)
+				}
+				if cmd.Flags().Changed("kind") {
+					items[index].Kind = ctmf.Kind
+				}
+				if cmd.Flags().Changed("group") {
+					items[index].Group = ctmf.Group
+				}
+				if cmd.Flags().Changed("version") {
+					items[index].Version = ctmf.Version
+				}
+			}
+			viper.Set(config.KeyChannelTypeMappings, items)
+			if err := viper.WriteConfig(); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Channel type mapping with alias '%s' was updated\n", args[0])
+			return nil
+		},
+	}
+	ctmf.AddFlags(updateChannelTypeMapCmd)
+	return updateChannelTypeMapCmd
+}

--- a/pkg/kn/commands/config/channel_type_mapping.go
+++ b/pkg/kn/commands/config/channel_type_mapping.go
@@ -1,0 +1,34 @@
+// Copyright © 2022 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configCmd
+
+import (
+	"github.com/spf13/cobra"
+	"knative.dev/client/pkg/kn/commands"
+	"knative.dev/client/pkg/kn/commands/config/channel"
+)
+
+// NewConfigChannelTypeMappingCommand represents 'kn config channel-type-mapping' command
+func NewConfigChannelTypeMappingCommand(p *commands.KnParams) *cobra.Command {
+	channelTypeMappingCmd := &cobra.Command{
+		Use:   "channel-type-mapping",
+		Short: "Manage channel type mapping list",
+	}
+	channelTypeMappingCmd.AddCommand(channel.NewDeleteCommand())
+	channelTypeMappingCmd.AddCommand(channel.NewAddCommand())
+	channelTypeMappingCmd.AddCommand(channel.NewUpdateCommand())
+	channelTypeMappingCmd.AddCommand(channel.NewListCommand())
+	return channelTypeMappingCmd
+}

--- a/pkg/kn/commands/config/channel_type_mapping_test.go
+++ b/pkg/kn/commands/config/channel_type_mapping_test.go
@@ -1,0 +1,214 @@
+// Copyright © 2022 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configCmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/spf13/viper"
+	"knative.dev/client/pkg/kn/commands/config/channel"
+	"knative.dev/client/pkg/kn/config"
+)
+
+const cfgKey = config.KeyChannelTypeMappings
+
+var initValue = []config.ChannelTypeMapping{
+	{Alias: "Kafka", Kind: "KafkaChannel", Group: "messaging.knative.dev", Version: "v1alpha1"},
+}
+
+func TestConfigCommandChannelTypeMappingList(t *testing.T) {
+	tempfile, err := ioutil.TempFile("", "test.*.yaml")
+	if err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+
+	expectedResult := `- alias: Kafka
+  kind: KafkaChannel
+  group: messaging.knative.dev
+  version: v1alpha1
+`
+
+	previousValue := viper.Get(cfgKey)
+	defer func() {
+		os.Remove(tempfile.Name())
+		viper.Set(cfgKey, previousValue)
+	}()
+
+	viper.Set(cfgKey, initValue)
+	viper.SetConfigFile(tempfile.Name())
+	output, err := executeConfigCommand("channel-type-mapping", "list")
+	if err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+	if output != expectedResult {
+		t.Errorf("Expected to get %q but got %q", expectedResult, output)
+	}
+}
+
+func TestConfigCommandChannelTypeMappingUpdate(t *testing.T) {
+	tempfile, err := ioutil.TempFile("", "test.*.yaml")
+	if err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+
+	expected := []config.ChannelTypeMapping{
+		{Alias: "Kafka", Kind: "KafkaChannel", Group: "messaging.knative.dev", Version: "v1alpha1"},
+		{Alias: "RabbitMQ", Kind: "RabbitMQChannel", Group: "messaging.knative.dev", Version: "v2"},
+	}
+
+	previousValue := viper.Get(cfgKey)
+	defer func() {
+		os.Remove(tempfile.Name())
+		viper.Set(cfgKey, previousValue)
+	}()
+
+	viper.Set(cfgKey, initValue)
+	viper.SetConfigFile(tempfile.Name())
+
+	if _, err := executeConfigCommand("channel-type-mapping", "add", "RabbitMQ", "--kind", "RabbitMQChannel", "--version", "v2", "--group", "messaging.knative.dev"); err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+
+	result := []config.ChannelTypeMapping{}
+	viper.UnmarshalKey(cfgKey, &result)
+	if len(result) != 2 {
+		t.Errorf("Expected to get %q but got %q", expected, result)
+	}
+	for ix := range result {
+		if result[ix].Alias != expected[ix].Alias ||
+			result[ix].Kind != expected[ix].Kind ||
+			result[ix].Group != expected[ix].Group ||
+			result[ix].Version != expected[ix].Version {
+			t.Errorf("Expected at index %d to get %q but got %q", ix, expected[ix], result[ix])
+		}
+	}
+}
+
+func TestConfigCommandChannelTypeMappingAdd(t *testing.T) {
+	tempfile, err := ioutil.TempFile("", "test.*.yaml")
+	if err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+
+	expected := []config.ChannelTypeMapping{
+		{Alias: "Kafka", Kind: "KafkaChannel", Group: "msg.knative.dev", Version: "v1"},
+	}
+
+	previousValue := viper.Get(cfgKey)
+	defer func() {
+		os.Remove(tempfile.Name())
+		viper.Set(cfgKey, previousValue)
+	}()
+
+	viper.Set(cfgKey, initValue)
+	viper.SetConfigFile(tempfile.Name())
+
+	if _, err := executeConfigCommand("channel-type-mapping", "update", "Kafka", "--version", "v1", "--group", "msg.knative.dev"); err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+
+	result := []config.ChannelTypeMapping{}
+	viper.UnmarshalKey(cfgKey, &result)
+	if len(result) != 1 ||
+		result[0].Alias != expected[0].Alias ||
+		result[0].Kind != expected[0].Kind ||
+		result[0].Group != expected[0].Group ||
+		result[0].Version != expected[0].Version {
+		t.Errorf("Expected to get %q but got %q", expected, result)
+	}
+}
+
+func TestConfigCommandChannelTypeMappingDelete(t *testing.T) {
+	tempfile, err := ioutil.TempFile("", "test.*.yaml")
+	if err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+
+	expected := []config.ChannelTypeMapping{}
+
+	previousValue := viper.Get(cfgKey)
+	defer func() {
+		os.Remove(tempfile.Name())
+		viper.Set(cfgKey, previousValue)
+	}()
+
+	viper.Set(cfgKey, initValue)
+	viper.SetConfigFile(tempfile.Name())
+
+	if _, err := executeConfigCommand("channel-type-mapping", "delete", "Kafka"); err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+
+	result := []config.ChannelTypeMapping{}
+	viper.UnmarshalKey(cfgKey, &result)
+	if len(result) != 0 {
+		t.Errorf("Expected to get %q but got %q", expected, result)
+	}
+}
+
+func TestConfigCommandChannelTypeMappingUpdateNotFoundAlias(t *testing.T) {
+	tempfile, err := ioutil.TempFile("", "test.*.yaml")
+	if err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+
+	expected := fmt.Sprintf(channel.ChannelTypeAliasNotFoundErrorMsg, "Kafka2")
+
+	previousValue := viper.Get(cfgKey)
+	defer func() {
+		os.Remove(tempfile.Name())
+		viper.Set(cfgKey, previousValue)
+	}()
+
+	viper.Set(cfgKey, initValue)
+	viper.SetConfigFile(tempfile.Name())
+
+	_, err = executeConfigCommand("channel-type-mapping", "update", "Kafka2")
+	if err == nil {
+		t.Errorf("Expected to get an error but got nothing")
+	}
+	if err.Error() != expected {
+		t.Errorf("Expected to get error %q but got %q", expected, err)
+	}
+}
+
+func TestConfigCommandChannelTypeMappingAddExistsAlias(t *testing.T) {
+	tempfile, err := ioutil.TempFile("", "test.*.yaml")
+	if err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+
+	expected := fmt.Sprintf(channel.ChannelTypeAliasExistsErrorMsg, "Kafka")
+
+	previousValue := viper.Get(cfgKey)
+	defer func() {
+		os.Remove(tempfile.Name())
+		viper.Set(cfgKey, previousValue)
+	}()
+
+	viper.Set(cfgKey, initValue)
+	viper.SetConfigFile(tempfile.Name())
+
+	_, err = executeConfigCommand("channel-type-mapping", "add", "Kafka")
+	if err == nil {
+		t.Errorf("Expected to get an error but got nothing")
+	}
+	if err.Error() != expected {
+		t.Errorf("Expected to get error %q but got %q", expected, err)
+	}
+}

--- a/pkg/kn/commands/config/config.go
+++ b/pkg/kn/commands/config/config.go
@@ -1,0 +1,39 @@
+// Copyright © 2022 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configCmd
+
+import (
+	"github.com/spf13/cobra"
+	"knative.dev/client/pkg/kn/commands"
+)
+
+var cfgCmdExamples = ``
+
+var ConfigKeyNotFoundErrorMsg = "Could not find %q in the configuration file"
+
+func NewConfigCommand(p *commands.KnParams) *cobra.Command {
+	cfgCmd := &cobra.Command{
+		Use:     "config COMMAND",
+		Short:   "Manage Knative configuration file",
+		Aliases: []string{"cfg"},
+		Example: cfgCmdExamples,
+	}
+	cfgCmd.AddCommand(NewConfigGetCommand(p))
+	cfgCmd.AddCommand(NewConfigSetCommand(p))
+	cfgCmd.AddCommand(NewConfigShowCommand(p))
+	cfgCmd.AddCommand(NewConfigSinkMappingCommand(p))
+	cfgCmd.AddCommand(NewConfigChannelTypeMappingCommand(p))
+	return cfgCmd
+}

--- a/pkg/kn/commands/config/config_test.go
+++ b/pkg/kn/commands/config/config_test.go
@@ -1,0 +1,36 @@
+// Copyright © 2022 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configCmd
+
+import (
+	"bytes"
+
+	"knative.dev/client/pkg/kn/commands"
+)
+
+func executeConfigCommand(args ...string) (string, error) {
+	knParams := &commands.KnParams{}
+
+	output := new(bytes.Buffer)
+	knParams.Output = output
+
+	cmd := NewConfigCommand(knParams)
+	cmd.SetArgs(args)
+	cmd.SetOutput(output)
+
+	err := cmd.Execute()
+
+	return output.String(), err
+}

--- a/pkg/kn/commands/config/get.go
+++ b/pkg/kn/commands/config/get.go
@@ -1,0 +1,48 @@
+// Copyright © 2022 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configCmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
+	"knative.dev/client/pkg/kn/commands"
+)
+
+// NewConfigGetCommand represents 'kn config get' command
+func NewConfigGetCommand(p *commands.KnParams) *cobra.Command {
+	getCmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get configuration settings",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			for _, cfgPath := range args {
+				cfg := viper.Get(cfgPath)
+				if cfg == nil {
+					return fmt.Errorf(ConfigKeyNotFoundErrorMsg, cfgPath)
+				}
+				b, err := yaml.Marshal(cfg)
+				if err != nil {
+					return err
+				}
+				fmt.Fprint(cmd.OutOrStdout(), string(b))
+			}
+			return nil
+		},
+	}
+	return getCmd
+}

--- a/pkg/kn/commands/config/get_test.go
+++ b/pkg/kn/commands/config/get_test.go
@@ -1,0 +1,98 @@
+// Copyright © 2022 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configCmd
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"knative.dev/client/pkg/kn/config"
+)
+
+func TestConfigCommandGetSuccess(t *testing.T) {
+	testCases := []struct {
+		name          string
+		key           string
+		value         interface{}
+		expectedValue string
+	}{
+		{
+			name:          "get plugins directory",
+			key:           "plugins.directory",
+			value:         "/kn/plugins",
+			expectedValue: "/kn/plugins",
+		},
+		{
+			name:  "get plugins",
+			key:   "plugins",
+			value: map[string]map[string]string{"plugins": {"directory": "/kn/plugins"}},
+			expectedValue: `plugins:
+  directory: /kn/plugins`,
+		},
+		{
+			name: "get channel-type-mappings",
+			key:  "eventing.channel-type-mappings",
+			value: map[string]map[string][]config.ChannelTypeMapping{
+				"eventing": {
+					"channel-type-mappings": []config.ChannelTypeMapping{
+						{Alias: "kinesis", Kind: "KafkaChannel", Group: "dev.1", Version: "v1"},
+						{Alias: "kafka", Kind: "KafkaChannel", Group: "knative.messaging", Version: "v1alpha1"},
+						{Alias: "0MQ", Kind: "ZeroMQChannel", Group: "dev.1", Version: "v1beta1"},
+					}}},
+			expectedValue: `eventing:
+  channel-type-mappings:
+  - alias: kinesis
+    kind: KafkaChannel
+    group: dev.1
+    version: v1
+  - alias: kafka
+    kind: KafkaChannel
+    group: knative.messaging
+    version: v1alpha1
+  - alias: 0MQ
+    kind: ZeroMQChannel
+    group: dev.1
+    version: v1beta1`,
+		},
+	}
+
+	for _, tc := range testCases {
+		previousValue := viper.Get(tc.key)
+		viper.Set(tc.key, tc.value)
+		output, err := executeConfigCommand("get", tc.key)
+		if err != nil {
+			t.Errorf("Test %q failed: expected no errors but got %s", tc.name, err)
+		}
+		viper.Set(tc.key, previousValue)
+		result := strings.TrimSuffix(output, "\n")
+		if result != tc.expectedValue {
+			t.Errorf("Test %q failed: expected %q but got %q", tc.name, tc.expectedValue, result)
+		}
+	}
+}
+
+func TestConfigCommandGetNotSetKey(t *testing.T) {
+	notExistKey := "system-config"
+	_, err := executeConfigCommand("get", notExistKey)
+	if err == nil {
+		t.Errorf("Expected test to fail but it did not")
+	}
+	expected := fmt.Sprintf(ConfigKeyNotFoundErrorMsg, notExistKey)
+	if err != nil && err.Error() != expected {
+		t.Errorf("Expected to get %s but %s", expected, err)
+	}
+}

--- a/pkg/kn/commands/config/set.go
+++ b/pkg/kn/commands/config/set.go
@@ -1,0 +1,70 @@
+// Copyright © 2022 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configCmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"knative.dev/client/pkg/kn/commands"
+)
+
+var ArgumentMissingValueErrorMsg = "Invalid argument %q: this is the correct structure key=value"
+var NonScalarConfigPathErrorMsg = "The given key %q does not store a scalar value"
+
+// NewConfigSetCommand represents 'kn config set' command
+func NewConfigSetCommand(p *commands.KnParams) *cobra.Command {
+	setCmd := &cobra.Command{
+		Use:   "set",
+		Short: "Set configuration settings that are scalar",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			for _, arg := range args {
+				keyVal, err := splitToKeyValue(arg)
+				if err != nil {
+					return err
+				}
+				cfgPath := keyVal[0]
+				newValue := keyVal[1]
+				if !isValidScalarConfigKey(cfgPath) {
+					return fmt.Errorf(NonScalarConfigPathErrorMsg, cfgPath)
+				}
+				viper.Set(cfgPath, newValue)
+				if err := viper.WriteConfig(); err != nil {
+					return err
+				}
+				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%s=%s", cfgPath, newValue); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+	return setCmd
+}
+
+func splitToKeyValue(arg string) ([2]string, error) {
+	keyVal := strings.Split(arg, "=")
+	if len(keyVal) != 2 {
+		return [2]string{}, fmt.Errorf(ArgumentMissingValueErrorMsg, arg)
+	}
+	return [2]string{keyVal[0], keyVal[1]}, nil
+}
+
+func isValidScalarConfigKey(configPath string) bool {
+	return configPath == "plugins.directory"
+}

--- a/pkg/kn/commands/config/set_test.go
+++ b/pkg/kn/commands/config/set_test.go
@@ -1,0 +1,94 @@
+// Copyright © 2022 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configCmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestConfigCommandSetSuccess(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "plugins.*")
+	if err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+	tempfile, err := ioutil.TempFile(tmpdir, "test.*.yaml")
+	if err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+	defer func() {
+		os.RemoveAll(tmpdir)
+		os.Remove(tempfile.Name())
+	}()
+	cfgKey := "plugins.directory"
+	initValue := ""
+	newValue := tmpdir
+
+	previousValue := viper.Get(cfgKey)
+	viper.Set(cfgKey, initValue)
+	viper.SetConfigFile(tempfile.Name())
+	if _, err := executeConfigCommand("set", fmt.Sprintf("%s=%s", cfgKey, newValue)); err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+	result := viper.GetString(cfgKey)
+	viper.Set(cfgKey, previousValue)
+	if result != newValue {
+		t.Errorf("Expected to get %s but got %s", newValue, result)
+	}
+}
+
+func TestConfigCommandSetMissingValueInArgument(t *testing.T) {
+	arg := "plugins.directory"
+	_, err := executeConfigCommand("set", arg)
+	if err == nil {
+		t.Errorf("Expected test to fail but it did not")
+	}
+	expected := fmt.Sprintf(ArgumentMissingValueErrorMsg, arg)
+
+	if err != nil && err.Error() != expected {
+		t.Errorf("Expected to get %s but %s", expected, err)
+	}
+}
+
+func TestConfigCommandSetTwoManyEqualSignsInArgument(t *testing.T) {
+	arg := "plugins.directory=bla=bla"
+	_, err := executeConfigCommand("set", arg)
+	if err == nil {
+		t.Errorf("Expected test to fail but it did not")
+	}
+	expected := fmt.Sprintf(ArgumentMissingValueErrorMsg, arg)
+
+	if err != nil && err.Error() != expected {
+		t.Errorf("Expected to get %s but %s", expected, err)
+	}
+}
+
+func TestConfigCommandSetNonScalarConfig(t *testing.T) {
+	cfgKey := "plugins"
+	arg := fmt.Sprintf("%s={directory: ~/kn/plugins}", cfgKey)
+	_, err := executeConfigCommand("set", arg)
+	if err == nil {
+		t.Errorf("Expected test to fail but it did not")
+	}
+	expected := fmt.Sprintf(NonScalarConfigPathErrorMsg, cfgKey)
+
+	if err != nil && err.Error() != expected {
+		t.Errorf("Expected to get %s but %s", expected, err)
+	}
+}

--- a/pkg/kn/commands/config/show.go
+++ b/pkg/kn/commands/config/show.go
@@ -1,0 +1,43 @@
+// Copyright © 2022 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configCmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
+	"knative.dev/client/pkg/kn/commands"
+)
+
+// NewConfigSetCommand represents 'kn config show' command
+func NewConfigShowCommand(p *commands.KnParams) *cobra.Command {
+	showCmd := &cobra.Command{
+		Use:   "show",
+		Short: "Show configuration settings",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfgSettings := viper.AllSettings()
+			b, err := yaml.Marshal(cfgSettings)
+			if err != nil {
+				return err
+			}
+			fmt.Fprint(cmd.OutOrStdout(), string(b))
+			return nil
+		},
+	}
+	return showCmd
+}

--- a/pkg/kn/commands/config/show_test.go
+++ b/pkg/kn/commands/config/show_test.go
@@ -1,0 +1,70 @@
+// Copyright © 2022 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configCmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"knative.dev/client/pkg/kn/config"
+)
+
+func TestConfigCommandShowSuccess(t *testing.T) {
+	config := map[string]interface{}{
+		"eventing.sink-mappings": []config.SinkMapping{
+			{Prefix: "svc", Resource: "services", Group: "core", Version: "v2"},
+		},
+		"eventing.channel-type-mappings": []config.ChannelTypeMapping{
+			{Alias: "kafka", Kind: "KafkaChannel", Group: "messaging.knative.dev", Version: "v1alpha1"},
+		},
+		"plugins.directory": "~/.config/kn/v2/plugins",
+	}
+	prevConfigs := map[string]interface{}{
+		"eventing.sink-mappings":         nil,
+		"eventing.channel-type-mappings": nil,
+		"plugins.directory":              "~/.config/kn/v2/plugins",
+	}
+	for cfgKey, newValue := range config {
+		prevConfigs[cfgKey] = viper.Get(cfgKey)
+		viper.Set(cfgKey, newValue)
+	}
+	defer func() {
+		for key, value := range prevConfigs {
+			viper.Set(key, value)
+		}
+	}()
+	expectedValue := `eventing:
+  channel-type-mappings:
+  - alias: kafka
+    kind: KafkaChannel
+    group: messaging.knative.dev
+    version: v1alpha1
+  sink-mappings:
+  - prefix: svc
+    resource: services
+    group: core
+    version: v2
+plugins:
+  directory: ~/.config/kn/v2/plugins`
+	output, err := executeConfigCommand("show")
+	if err != nil {
+		t.Errorf("Test failed: expected no errors but got %s", err)
+	}
+	result := strings.TrimSuffix(output, "\n")
+	if result != expectedValue {
+		t.Errorf("Test failed: expected %q but got %q", expectedValue, result)
+	}
+}

--- a/pkg/kn/commands/config/sink/add.go
+++ b/pkg/kn/commands/config/sink/add.go
@@ -1,0 +1,60 @@
+// Copyright © 2022 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sink
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"knative.dev/client/pkg/kn/config"
+)
+
+const SinkPrefixExistsErrorMsg = "Sink prefix %q already exists in the configuration file"
+
+// NewAddCommand defines and processes `kn config sink-mapping add`
+func NewAddCommand() *cobra.Command {
+	smf := SinkMappingFlags{}
+	addSinkMapCmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add a new sink mapping",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			items := []config.SinkMapping{}
+			if err := viper.UnmarshalKey(config.KeySinkMappings, &items); err != nil {
+				return err
+			}
+			sinkHash := map[string]bool{}
+			for _, item := range items {
+				sinkHash[item.Prefix] = true
+			}
+			for _, prefix := range args {
+				if _, ok := sinkHash[prefix]; ok {
+					return fmt.Errorf(SinkPrefixExistsErrorMsg, prefix)
+				}
+				smf.Prefix = prefix
+			}
+			newList := append(items, smf.SinkMapping)
+			viper.Set(config.KeySinkMappings, newList)
+			if err := viper.WriteConfig(); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Sink mapping with prefix '%s' was added\n", args[0])
+			return nil
+		},
+	}
+	smf.AddFlags(addSinkMapCmd)
+	return addSinkMapCmd
+}

--- a/pkg/kn/commands/config/sink/delete.go
+++ b/pkg/kn/commands/config/sink/delete.go
@@ -1,0 +1,57 @@
+// Copyright © 2022 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sink
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"knative.dev/client/pkg/kn/config"
+)
+
+// NewDeleteCommand represents 'kn config sink-mapping delete' command
+func NewDeleteCommand() *cobra.Command {
+	deleteSinkMapCmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete a sink mapping by its prefix",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			sinkMappings := []config.SinkMapping{}
+			if err := viper.UnmarshalKey(config.KeySinkMappings, &sinkMappings); err != nil {
+				return err
+			}
+
+			prefixHash := map[string]bool{}
+			for _, prefix := range args {
+				prefixHash[prefix] = true
+			}
+
+			newList := []config.SinkMapping{}
+			for _, sinkMap := range sinkMappings {
+				if _, ok := prefixHash[sinkMap.Prefix]; !ok {
+					newList = append(newList, sinkMap)
+				}
+			}
+			viper.Set(config.KeySinkMappings, newList)
+			if err := viper.WriteConfig(); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Sink mapping with prefix '%s' was deleted\n", args[0])
+			return nil
+		},
+	}
+	return deleteSinkMapCmd
+}

--- a/pkg/kn/commands/config/sink/flags.go
+++ b/pkg/kn/commands/config/sink/flags.go
@@ -1,0 +1,30 @@
+// Copyright © 2022 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sink
+
+import (
+	"github.com/spf13/cobra"
+	"knative.dev/client/pkg/kn/config"
+)
+
+type SinkMappingFlags struct {
+	config.SinkMapping
+}
+
+func (smf *SinkMappingFlags) AddFlags(c *cobra.Command) {
+	c.Flags().StringVar(&smf.Resource, "resource", "", "The lowercased, plural name of the Kubernetes resource type. For example, services or brokers")
+	c.Flags().StringVar(&smf.Group, "group", "", "The API group of the Kubernetes resource")
+	c.Flags().StringVar(&smf.Version, "version", "", "The version of the Kubernetes resource")
+}

--- a/pkg/kn/commands/config/sink/list.go
+++ b/pkg/kn/commands/config/sink/list.go
@@ -1,0 +1,48 @@
+// Copyright © 2022 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sink
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
+	"knative.dev/client/pkg/kn/config"
+)
+
+// NewListCommand defines and processes `kn config sink-mapping list`
+func NewListCommand() *cobra.Command {
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "Show a sink mapping list",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			items := []config.SinkMapping{}
+			if err := viper.UnmarshalKey(config.KeySinkMappings, &items); err != nil {
+				return err
+			}
+			b, err := yaml.Marshal(items)
+			if err != nil {
+				return err
+			}
+			if _, err := fmt.Fprint(cmd.OutOrStdout(), string(b)); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	return listCmd
+}

--- a/pkg/kn/commands/config/sink/update.go
+++ b/pkg/kn/commands/config/sink/update.go
@@ -1,0 +1,73 @@
+// Copyright © 2022 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sink
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"knative.dev/client/pkg/kn/config"
+)
+
+const SinkPrefixNotFoundErrorMsg = "Sink prefix %q was not found in the configuration file"
+
+// NewUpdateCommand defines and processes `kn config sink-mapping update`
+func NewUpdateCommand() *cobra.Command {
+	smf := SinkMappingFlags{}
+	updateSinkMapCmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update sink mapping by its prefix",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			items := []config.SinkMapping{}
+			if err := viper.UnmarshalKey(config.KeySinkMappings, &items); err != nil {
+				return err
+			}
+			prefixHash := map[string]int{}
+			for _, prefix := range args {
+				prefixHash[prefix] = -1
+			}
+
+			for ix, item := range items {
+				if _, ok := prefixHash[item.Prefix]; ok {
+					prefixHash[item.Prefix] = ix
+				}
+			}
+			for prefix, index := range prefixHash {
+				if index == -1 {
+					return fmt.Errorf(SinkPrefixNotFoundErrorMsg, prefix)
+				}
+				if cmd.Flags().Changed("resource") {
+					items[index].Resource = smf.Resource
+				}
+				if cmd.Flags().Changed("group") {
+					items[index].Group = smf.Group
+				}
+				if cmd.Flags().Changed("version") {
+					items[index].Version = smf.Version
+				}
+			}
+			viper.Set(config.KeySinkMappings, items)
+			if err := viper.WriteConfig(); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Sink mapping with prefix '%s' was updated\n", args[0])
+			return nil
+		},
+	}
+	smf.AddFlags(updateSinkMapCmd)
+	return updateSinkMapCmd
+}

--- a/pkg/kn/commands/config/sink_mapping.go
+++ b/pkg/kn/commands/config/sink_mapping.go
@@ -1,0 +1,34 @@
+// Copyright © 2022 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configCmd
+
+import (
+	"github.com/spf13/cobra"
+	"knative.dev/client/pkg/kn/commands"
+	"knative.dev/client/pkg/kn/commands/config/sink"
+)
+
+// NewConfigSinkMappingCommand represents 'kn config sink-mapping' command
+func NewConfigSinkMappingCommand(p *commands.KnParams) *cobra.Command {
+	sinkMappingCmd := &cobra.Command{
+		Use:   "sink-mapping",
+		Short: "Manage sink mapping list",
+	}
+	sinkMappingCmd.AddCommand(sink.NewDeleteCommand())
+	sinkMappingCmd.AddCommand(sink.NewAddCommand())
+	sinkMappingCmd.AddCommand(sink.NewUpdateCommand())
+	sinkMappingCmd.AddCommand(sink.NewListCommand())
+	return sinkMappingCmd
+}

--- a/pkg/kn/commands/config/sink_mapping_test.go
+++ b/pkg/kn/commands/config/sink_mapping_test.go
@@ -1,0 +1,212 @@
+// Copyright © 2022 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configCmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/spf13/viper"
+	"knative.dev/client/pkg/kn/commands/config/sink"
+	"knative.dev/client/pkg/kn/config"
+)
+
+var initSinkMapping = []config.SinkMapping{
+	{Prefix: "svc", Resource: "services", Group: "core", Version: "v1alpha1"},
+}
+
+func TestConfigCommandSinkMappingList(t *testing.T) {
+	tempfile, err := ioutil.TempFile("", "test.*.yaml")
+	if err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+
+	expectedResult := `- prefix: svc
+  resource: services
+  group: core
+  version: v1alpha1
+`
+
+	previousValue := viper.Get(config.KeySinkMappings)
+	defer func() {
+		os.Remove(tempfile.Name())
+		viper.Set(config.KeySinkMappings, previousValue)
+	}()
+
+	viper.Set(config.KeySinkMappings, initSinkMapping)
+	viper.SetConfigFile(tempfile.Name())
+	output, err := executeConfigCommand("sink-mapping", "list")
+	if err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+	if output != expectedResult {
+		t.Errorf("Expected to get %q but got %q", expectedResult, output)
+	}
+}
+
+func TestConfigCommandSinkMappingUpdate(t *testing.T) {
+	tempfile, err := ioutil.TempFile("", "test.*.yaml")
+	if err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+
+	expected := []config.SinkMapping{
+		{Prefix: "svc", Resource: "services", Group: "core", Version: "v1alpha1"},
+		{Prefix: "ksvc", Resource: "services", Group: "api", Version: "v3beta1"},
+	}
+
+	previousValue := viper.Get(config.KeySinkMappings)
+	defer func() {
+		os.Remove(tempfile.Name())
+		viper.Set(config.KeySinkMappings, previousValue)
+	}()
+
+	viper.Set(config.KeySinkMappings, initSinkMapping)
+	viper.SetConfigFile(tempfile.Name())
+
+	if _, err := executeConfigCommand("sink-mapping", "add", "ksvc", "--resource", "services", "--version", "v3beta1", "--group", "api"); err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+
+	result := []config.SinkMapping{}
+	viper.UnmarshalKey(config.KeySinkMappings, &result)
+	if len(result) != 2 {
+		t.Errorf("Expected to get %q but got %q", expected, result)
+	}
+	for ix := range result {
+		if result[ix].Prefix != expected[ix].Prefix ||
+			result[ix].Resource != expected[ix].Resource ||
+			result[ix].Group != expected[ix].Group ||
+			result[ix].Version != expected[ix].Version {
+			t.Errorf("Expected at index %d to get %q but got %q", ix, expected[ix], result[ix])
+		}
+	}
+}
+
+func TestConfigCommandSinkMappingAdd(t *testing.T) {
+	tempfile, err := ioutil.TempFile("", "test.*.yaml")
+	if err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+
+	expected := []config.SinkMapping{
+		{Prefix: "svc", Resource: "services", Group: "api", Version: "v2"},
+	}
+
+	previousValue := viper.Get(config.KeySinkMappings)
+	defer func() {
+		os.Remove(tempfile.Name())
+		viper.Set(config.KeySinkMappings, previousValue)
+	}()
+
+	viper.Set(config.KeySinkMappings, initSinkMapping)
+	viper.SetConfigFile(tempfile.Name())
+
+	if _, err := executeConfigCommand("sink-mapping", "update", "svc", "--version", "v2", "--group", "api"); err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+
+	result := []config.SinkMapping{}
+	viper.UnmarshalKey(config.KeySinkMappings, &result)
+	if len(result) != 1 ||
+		result[0].Prefix != expected[0].Prefix ||
+		result[0].Resource != expected[0].Resource ||
+		result[0].Group != expected[0].Group ||
+		result[0].Version != expected[0].Version {
+		t.Errorf("Expected to get %q but got %q", expected, result)
+	}
+}
+
+func TestConfigCommandSinkMappingDelete(t *testing.T) {
+	tempfile, err := ioutil.TempFile("", "test.*.yaml")
+	if err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+
+	expected := []config.ChannelTypeMapping{}
+
+	previousValue := viper.Get(config.KeySinkMappings)
+	defer func() {
+		os.Remove(tempfile.Name())
+		viper.Set(config.KeySinkMappings, previousValue)
+	}()
+
+	viper.Set(config.KeySinkMappings, initSinkMapping)
+	viper.SetConfigFile(tempfile.Name())
+
+	if _, err := executeConfigCommand("sink-mapping", "delete", "svc"); err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+
+	result := []config.SinkMapping{}
+	viper.UnmarshalKey(config.KeySinkMappings, &result)
+	if len(result) != 0 {
+		t.Errorf("Expected to get %q but got %q", expected, result)
+	}
+}
+
+func TestConfigCommandSinkMappingUpdateNotFoundAlias(t *testing.T) {
+	tempfile, err := ioutil.TempFile("", "test.*.yaml")
+	if err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+
+	expected := fmt.Sprintf(sink.SinkPrefixNotFoundErrorMsg, "ksvc")
+
+	previousValue := viper.Get(config.KeySinkMappings)
+	defer func() {
+		os.Remove(tempfile.Name())
+		viper.Set(config.KeySinkMappings, previousValue)
+	}()
+
+	viper.Set(config.KeySinkMappings, initSinkMapping)
+	viper.SetConfigFile(tempfile.Name())
+
+	_, err = executeConfigCommand("sink-mapping", "update", "ksvc")
+	if err == nil {
+		t.Errorf("Expected to get an error but got nothing")
+	}
+	if err.Error() != expected {
+		t.Errorf("Expected to get error %q but got %q", expected, err)
+	}
+}
+
+func TestConfigCommandSinkMappingAddExistsAlias(t *testing.T) {
+	tempfile, err := ioutil.TempFile("", "test.*.yaml")
+	if err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+
+	expected := fmt.Sprintf(sink.SinkPrefixExistsErrorMsg, "svc")
+
+	previousValue := viper.Get(config.KeySinkMappings)
+	defer func() {
+		os.Remove(tempfile.Name())
+		viper.Set(config.KeySinkMappings, previousValue)
+	}()
+
+	viper.Set(config.KeySinkMappings, initSinkMapping)
+	viper.SetConfigFile(tempfile.Name())
+
+	_, err = executeConfigCommand("sink-mapping", "add", "svc")
+	if err == nil {
+		t.Errorf("Expected to get an error but got nothing")
+	}
+	if err.Error() != expected {
+		t.Errorf("Expected to get error %q but got %q", expected, err)
+	}
+}

--- a/pkg/kn/config/config.go
+++ b/pkg/kn/config/config.go
@@ -76,8 +76,8 @@ func (c *config) ConfigFile() string {
 
 // PluginsDir returns the plugins' directory
 func (c *config) PluginsDir() string {
-	if viper.IsSet(keyPluginsDirectory) {
-		return viper.GetString(keyPluginsDirectory)
+	if viper.IsSet(KeyPluginsDirectory) {
+		return viper.GetString(KeyPluginsDirectory)
 	} else if viper.IsSet(legacyKeyPluginsDirectory) {
 		// Remove that branch if legacy option is switched off
 		return viper.GetString(legacyKeyPluginsDirectory)
@@ -121,7 +121,7 @@ func BootstrapConfig() error {
 
 	// Bind flags so that options that have been provided have priority.
 	// Important: Always read options via GlobalConfig methods
-	err = viper.BindPFlag(keyPluginsDirectory, bootstrapFlagSet.Lookup(flagPluginsDir))
+	err = viper.BindPFlag(KeyPluginsDirectory, bootstrapFlagSet.Lookup(flagPluginsDir))
 	if err != nil {
 		return err
 	}
@@ -245,8 +245,8 @@ func dirExists(path string) bool {
 func parseSinkMappings() error {
 	// Parse sink configuration
 	key := ""
-	if viper.IsSet(keySinkMappings) {
-		key = keySinkMappings
+	if viper.IsSet(KeySinkMappings) {
+		key = KeySinkMappings
 	}
 	if key == "" && viper.IsSet(legacyKeySinkMappings) {
 		key = legacyKeySinkMappings
@@ -264,8 +264,8 @@ func parseSinkMappings() error {
 
 // parse channel type mappings and store them in the global configuration
 func parseChannelTypeMappings() error {
-	if viper.IsSet(keyChannelTypeMappings) {
-		err := viper.UnmarshalKey(keyChannelTypeMappings, &globalConfig.channelTypeMappings)
+	if viper.IsSet(KeyChannelTypeMappings) {
+		err := viper.UnmarshalKey(KeyChannelTypeMappings, &globalConfig.channelTypeMappings)
 		if err != nil {
 			return fmt.Errorf("error while parsing channel type mappings in configuration file %s: %w",
 				viper.ConfigFileUsed(), err)

--- a/pkg/kn/config/types.go
+++ b/pkg/kn/config/types.go
@@ -70,9 +70,9 @@ type ChannelTypeMapping struct {
 
 // config Keys for looking up in viper
 const (
-	keyPluginsDirectory    = "plugins.directory"
-	keySinkMappings        = "eventing.sink-mappings"
-	keyChannelTypeMappings = "eventing.channel-type-mappings"
+	KeyPluginsDirectory    = "plugins.directory"
+	KeySinkMappings        = "eventing.sink-mappings"
+	KeyChannelTypeMappings = "eventing.channel-type-mappings"
 )
 
 // legacy config keys, deprecated

--- a/pkg/kn/root/root.go
+++ b/pkg/kn/root/root.go
@@ -31,6 +31,7 @@ import (
 	"knative.dev/client/pkg/kn/commands/broker"
 	"knative.dev/client/pkg/kn/commands/channel"
 	"knative.dev/client/pkg/kn/commands/completion"
+	cfgCmd "knative.dev/client/pkg/kn/commands/config"
 	"knative.dev/client/pkg/kn/commands/container"
 	"knative.dev/client/pkg/kn/commands/domain"
 	"knative.dev/client/pkg/kn/commands/eventtype"
@@ -117,6 +118,7 @@ Find more information about Knative at: https://knative.dev`, rootName),
 				plugin.NewPluginCommand(p),
 				completion.NewCompletionCommand(p),
 				version.NewVersionCommand(p),
+				cfgCmd.NewConfigCommand(p),
 			},
 		},
 	}


### PR DESCRIPTION
## Description
Add config command to kn CLI to read, edit or initialize knative configuration files

## Changes

* Add `config get`
* Add `config set (plugins.directory)`
* Add `config show`
* Add `config sink-mapping (list / update / add / delete)`
* Add `config channel-type-mapping (list / update / add / delete)`

## Reference

closes #1293

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

/lint
