### PR TITLE
Fix for panic during channel list

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,11 @@
 [cols="1,10,3", options="header", width="100%"]
 |===
 | | Description | PR
+
+| 🐛
+| Fixed panic in `kn channel list`
+| https://github.com/knative/client/pull/1568[#1568]
+
 | 🗑
 | Remove deprecated Hugo frontmatter generation for docs
 | https://github.com/knative/client/pull/1563[#1563]

--- a/pkg/kn/commands/channel/flags.go
+++ b/pkg/kn/commands/channel/flags.go
@@ -56,7 +56,14 @@ func printChannel(channel *messagingv1.Channel, options hprinters.PrintOptions) 
 	}
 
 	name := channel.Name
-	ctype := channel.Spec.ChannelTemplate.Kind
+	template := channel.Spec.ChannelTemplate
+
+	var ctype string
+	if template == nil {
+		ctype = ""
+	} else {
+		ctype = template.Kind
+	}
 	url := ""
 	if channel.Status.Address != nil {
 		url = channel.Status.Address.URL.String()


### PR DESCRIPTION
## Description
`kn channel list` was panicking when a channel in the list didn't have `.Spec.ChannelTemplate` field set to a non-nil value.
<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Added a nil check

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
