### PR TITLE
Updates kn versions for presubmit integration test

### DIFF
--- a/test/presubmit-integration-tests-latest-release.sh
+++ b/test/presubmit-integration-tests-latest-release.sh
@@ -17,7 +17,7 @@
 # This script is used in Knative/test-infra as a custom prow job to run the
 # integration tests against Knative Serving / Eventing of a specific version.
 
-export KNATIVE_SERVING_VERSION="1.0.0"
-export KNATIVE_EVENTING_VERSION="1.0.0"
+export KNATIVE_SERVING_VERSION="1.2.0"
+export KNATIVE_EVENTING_VERSION="1.2.0"
 
 $(dirname $0)/presubmit-tests.sh --integration-tests


### PR DESCRIPTION
## Description

Updating the `presubmit-integration-tests-latest-release` test to Knative serving/eventing v1.2 as per https://github.com/knative/release#knativeclient

/hold
until serving/eventing are release on Jan 25