### PR TITLE
Remove k8s cluster version pin

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -37,7 +37,7 @@ export PATH=$PATH:${REPO_ROOT_DIR}
 
 run() {
   # Create cluster
-  initialize $@ --skip-istio-addon --cluster-version=1.20
+  initialize $@ --skip-istio-addon
 
   # Smoke test
   eval smoke_test || fail_test


### PR DESCRIPTION
## Description

It's affecting latest integrations tests with net-istio failing to deploy due too low cluster version.

E.g.: https://github.com/knative/client/pull/1571

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Remove k8s cluster version pin

/cc @rhuss @vyasgun 
