### PR TITLE
remove hardcoded kn for usage and error

### DIFF
--- a/cmd/kn/main.go
+++ b/cmd/kn/main.go
@@ -185,7 +185,7 @@ func printError(err error) {
 		// Sending `os.Args[0]` instead, may result in panics while compiling the regexp, as it
 		// may expand to the absolute path of the kn binary and the path may collide with regexp expressions.
 		// see https://github.com/knative/client/issues/1172
-		fmt.Fprintf(os.Stderr, "Run '%s --help' for usage\n", extractCommandPathFromErrorMessage(err.Error(), "kn"))
+		fmt.Fprintf(os.Stderr, "Run '%s --help' for usage\n", extractCommandPathFromErrorMessage(err.Error(), root.GetBinaryName()))
 	}
 }
 

--- a/cmd/kn/main_test.go
+++ b/cmd/kn/main_test.go
@@ -333,6 +333,7 @@ func TestRunWithExit(t *testing.T) {
 func TestExtractCommandPathFromErrorMessage(t *testing.T) {
 	for _, d := range []struct{ arg0, errMsg, expected string }{
 		{"kn", "Invalid argument for 'kn service'", "kn service"},
+		{"kn1", "Invalid argument for 'kn1 service'", "kn1 service"},
 		{"C:\\Users\\hudson.DESKTOP-T61GB27\\Documents\\foo-with-revisions", "Invalid argument for 'C:\\Users\\hudson.DESKTOP-T61GB27\\Documents\\foo-with-revisions test'", "C:\\Users\\hudson.DESKTOP-T61GB27\\Documents\\foo-with-revisions test"},
 	} {
 		assert.Equal(t, extractCommandPathFromErrorMessage(d.errMsg, d.arg0), d.expected)

--- a/docs/cmd/kn.md
+++ b/docs/cmd/kn.md
@@ -6,7 +6,7 @@ kn manages Knative Serving and Eventing resources
 
 kn is the command line interface for managing Knative Serving and Eventing resources
 
- Find more information about Knative at: https://knative.dev
+Find more information about Knative at: https://knative.dev
 
 ### Options
 

--- a/hack/generate-docs.go
+++ b/hack/generate-docs.go
@@ -24,6 +24,7 @@ import (
 )
 
 func main() {
+	os.Args = []string{"kn"}
 	rootCmd, err := root.NewRootCommand(nil)
 	if err != nil {
 		log.Panicf("can not create root command: %v", err)

--- a/pkg/kn/root/root.go
+++ b/pkg/kn/root/root.go
@@ -186,7 +186,7 @@ func ExtractSubCommandNames(cmds []*cobra.Command) []string {
 // for example
 // /usr/bin/kn1 service list would return kn1
 // kn service list would return kn
-// mykn sevice list would return mykn
+// mykn service list would return mykn
 func GetBinaryName() string {
 	_, name := filepath.Split(os.Args[0])
 	return name

--- a/pkg/kn/root/root.go
+++ b/pkg/kn/root/root.go
@@ -183,7 +183,7 @@ func ExtractSubCommandNames(cmds []*cobra.Command) []string {
 }
 
 // GetBinaryName returns the actual binary name of the kn cli
-// for example 
+// for example
 // /usr/bin/kn1 service list would return kn1
 // kn service list would return kn
 // mykn sevice list would return mykn

--- a/pkg/kn/root/root.go
+++ b/pkg/kn/root/root.go
@@ -182,6 +182,11 @@ func ExtractSubCommandNames(cmds []*cobra.Command) []string {
 	return ret
 }
 
+// GetBinaryName returns the actual binary name of the kn cli
+// for example 
+// /usr/bin/kn1 service list would return kn1
+// kn service list would return kn
+// mykn sevice list would return mykn
 func GetBinaryName() string {
 	_, name := filepath.Split(os.Args[0])
 	return name

--- a/pkg/kn/root/root_test.go
+++ b/pkg/kn/root/root_test.go
@@ -16,6 +16,7 @@ package root
 
 import (
 	"errors"
+	"os"
 	"strings"
 	"testing"
 
@@ -26,6 +27,7 @@ import (
 )
 
 func TestNewRootCommand(t *testing.T) {
+	os.Args = []string{"kn"}
 	rootCmd, err := NewRootCommand(nil)
 	assert.NilError(t, err)
 	if rootCmd == nil {
@@ -142,4 +144,25 @@ func checkCommandGroup(t *testing.T, commands []string, rootCmd *cobra.Command) 
 	err = cmd.RunE(cmd, []string{"deeper"})
 	assert.Assert(t, err != nil)
 	assert.Assert(t, util.ContainsAll(err.Error(), "deeper", "unknown", "sub-command", cmd.Name()))
+}
+
+func TestRootCommandForBinaryNames(t *testing.T) {
+	for _, test := range []struct {
+		arg        string
+		binaryName string
+	}{
+		{"kn", "kn"},
+		{"kn1", "kn1"},
+		{"/usr/bin/mykn", "mykn"},
+	} {
+		os.Args = []string{test.arg}
+		rootCmd, err := NewRootCommand(nil)
+		assert.NilError(t, err)
+		if rootCmd == nil {
+			t.Fatal("rootCmd = nil, want not nil")
+		}
+
+		assert.Equal(t, rootCmd.Name(), test.binaryName)
+	}
+
 }


### PR DESCRIPTION
## Description

Removed hard-coded "kn" in usage/error messages

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #1191 

<!--
/lint
-->
