### PR TITLE
Adding completion for remaining Eventing resources

### DIFF
--- a/pkg/kn/commands/channel/delete.go
+++ b/pkg/kn/commands/channel/delete.go
@@ -30,6 +30,7 @@ func NewChannelDeleteCommand(p *commands.KnParams) *cobra.Command {
 		Example: `
   # Delete a channel 'pipe'
   kn channel delete pipe`,
+		ValidArgsFunction: commands.ResourceNameCompletionFunc(p),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("'kn channel delete' requires the channel name as single argument")

--- a/pkg/kn/commands/channel/describe.go
+++ b/pkg/kn/commands/channel/describe.go
@@ -43,9 +43,10 @@ func NewChannelDescribeCommand(p *commands.KnParams) *cobra.Command {
 	machineReadablePrintFlags := genericclioptions.NewPrintFlags("")
 
 	cmd := &cobra.Command{
-		Use:     "describe NAME",
-		Short:   "Show details of a channel",
-		Example: describeExample,
+		Use:               "describe NAME",
+		Short:             "Show details of a channel",
+		Example:           describeExample,
+		ValidArgsFunction: commands.ResourceNameCompletionFunc(p),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("'kn channel describe' requires the channel name given as single argument")

--- a/pkg/kn/commands/completion_helper.go
+++ b/pkg/kn/commands/completion_helper.go
@@ -18,8 +18,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	clientv1beta2 "knative.dev/client/pkg/sources/v1beta2"
-	sourcesv1beta2 "knative.dev/eventing/pkg/client/clientset/versioned/typed/sources/v1beta2"
 )
 
 type completionConfig struct {
@@ -355,25 +353,11 @@ func completePingSource(config *completionConfig) (suggestions []string) {
 		return
 	}
 
-	var pingSourcesClient clientv1beta2.KnPingSourcesClient
-	if config.params.NewSourcesV1beta2Client == nil {
-		clientConfig, err := config.params.RestConfig()
-		if err != nil {
-			return
-		}
-
-		client, err := sourcesv1beta2.NewForConfig(clientConfig)
-		if err != nil {
-			return
-		}
-		pingSourcesClient = clientv1beta2.NewKnSourcesClient(client, namespace).PingSourcesClient()
-	} else {
-		client, err := config.params.NewSourcesV1beta2Client(namespace)
-		if err != nil {
-			return
-		}
-		pingSourcesClient = client.PingSourcesClient()
+	client, err := config.params.NewSourcesV1beta2Client(namespace)
+	if err != nil {
+		return
 	}
+	pingSourcesClient := client.PingSourcesClient()
 
 	pingSourceList, err := pingSourcesClient.ListPingSource(config.command.Context())
 	if err != nil {

--- a/pkg/kn/commands/completion_helper.go
+++ b/pkg/kn/commands/completion_helper.go
@@ -30,6 +30,7 @@ type completionConfig struct {
 var (
 	resourceToFuncMap = map[string]func(config *completionConfig) []string{
 		"apiserver": completeApiserverSource,
+		"binding":   completeBindingSource,
 		"broker":    completeBroker,
 		"container": completeContainerSource,
 		"domain":    completeDomain,
@@ -305,6 +306,32 @@ func completeApiserverSource(config *completionConfig) (suggestions []string) {
 		return
 	}
 	for _, sug := range apiServerSourceList.Items {
+		if !strings.HasPrefix(sug.Name, config.toComplete) {
+			continue
+		}
+		suggestions = append(suggestions, sug.Name)
+	}
+	return
+}
+
+func completeBindingSource(config *completionConfig) (suggestions []string) {
+	suggestions = make([]string, 0)
+	if len(config.args) != 0 {
+		return
+	}
+	namespace, err := config.params.GetNamespace(config.command)
+	if err != nil {
+		return
+	}
+	client, err := config.params.NewSourcesClient(namespace)
+	if err != nil {
+		return
+	}
+	bindingList, err := client.SinkBindingClient().ListSinkBindings(config.command.Context())
+	if err != nil {
+		return
+	}
+	for _, sug := range bindingList.Items {
 		if !strings.HasPrefix(sug.Name, config.toComplete) {
 			continue
 		}

--- a/pkg/kn/commands/completion_helper.go
+++ b/pkg/kn/commands/completion_helper.go
@@ -29,6 +29,7 @@ type completionConfig struct {
 
 var (
 	resourceToFuncMap = map[string]func(config *completionConfig) []string{
+		"apiserver": completeApiserverSource,
 		"broker":    completeBroker,
 		"container": completeContainerSource,
 		"domain":    completeDomain,
@@ -278,6 +279,32 @@ func completeContainerSource(config *completionConfig) (suggestions []string) {
 		return
 	}
 	for _, sug := range containerSourceList.Items {
+		if !strings.HasPrefix(sug.Name, config.toComplete) {
+			continue
+		}
+		suggestions = append(suggestions, sug.Name)
+	}
+	return
+}
+
+func completeApiserverSource(config *completionConfig) (suggestions []string) {
+	suggestions = make([]string, 0)
+	if len(config.args) != 0 {
+		return
+	}
+	namespace, err := config.params.GetNamespace(config.command)
+	if err != nil {
+		return
+	}
+	client, err := config.params.NewSourcesClient(namespace)
+	if err != nil {
+		return
+	}
+	apiServerSourceList, err := client.APIServerSourcesClient().ListAPIServerSource(config.command.Context())
+	if err != nil {
+		return
+	}
+	for _, sug := range apiServerSourceList.Items {
 		if !strings.HasPrefix(sug.Name, config.toComplete) {
 			continue
 		}

--- a/pkg/kn/commands/completion_helper.go
+++ b/pkg/kn/commands/completion_helper.go
@@ -31,17 +31,18 @@ type completionConfig struct {
 
 var (
 	resourceToFuncMap = map[string]func(config *completionConfig) []string{
-		"apiserver": completeApiserverSource,
-		"binding":   completeBindingSource,
-		"broker":    completeBroker,
-		"channel":   completeChannel,
-		"container": completeContainerSource,
-		"domain":    completeDomain,
-		"ping":      completePingSource,
-		"revision":  completeRevision,
-		"route":     completeRoute,
-		"service":   completeService,
-		"trigger":   completeTrigger,
+		"apiserver":    completeApiserverSource,
+		"binding":      completeBindingSource,
+		"broker":       completeBroker,
+		"channel":      completeChannel,
+		"container":    completeContainerSource,
+		"domain":       completeDomain,
+		"ping":         completePingSource,
+		"revision":     completeRevision,
+		"route":        completeRoute,
+		"service":      completeService,
+		"subscription": completeSubscription,
+		"trigger":      completeTrigger,
 	}
 )
 
@@ -407,6 +408,34 @@ func completeChannel(config *completionConfig) (suggestions []string) {
 		return
 	}
 	for _, sug := range channelList.Items {
+		if !strings.HasPrefix(sug.Name, config.toComplete) {
+			continue
+		}
+		suggestions = append(suggestions, sug.Name)
+	}
+	return
+}
+
+func completeSubscription(config *completionConfig) (suggestions []string) {
+	suggestions = make([]string, 0)
+	if len(config.args) != 0 {
+		return
+	}
+	namespace, err := config.params.GetNamespace(config.command)
+	if err != nil {
+		return
+	}
+
+	client, err := config.params.NewMessagingClient(namespace)
+	if err != nil {
+		return
+	}
+
+	subscriptionList, err := client.SubscriptionsClient().ListSubscription(config.command.Context())
+	if err != nil {
+		return
+	}
+	for _, sug := range subscriptionList.Items {
 		if !strings.HasPrefix(sug.Name, config.toComplete) {
 			continue
 		}

--- a/pkg/kn/commands/completion_helper.go
+++ b/pkg/kn/commands/completion_helper.go
@@ -34,6 +34,7 @@ var (
 		"apiserver": completeApiserverSource,
 		"binding":   completeBindingSource,
 		"broker":    completeBroker,
+		"channel":   completeChannel,
 		"container": completeContainerSource,
 		"domain":    completeDomain,
 		"ping":      completePingSource,
@@ -378,6 +379,34 @@ func completePingSource(config *completionConfig) (suggestions []string) {
 		return
 	}
 	for _, sug := range pingSourceList.Items {
+		if !strings.HasPrefix(sug.Name, config.toComplete) {
+			continue
+		}
+		suggestions = append(suggestions, sug.Name)
+	}
+	return
+}
+
+func completeChannel(config *completionConfig) (suggestions []string) {
+	suggestions = make([]string, 0)
+	if len(config.args) != 0 {
+		return
+	}
+	namespace, err := config.params.GetNamespace(config.command)
+	if err != nil {
+		return
+	}
+
+	client, err := config.params.NewMessagingClient(namespace)
+	if err != nil {
+		return
+	}
+
+	channelList, err := client.ChannelsClient().ListChannel(config.command.Context())
+	if err != nil {
+		return
+	}
+	for _, sug := range channelList.Items {
 		if !strings.HasPrefix(sug.Name, config.toComplete) {
 			continue
 		}

--- a/pkg/kn/commands/completion_helper.go
+++ b/pkg/kn/commands/completion_helper.go
@@ -29,12 +29,13 @@ type completionConfig struct {
 
 var (
 	resourceToFuncMap = map[string]func(config *completionConfig) []string{
-		"broker":   completeBroker,
-		"domain":   completeDomain,
-		"revision": completeRevision,
-		"route":    completeRoute,
-		"service":  completeService,
-		"trigger":  completeTrigger,
+		"broker":    completeBroker,
+		"container": completeContainerSource,
+		"domain":    completeDomain,
+		"revision":  completeRevision,
+		"route":     completeRoute,
+		"service":   completeService,
+		"trigger":   completeTrigger,
 	}
 )
 
@@ -251,6 +252,32 @@ func completeTrigger(config *completionConfig) (suggestions []string) {
 		return
 	}
 	for _, sug := range triggerList.Items {
+		if !strings.HasPrefix(sug.Name, config.toComplete) {
+			continue
+		}
+		suggestions = append(suggestions, sug.Name)
+	}
+	return
+}
+
+func completeContainerSource(config *completionConfig) (suggestions []string) {
+	suggestions = make([]string, 0)
+	if len(config.args) != 0 {
+		return
+	}
+	namespace, err := config.params.GetNamespace(config.command)
+	if err != nil {
+		return
+	}
+	client, err := config.params.NewSourcesClient(namespace)
+	if err != nil {
+		return
+	}
+	containerSourceList, err := client.ContainerSourcesClient().ListContainerSources(config.command.Context())
+	if err != nil {
+		return
+	}
+	for _, sug := range containerSourceList.Items {
 		if !strings.HasPrefix(sug.Name, config.toComplete) {
 			continue
 		}

--- a/pkg/kn/commands/completion_helper.go
+++ b/pkg/kn/commands/completion_helper.go
@@ -34,6 +34,7 @@ var (
 		"revision": completeRevision,
 		"route":    completeRoute,
 		"service":  completeService,
+		"trigger":  completeTrigger,
 	}
 )
 
@@ -224,6 +225,32 @@ func completeDomain(config *completionConfig) (suggestions []string) {
 		return
 	}
 	for _, sug := range domainMappingList.Items {
+		if !strings.HasPrefix(sug.Name, config.toComplete) {
+			continue
+		}
+		suggestions = append(suggestions, sug.Name)
+	}
+	return
+}
+
+func completeTrigger(config *completionConfig) (suggestions []string) {
+	suggestions = make([]string, 0)
+	if len(config.args) != 0 {
+		return
+	}
+	namespace, err := config.params.GetNamespace(config.command)
+	if err != nil {
+		return
+	}
+	client, err := config.params.NewEventingClient(namespace)
+	if err != nil {
+		return
+	}
+	triggerList, err := client.ListTriggers(config.command.Context())
+	if err != nil {
+		return
+	}
+	for _, sug := range triggerList.Items {
 		if !strings.HasPrefix(sug.Name, config.toComplete) {
 			continue
 		}

--- a/pkg/kn/commands/completion_helper_test.go
+++ b/pkg/kn/commands/completion_helper_test.go
@@ -264,6 +264,31 @@ var (
 	testNsApiServerSources = []sourcesv1.ApiServerSource{testApiServerSource1, testApiServerSource2, testApiServerSource3}
 )
 
+var (
+	testSinkBinding1 = sourcesv1.SinkBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "SinkBinding",
+			APIVersion: "sources.knative.dev/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-sink-binding-1", Namespace: testNs},
+	}
+	testSinkBinding2 = sourcesv1.SinkBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "SinkBinding",
+			APIVersion: "sources.knative.dev/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-sink-binding-2", Namespace: testNs},
+	}
+	testSinkBinding3 = sourcesv1.SinkBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "SinkBinding",
+			APIVersion: "sources.knative.dev/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-sink-binding-3", Namespace: testNs},
+	}
+	testNsSinkBindings = []sourcesv1.SinkBinding{testSinkBinding1, testSinkBinding2, testSinkBinding3}
+)
+
 var knParams = initialiseKnParams()
 
 func initialiseKnParams() *KnParams {
@@ -1029,6 +1054,84 @@ func setupTempDir(t *testing.T) string {
 	}
 
 	return tempDir
+}
+
+func TestResourceNameCompletionFuncBindingSource(t *testing.T) {
+	completionFunc := ResourceNameCompletionFunc(knParams)
+
+	fakeSources.AddReactor("list", "sinkbindings",
+		func(a clienttesting.Action) (bool, runtime.Object, error) {
+			if a.GetNamespace() == errorNs {
+				return true, nil, errors.NewInternalError(fmt.Errorf("unable to list revisions"))
+			}
+			return true, &sourcesv1.SinkBindingList{Items: testNsSinkBindings}, nil
+		})
+
+	tests := []testType{
+		{
+			"Empty suggestions when non-zero args",
+			testNs,
+			knParams,
+			[]string{"xyz"},
+			"",
+			"binding",
+		},
+		{
+			"Empty suggestions when no namespace flag",
+			"",
+			knParams,
+			nil,
+			"",
+			"binding",
+		},
+		{
+			"Suggestions when test-ns namespace set",
+			testNs,
+			knParams,
+			nil,
+			"",
+			"binding",
+		},
+		{
+			"Empty suggestions when toComplete is not a prefix",
+			testNs,
+			knParams,
+			nil,
+			"xyz",
+			"binding",
+		},
+		{
+			"Empty suggestions when error during list operation",
+			errorNs,
+			knParams,
+			nil,
+			"",
+			"binding",
+		},
+	}
+	for _, tt := range tests {
+		cmd := getResourceCommandWithTestSubcommand(tt.resource, tt.namespace != "", tt.resource != "no-parent")
+		t.Run(tt.name, func(t *testing.T) {
+			config := &completionConfig{
+				params:     tt.p,
+				command:    cmd,
+				args:       tt.args,
+				toComplete: tt.toComplete,
+			}
+			expectedFunc := resourceToFuncMap[tt.resource]
+			if expectedFunc == nil {
+				expectedFunc = func(config *completionConfig) []string {
+					return []string{}
+				}
+			}
+			cmd.Flags().Set("namespace", tt.namespace)
+			actualSuggestions, actualDirective := completionFunc(cmd, tt.args, tt.toComplete)
+			expectedSuggestions := expectedFunc(config)
+			expectedDirective := cobra.ShellCompDirectiveNoFileComp
+			assert.DeepEqual(t, actualSuggestions, expectedSuggestions)
+			assert.Equal(t, actualDirective, expectedDirective)
+		})
+	}
 }
 
 func writeToFile(t *testing.T, testSvc servingv1.Service, tempFile *os.File) {

--- a/pkg/kn/commands/completion_helper_test.go
+++ b/pkg/kn/commands/completion_helper_test.go
@@ -520,7 +520,7 @@ func TestResourceNameCompletionFuncBroker(t *testing.T) {
 
 	fakeEventing.AddReactor("list", "brokers", func(action clienttesting.Action) (bool, runtime.Object, error) {
 		if action.GetNamespace() == errorNs {
-			return true, nil, errors.NewInternalError(fmt.Errorf("unable to list services"))
+			return true, nil, errors.NewInternalError(fmt.Errorf("unable to list brokers"))
 		}
 		return true, &eventingv1.BrokerList{Items: testNsBrokers}, nil
 	})
@@ -755,7 +755,7 @@ func TestResourceNameCompletionFuncRoute(t *testing.T) {
 	fakeServing.AddReactor("list", "routes",
 		func(a clienttesting.Action) (bool, runtime.Object, error) {
 			if a.GetNamespace() == errorNs {
-				return true, nil, errors.NewInternalError(fmt.Errorf("unable to list services"))
+				return true, nil, errors.NewInternalError(fmt.Errorf("unable to list routes"))
 			}
 			return true, &servingv1.RouteList{Items: testNsRoutes}, nil
 		})
@@ -833,7 +833,7 @@ func TestResourceNameCompletionFuncDomain(t *testing.T) {
 	fakeServingAlpha.AddReactor("list", "domainmappings",
 		func(a clienttesting.Action) (bool, runtime.Object, error) {
 			if a.GetNamespace() == errorNs {
-				return true, nil, errors.NewInternalError(fmt.Errorf("unable to list services"))
+				return true, nil, errors.NewInternalError(fmt.Errorf("unable to list domains"))
 			}
 			return true, &v1alpha1.DomainMappingList{Items: testNsDomains}, nil
 		})
@@ -911,7 +911,7 @@ func TestResourceNameCompletionFuncTrigger(t *testing.T) {
 	fakeServing.AddReactor("list", "triggers",
 		func(a clienttesting.Action) (bool, runtime.Object, error) {
 			if a.GetNamespace() == errorNs {
-				return true, nil, errors.NewInternalError(fmt.Errorf("unable to list revisions"))
+				return true, nil, errors.NewInternalError(fmt.Errorf("unable to list triggers"))
 			}
 			return true, &eventingv1.TriggerList{Items: testNsTriggers}, nil
 		})
@@ -989,7 +989,7 @@ func TestResourceNameCompletionFuncContainerSource(t *testing.T) {
 	fakeSources.AddReactor("list", "containersources",
 		func(a clienttesting.Action) (bool, runtime.Object, error) {
 			if a.GetNamespace() == errorNs {
-				return true, nil, errors.NewInternalError(fmt.Errorf("unable to list revisions"))
+				return true, nil, errors.NewInternalError(fmt.Errorf("unable to list container sources"))
 			}
 			return true, &sourcesv1.ContainerSourceList{Items: testNsContainerSources}, nil
 		})
@@ -1067,7 +1067,7 @@ func TestResourceNameCompletionFuncApiserverSource(t *testing.T) {
 	fakeSources.AddReactor("list", "apiserversources",
 		func(a clienttesting.Action) (bool, runtime.Object, error) {
 			if a.GetNamespace() == errorNs {
-				return true, nil, errors.NewInternalError(fmt.Errorf("unable to list revisions"))
+				return true, nil, errors.NewInternalError(fmt.Errorf("unable to list apiserver sources"))
 			}
 			return true, &sourcesv1.ApiServerSourceList{Items: testNsApiServerSources}, nil
 		})
@@ -1145,7 +1145,7 @@ func TestResourceNameCompletionFuncBindingSource(t *testing.T) {
 	fakeSources.AddReactor("list", "sinkbindings",
 		func(a clienttesting.Action) (bool, runtime.Object, error) {
 			if a.GetNamespace() == errorNs {
-				return true, nil, errors.NewInternalError(fmt.Errorf("unable to list revisions"))
+				return true, nil, errors.NewInternalError(fmt.Errorf("unable to list binding sources"))
 			}
 			return true, &sourcesv1.SinkBindingList{Items: testNsSinkBindings}, nil
 		})
@@ -1223,7 +1223,7 @@ func TestResourceNameCompletionFuncPingSource(t *testing.T) {
 	fakeSourcesV1Beta2.AddReactor("list", "pingsources",
 		func(a clienttesting.Action) (bool, runtime.Object, error) {
 			if a.GetNamespace() == errorNs {
-				return true, nil, errors.NewInternalError(fmt.Errorf("unable to list revisions"))
+				return true, nil, errors.NewInternalError(fmt.Errorf("unable to list ping sources"))
 			}
 			return true, &sourcesv1beta2.PingSourceList{Items: testNsPingSources}, nil
 		})
@@ -1259,7 +1259,7 @@ func TestResourceNameCompletionFuncPingSource(t *testing.T) {
 			knParams,
 			nil,
 			"xyz",
-			"binding",
+			"ping",
 		},
 		{
 			"Empty suggestions when error during list operation",

--- a/pkg/kn/commands/source/apiserver/delete.go
+++ b/pkg/kn/commands/source/apiserver/delete.go
@@ -31,6 +31,7 @@ func NewAPIServerDeleteCommand(p *commands.KnParams) *cobra.Command {
 		Example: `
   # Delete an ApiServerSource 'k8sevents' in default namespace
   kn source apiserver delete k8sevents`,
+		ValidArgsFunction: commands.ResourceNameCompletionFunc(p),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("requires the name of the source as single argument")

--- a/pkg/kn/commands/source/apiserver/describe.go
+++ b/pkg/kn/commands/source/apiserver/describe.go
@@ -42,9 +42,10 @@ func NewAPIServerDescribeCommand(p *commands.KnParams) *cobra.Command {
 	machineReadablePrintFlags := genericclioptions.NewPrintFlags("")
 
 	command := &cobra.Command{
-		Use:     "describe NAME",
-		Short:   "Show details of an api-server source",
-		Example: describeExample,
+		Use:               "describe NAME",
+		Short:             "Show details of an api-server source",
+		Example:           describeExample,
+		ValidArgsFunction: commands.ResourceNameCompletionFunc(p),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("'kn source apiserver describe' requires name of the source as single argument")

--- a/pkg/kn/commands/source/apiserver/update.go
+++ b/pkg/kn/commands/source/apiserver/update.go
@@ -38,6 +38,7 @@ func NewAPIServerUpdateCommand(p *commands.KnParams) *cobra.Command {
   # Update an ApiServerSource 'k8sevents' with different service account and sink service
   kn source apiserver update k8sevents --service-account newsa --sink ksvc:newsvc`,
 
+		ValidArgsFunction: commands.ResourceNameCompletionFunc(p),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {
 				return errors.New("requires the name of the source as single argument")

--- a/pkg/kn/commands/source/binding/delete.go
+++ b/pkg/kn/commands/source/binding/delete.go
@@ -30,6 +30,7 @@ func NewBindingDeleteCommand(p *commands.KnParams) *cobra.Command {
 		Example: `
   # Delete a sink binding with name 'my-binding'
   kn source binding delete my-binding`,
+		ValidArgsFunction: commands.ResourceNameCompletionFunc(p),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("requires the name of the sink binding to delete as single argument")

--- a/pkg/kn/commands/source/binding/describe.go
+++ b/pkg/kn/commands/source/binding/describe.go
@@ -43,9 +43,10 @@ func NewBindingDescribeCommand(p *commands.KnParams) *cobra.Command {
 	machineReadablePrintFlags := genericclioptions.NewPrintFlags("")
 
 	command := &cobra.Command{
-		Use:     "describe NAME",
-		Short:   "Show details of a sink binding",
-		Example: describeExample,
+		Use:               "describe NAME",
+		Short:             "Show details of a sink binding",
+		Example:           describeExample,
+		ValidArgsFunction: commands.ResourceNameCompletionFunc(p),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("'kn source binding describe' requires name of the sink binding as single argument")

--- a/pkg/kn/commands/source/binding/update.go
+++ b/pkg/kn/commands/source/binding/update.go
@@ -38,6 +38,7 @@ func NewBindingUpdateCommand(p *commands.KnParams) *cobra.Command {
   # Update the subject of a sink binding 'my-binding' to a new cronjob with label selector 'app=ping'  
   kn source binding update my-binding --subject cronjob:batch/v1beta1:app=ping"`,
 
+		ValidArgsFunction: commands.ResourceNameCompletionFunc(p),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {
 				return errors.New("requires the name of the sink binding to update as single argument")

--- a/pkg/kn/commands/source/container/delete.go
+++ b/pkg/kn/commands/source/container/delete.go
@@ -33,6 +33,7 @@ func NewContainerDeleteCommand(p *commands.KnParams) *cobra.Command {
 		Example: `
   # Delete a ContainerSource 'containersrc' in default namespace
   kn source container delete containersrc`,
+		ValidArgsFunction: commands.ResourceNameCompletionFunc(p),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("requires the name of the source as single argument")

--- a/pkg/kn/commands/source/container/describe.go
+++ b/pkg/kn/commands/source/container/describe.go
@@ -36,6 +36,7 @@ func NewContainerDescribeCommand(p *commands.KnParams) *cobra.Command {
 		Example: `
   # Describe a container source with name 'k8sevents'
   kn source container describe k8sevents`,
+		ValidArgsFunction: commands.ResourceNameCompletionFunc(p),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("'kn source container describe' requires name of the source as single argument")

--- a/pkg/kn/commands/source/ping/delete.go
+++ b/pkg/kn/commands/source/ping/delete.go
@@ -30,6 +30,7 @@ func NewPingDeleteCommand(p *commands.KnParams) *cobra.Command {
 		Example: `
   # Delete a Ping source 'my-ping'
   kn source ping delete my-ping`,
+		ValidArgsFunction: commands.ResourceNameCompletionFunc(p),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("'requires the name of the Ping source to delete as single argument")

--- a/pkg/kn/commands/source/ping/describe.go
+++ b/pkg/kn/commands/source/ping/describe.go
@@ -41,9 +41,10 @@ func NewPingDescribeCommand(p *commands.KnParams) *cobra.Command {
 	machineReadablePrintFlags := genericclioptions.NewPrintFlags("")
 
 	command := &cobra.Command{
-		Use:     "describe NAME",
-		Short:   "Show details of a ping source",
-		Example: describeExample,
+		Use:               "describe NAME",
+		Short:             "Show details of a ping source",
+		Example:           describeExample,
+		ValidArgsFunction: commands.ResourceNameCompletionFunc(p),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("'kn source ping describe' requires name of the source as single argument")

--- a/pkg/kn/commands/source/ping/update.go
+++ b/pkg/kn/commands/source/ping/update.go
@@ -42,6 +42,7 @@ func NewPingUpdateCommand(p *commands.KnParams) *cobra.Command {
   # Update the schedule of a Ping source 'my-ping' to fire every minute
   kn source ping update my-ping --schedule "* * * * *"`,
 
+		ValidArgsFunction: commands.ResourceNameCompletionFunc(p),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {
 				return errors.New("name of Ping source required")

--- a/pkg/kn/commands/subscription/delete.go
+++ b/pkg/kn/commands/subscription/delete.go
@@ -32,6 +32,7 @@ func NewSubscriptionDeleteCommand(p *commands.KnParams) *cobra.Command {
 		Example: `
   # Delete a subscription 'sub0'
   kn subscription delete sub0`,
+		ValidArgsFunction: commands.ResourceNameCompletionFunc(p),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("'kn subscription delete' requires the subscription name as single argument")

--- a/pkg/kn/commands/subscription/describe.go
+++ b/pkg/kn/commands/subscription/describe.go
@@ -43,6 +43,7 @@ func NewSubscriptionDescribeCommand(p *commands.KnParams) *cobra.Command {
 		Example: `
   # Describe a subscription 'pipe'
   kn subscription describe pipe`,
+		ValidArgsFunction: commands.ResourceNameCompletionFunc(p),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("'kn subscription describe' requires the subscription name given as single argument")

--- a/pkg/kn/commands/subscription/update.go
+++ b/pkg/kn/commands/subscription/update.go
@@ -43,7 +43,7 @@ func NewSubscriptionUpdateCommand(p *commands.KnParams) *cobra.Command {
 
   # Update a subscription 'sub1' with subscriber ksvc 'mirror', reply to a broker 'nest' and DeadLetterSink to a ksvc 'bucket'
   kn subscription update sub1 --sink mirror --sink-reply broker:nest --sink-dead-letter bucket`,
-
+		ValidArgsFunction: commands.ResourceNameCompletionFunc(p),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {
 				return errors.New("'kn subscription update' requires the subscription name given as single argument")

--- a/pkg/kn/commands/trigger/delete.go
+++ b/pkg/kn/commands/trigger/delete.go
@@ -30,6 +30,7 @@ func NewTriggerDeleteCommand(p *commands.KnParams) *cobra.Command {
 		Example: `
   # Delete a trigger 'mytrigger' in default namespace
   kn trigger delete mytrigger`,
+		ValidArgsFunction: commands.ResourceNameCompletionFunc(p),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("'trigger delete' requires the name of the trigger as single argument")

--- a/pkg/kn/commands/trigger/describe.go
+++ b/pkg/kn/commands/trigger/describe.go
@@ -40,9 +40,10 @@ func NewTriggerDescribeCommand(p *commands.KnParams) *cobra.Command {
 	machineReadablePrintFlags := genericclioptions.NewPrintFlags("")
 
 	command := &cobra.Command{
-		Use:     "describe NAME",
-		Short:   "Show details of a trigger",
-		Example: describeExample,
+		Use:               "describe NAME",
+		Short:             "Show details of a trigger",
+		Example:           describeExample,
+		ValidArgsFunction: commands.ResourceNameCompletionFunc(p),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("'kn trigger describe' requires name of the trigger as single argument")

--- a/pkg/kn/commands/trigger/update.go
+++ b/pkg/kn/commands/trigger/update.go
@@ -48,7 +48,7 @@ func NewTriggerUpdateCommand(p *commands.KnParams) *cobra.Command {
   # Update the sink of a trigger 'mytrigger' to 'ksvc:new-service'
   kn trigger update mytrigger --sink ksvc:new-service
   `,
-
+		ValidArgsFunction: commands.ResourceNameCompletionFunc(p),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {
 				return errors.New("name of trigger required")

--- a/pkg/kn/commands/types.go
+++ b/pkg/kn/commands/types.go
@@ -94,6 +94,10 @@ func (params *KnParams) Initialize() {
 	if params.NewDynamicClient == nil {
 		params.NewDynamicClient = params.newDynamicClient
 	}
+
+	if params.NewSourcesV1beta2Client == nil {
+		params.NewSourcesV1beta2Client = params.newSourcesClientV1beta2
+	}
 }
 
 func (params *KnParams) newServingClient(namespace string) (clientservingv1.KnServingClient, error) {


### PR DESCRIPTION
## Description
Context specific autocompletion for eventing resources
<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Added the ValidArgs function for the following resources
    * triggers
    * source:
        * ping
        * sinkbinding
        * apiserver
        * container
    * channel
    * subscription  

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #1373 

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
