### PR TITLE
change display versions

### DIFF
--- a/hack/build-flags.sh
+++ b/hack/build-flags.sh
@@ -19,6 +19,7 @@ function build_flags() {
   rev="$(git rev-parse --short HEAD)"
   local pkg="knative.dev/client/pkg/kn/commands/version"
   local version="${TAG:-}"
+  local major_minor="$(echo "${version}" | cut -f1-2 -d. -n)"
   # Use vYYYYMMDD-local-<hash> for the version string, if not passed.
   if [[ -z "${version}" ]]; then
     # Get the commit, excluding any tags but keeping the "dirty" flag
@@ -27,13 +28,21 @@ function build_flags() {
     [[ -n "${commit}" ]] || abort "error getting the current commit"
     version="v$(date +%Y%m%d)-local-${commit}"
   fi
-  # Extract Eventing and Serving versions from go.mod
+  # For Eventing and Serving versionings,
+  # major and minor versions are the same as client version
+  # patch version is from each technical version
+  technical_version_serving=$(grep "knative.dev/serving " "${base}/go.mod" \
+    | sed -s 's/.* \(v.[\.0-9]*\).*/\1/')
+  technical_version_eventing=$(grep "knative.dev/eventing " "${base}/go.mod" \
+    | sed -s 's/.* \(v.[\.0-9]*\).*/\1/')
   local version_serving version_eventing
-  version_serving=$(grep "knative.dev/serving " "${base}/go.mod" \
-    | sed -s 's/.* \(v.[\.0-9]*\).*/\1/')
-  version_eventing=$(grep "knative.dev/eventing " "${base}/go.mod" \
-    | sed -s 's/.* \(v.[\.0-9]*\).*/\1/')
-
+  if [[ -n "${major_minor}" ]]; then
+    version_serving=${major_minor}.$(echo ${technical_version_serving} |cut -f3 -d.)
+    version_eventing=${major_minor}.$(echo ${technical_version_eventing} |cut -f3 -d.)
+  else
+    version_serving="${technical_version_serving}"
+    version_eventing="${technical_version_eventing}"
+  fi
   echo "-X '${pkg}.BuildDate=${now}' \
   -X ${pkg}.Version=${version} \
   -X ${pkg}.GitRevision=${rev} \


### PR DESCRIPTION
## Description
Change display versions for Serving and Eventing for major/minor updates.

```
$ TAG=v1.2.0 hack/build.sh
🚒 Update
=== Update Deps for Golang
--- Go mod tidy and vendor
--- Removing unwanted vendor files
--- Updating licenses
--- Removing broken symlinks
🔍 Lint
 ️ License
📖 Docs
🚧 Compile
 Test
────────────────────────────────────────────
Version:      v1.2.0
Build Date:   2022-02-05 04:06:08
Git Revision: 6690a20e
Suppored APIs:
* Serving
  - serving.knative.dev/v1 (knative-serving v1.2.0)
* Eventing
  - sources.knative.dev/v1 (knative-eventing v1.2.0)
  - eventing.knative.dev/v1 (knative-eventing v1.2.0)
```

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->
* Add conditional statement in `hack/build-flags.sh` to check patch number to Serving and Eventing versions
* Displayed versions are depends on client's patch version

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #1542 

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
