### PR TITLE
Remove deprecated Hugo frontmatter generation for docs

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,7 +18,7 @@
 | | Description | PR
 | 🗑
 | Remove deprecated Hugo frontmatter generation for docs
-| https://github.com/knative/client/pull/[#]
+| https://github.com/knative/client/pull/1563[#1563]
 |===
 
 ## v1.1.0 (2021-12-14)

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,15 @@
 | https://github.com/knative/client/pull/[#]
 ////
 
+## v1.2.0 (unreleased)
+[cols="1,10,3", options="header", width="100%"]
+|===
+| | Description | PR
+| 🗑
+| Remove deprecated Hugo frontmatter generation for docs
+| https://github.com/knative/client/pull/[#]
+|===
+
 ## v1.1.0 (2021-12-14)
 [cols="1,10,3", options="header", width="100%"]
 |===

--- a/hack/generate-docs.go
+++ b/hack/generate-docs.go
@@ -18,9 +18,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
 
 	"github.com/spf13/cobra/doc"
 	"knative.dev/client/pkg/kn/root"
@@ -36,18 +33,7 @@ func main() {
 	if len(os.Args) > 1 {
 		dir = os.Args[1]
 	}
-	var withFrontMatter bool
-	if len(os.Args) > 2 {
-		withFrontMatter, err = strconv.ParseBool(os.Args[2])
-		if err != nil {
-			log.Panicf("invalid argument %s, has to be boolean to switch on/off generation of frontmatter (%v)", os.Args[2], err)
-		}
-	}
-	prependFunc := emptyString
-	if withFrontMatter {
-		prependFunc = addFrontMatter
-	}
-	err = doc.GenMarkdownTreeCustom(rootCmd, dir+"/docs/cmd/", prependFunc, identity)
+	err = doc.GenMarkdownTree(rootCmd, dir+"/docs/cmd/")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -56,24 +42,4 @@ func main() {
 
 func emptyString(filename string) string {
 	return ""
-}
-
-func addFrontMatter(fileName string) string {
-	// Convert to a title
-	title := filepath.Base(fileName)
-	title = title[0 : len(title)-len(filepath.Ext(title))]
-	title = strings.ReplaceAll(title, "_", " ")
-	ret := `
----
-title: "%s"
-#linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
-weight: 5
-type: "docs"
----
-`
-	return fmt.Sprintf(ret, title)
-}
-
-func identity(s string) string {
-	return s
 }

--- a/hack/generate-docs.go
+++ b/hack/generate-docs.go
@@ -39,7 +39,3 @@ func main() {
 		os.Exit(1)
 	}
 }
-
-func emptyString(filename string) string {
-	return ""
-}


### PR DESCRIPTION
## Description

Remove deprecated Hugo frontmatter generation for docs

## Changes

The `generate-docs.go` command is used to build documentation pages for `kn` for display on knative.dev. Now that the website has fully deprecated Hugo, custom front-matter no longer needs to be added to those pages. This PR removes the front-matter function from the `generate-docs.go` job.

## Reference

As per discussion [here](https://github.com/knative/docs/issues/4430#issuecomment-1008690021)

/lint
