### PR TITLE
Traffic split auto redirection should only consider the active revisions 

### DIFF
--- a/test/e2e/traffic_split_test.go
+++ b/test/e2e/traffic_split_test.go
@@ -194,8 +194,8 @@ func TestTrafficSplit(t *testing.T) {
 
 		test.ServiceCreate(r, serviceName)
 
-		test.ServiceUpdate(r, serviceName, "--env", "TARGET=v1")
-		test.ServiceUpdate(r, serviceName, "--env", "TARGET=v2")
+		test.ServiceUpdate(r, serviceName, "--env", "TARGET=v1", "--traffic", "40")
+		test.ServiceUpdate(r, serviceName, "--env", "TARGET=v2", "--traffic", fmt.Sprintf("%s=%d", rev1, 50))
 		test.ServiceUpdateWithError(r, serviceName, "--traffic", fmt.Sprintf("%s=%d", rev1, 50))
 
 		test.ServiceDelete(r, serviceName)

--- a/test/e2e/traffic_split_test.go
+++ b/test/e2e/traffic_split_test.go
@@ -138,7 +138,7 @@ func TestTrafficSplit(t *testing.T) {
 
 		serviceName := test.GetNextServiceName(serviceBase)
 		test.ServiceCreate(r, serviceName)
-		test.ServiceUpdate(r, serviceName, "--env", "TARGET=v1")
+		test.ServiceUpdate(r, serviceName, "--env", "TARGET=v1", "--traffic", "80")
 
 		rev1 := fmt.Sprintf("%s-00001", serviceName)
 		rev2 := fmt.Sprintf("%s-00002", serviceName)
@@ -191,11 +191,12 @@ func TestTrafficSplit(t *testing.T) {
 		serviceName := test.GetNextServiceName(serviceBase)
 
 		rev1 := fmt.Sprintf("%s-00001", serviceName)
+		rev2 := fmt.Sprintf("%s-00002", serviceName)
 
 		test.ServiceCreate(r, serviceName)
 
 		test.ServiceUpdate(r, serviceName, "--env", "TARGET=v1", "--traffic", "40")
-		test.ServiceUpdate(r, serviceName, "--env", "TARGET=v2", "--traffic", fmt.Sprintf("%s=%d", rev1, 50))
+		test.ServiceUpdate(r, serviceName, "--env", "TARGET=v2", "--traffic", fmt.Sprintf("%s=%d,%s=%d", rev1, 10, rev2, 20))
 		test.ServiceUpdateWithError(r, serviceName, "--traffic", fmt.Sprintf("%s=%d", rev1, 50))
 
 		test.ServiceDelete(r, serviceName)
@@ -209,7 +210,7 @@ func TestTrafficSplit(t *testing.T) {
 
 		test.ServiceCreate(r, serviceName)
 
-		test.ServiceUpdate(r, serviceName, "--env", "TARGET=v1")
+		test.ServiceUpdate(r, serviceName, "--env", "TARGET=v1", "--traffic", "20")
 		test.ServiceUpdateWithError(r, serviceName, "--env", "TARGET=v2", "--traffic", "@latest=50")
 
 		test.ServiceDelete(r, serviceName)


### PR DESCRIPTION
## Description

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Automatic redirection of traffic should only take the active revisions into consideration
* Modified unit test according to the change

```
gvyas-mac:client gvyas$ ./kn revision list -s cloudevents-player
NAME                       SERVICE              TRAFFIC   TAGS   GENERATION   AGE   CONDITIONS   READY   REASON
cloudevents-player-00005   cloudevents-player   100%             5            76m   3 OK / 4     True    
cloudevents-player-00004   cloudevents-player                    4            84m   3 OK / 4     True    
cloudevents-player-00003   cloudevents-player                    3            85m   3 OK / 4     True    
cloudevents-player-00002   cloudevents-player                    2            27d   3 OK / 4     True    
cloudevents-player-00001   cloudevents-player                    1            27d   3 OK / 4     True    
```
```
gvyas-mac:client gvyas$ ./kn service update cloudevents-player --env ABC=xyz --traffic 70
Updating Service 'cloudevents-player' in namespace 'default':

  0.065s The Route is still working to reflect the latest desired specification.
  0.110s ...
  3.198s Traffic is not yet migrated to the latest revision.
  3.262s Ingress has not yet been reconciled.
  3.309s Waiting for load balancer to be ready
  3.458s Ready to serve.

Service 'cloudevents-player' updated to latest revision 'cloudevents-player-00006' is available at URL:
http://cloudevents-player.default.10.111.180.117.sslip.io
gvyas-mac:client gvyas$ ./kn revision list -s cloudevents-player
NAME                       SERVICE              TRAFFIC   TAGS   GENERATION   AGE   CONDITIONS   READY   REASON
cloudevents-player-00006   cloudevents-player   70%              6            6s    4 OK / 4     True    
cloudevents-player-00005   cloudevents-player   30%              5            77m   3 OK / 4     True    
cloudevents-player-00004   cloudevents-player                    4            86m   3 OK / 4     True    
cloudevents-player-00003   cloudevents-player                    3            86m   3 OK / 4     True    
cloudevents-player-00002   cloudevents-player                    2            27d   3 OK / 4     True    
cloudevents-player-00001   cloudevents-player                    1            27d   3 OK / 4     True    
```

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #1609 

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
