### PR TITLE
Refactor version command to use go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.10.1
+	golang.org/x/mod v0.5.1
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	gotest.tools/v3 v3.0.3
 	k8s.io/api v0.22.5

--- a/pkg/kn/commands/version/version.go
+++ b/pkg/kn/commands/version/version.go
@@ -17,11 +17,13 @@ package version
 import (
 	"encoding/json"
 	"fmt"
+	"runtime/debug"
+	"strings"
 
 	"github.com/spf13/cobra"
-	"sigs.k8s.io/yaml"
-
+	"golang.org/x/mod/semver"
 	"knative.dev/client/pkg/kn/commands"
+	"sigs.k8s.io/yaml"
 )
 
 var Version string
@@ -29,17 +31,6 @@ var BuildDate string
 var GitRevision string
 var VersionServing string
 var VersionEventing string
-
-// update this var as we add more deps
-var apiVersions = map[string][]string{
-	"serving": {
-		fmt.Sprintf("serving.knative.dev/v1 (knative-serving %s)", VersionServing),
-	},
-	"eventing": {
-		fmt.Sprintf("sources.knative.dev/v1 (knative-eventing %s)", VersionEventing),
-		fmt.Sprintf("eventing.knative.dev/v1 (knative-eventing %s)", VersionEventing),
-	},
-}
 
 type knVersion struct {
 	Version       string
@@ -54,8 +45,41 @@ func NewVersionCommand(p *commands.KnParams) *cobra.Command {
 		Use:   "version",
 		Short: "Show the version of this client",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			info, ok := debug.ReadBuildInfo()
+			var apiVersions map[string][]string
+			if ok {
+				// Retrieve Serving & Eventing go.mod versions, format: v0.y.z
+				for _, dep := range info.Deps {
+					if strings.Contains(dep.Path, "knative.dev/serving") {
+						VersionServing = dep.Version
+					}
+					if strings.Contains(dep.Path, "knative.dev/eventing") {
+						VersionEventing = dep.Version
+					}
+				}
+				// For valid {Version} of kn take MajorMinor + patch version of dependency,
+				// e.g for client's release version=v1.3.0 + serving, eventing modules v0.30.0
+				// the resulting displayed version should be also 'v1.3.0'.
+				// Those versions should represent production releases tagged and published.
+				// Otherwise keep plain unmodified version from go.mod,
+				// that should cover local or nightly builds etc.
+				if semver.IsValid(Version) && semver.IsValid(VersionServing) && semver.IsValid(VersionEventing) {
+					VersionServing = semver.MajorMinor(Version) + VersionServing[5:]
+					VersionEventing = semver.MajorMinor(Version) + VersionEventing[5:]
+				}
+			}
+			apiVersions = map[string][]string{
+				"serving": {
+					fmt.Sprintf("serving.knative.dev/v1 (knative-serving %s)", VersionServing),
+				},
+				"eventing": {
+					fmt.Sprintf("sources.knative.dev/v1 (knative-eventing %s)", VersionEventing),
+					fmt.Sprintf("eventing.knative.dev/v1 (knative-eventing %s)", VersionEventing),
+				},
+			}
+
 			if cmd.Flags().Changed("output") {
-				return printVersionMachineReadable(cmd)
+				return printVersionMachineReadable(cmd, apiVersions)
 			}
 			out := cmd.OutOrStdout()
 			fmt.Fprintf(out, "Version:      %s\n", Version)
@@ -82,7 +106,7 @@ func NewVersionCommand(p *commands.KnParams) *cobra.Command {
 	return versionCmd
 }
 
-func printVersionMachineReadable(cmd *cobra.Command) error {
+func printVersionMachineReadable(cmd *cobra.Command, apiVersions map[string][]string) error {
 	out := cmd.OutOrStdout()
 	v := knVersion{Version, BuildDate, GitRevision, apiVersions}
 	format := cmd.Flag("output").Value.String()

--- a/pkg/kn/commands/version/version_test.go
+++ b/pkg/kn/commands/version/version_test.go
@@ -17,6 +17,7 @@ package version
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"text/template"
 
@@ -43,6 +44,16 @@ const (
 	fakeBuildDate   = "fake-build-date"
 	fakeGitRevision = "fake-git-revision"
 )
+
+var apiVersions = map[string][]string{
+	"serving": {
+		fmt.Sprintf("serving.knative.dev/v1 (knative-serving %s)", VersionServing),
+	},
+	"eventing": {
+		fmt.Sprintf("sources.knative.dev/v1 (knative-eventing %s)", VersionEventing),
+		fmt.Sprintf("eventing.knative.dev/v1 (knative-eventing %s)", VersionEventing),
+	},
+}
 
 func TestVersion(t *testing.T) {
 	var (

--- a/third_party/VENDOR-LICENSE/golang.org/x/mod/semver/LICENSE
+++ b/third_party/VENDOR-LICENSE/golang.org/x/mod/semver/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -286,6 +286,7 @@ go.uber.org/zap/zapcore
 golang.org/x/crypto/pkcs12
 golang.org/x/crypto/pkcs12/internal/rc2
 # golang.org/x/mod v0.5.1
+## explicit
 golang.org/x/mod/internal/lazyregexp
 golang.org/x/mod/module
 golang.org/x/mod/semver


### PR DESCRIPTION
## Description

For valid `Version` of kn take `MajorMinor + Patch` version of dependency, e.g for client's release `version=v1.3.0` + serving, eventing modules `v0.30.0`. The resulting displayed version should be also `v1.3.0`. Those versions should represent production releases tagged and published. Otherwise keep plain unmodified version from `go.mod`, that should cover local or nightly builds etc.

```
➜  client git:(pr/display-version) ./hack/build.sh -f
🚧 Compile
➜  client git:(pr/display-version) kn version
Version:      v20220308-local-9b0e1036
Build Date:   2022-03-08 15:40:19
Git Revision: 9b0e1036
Supported APIs:
* Serving
  - serving.knative.dev/v1 (knative-serving v0.29.1-0.20220307224905-f428fa524adc)
* Eventing
  - sources.knative.dev/v1 (knative-eventing v0.29.1-0.20220307200636-9590bc3a96a3)
  - eventing.knative.dev/v1 (knative-eventing v0.29.1-0.20220307200636-9590bc3a96a3)

```
```
➜  client git:(pr/display-version) TAG="v1.3.0" ./hack/build.sh -f                     
🚧 Compile
➜  client git:(pr/display-version) kn version
Version:      v1.3.0
Build Date:   2022-03-08 15:39:41
Git Revision: 9b0e1036
Supported APIs:
* Serving
  - serving.knative.dev/v1 (knative-serving v1.3.1-0.20220307224905-f428fa524adc)
* Eventing
  - sources.knative.dev/v1 (knative-eventing v1.3.1-0.20220307200636-9590bc3a96a3)
  - eventing.knative.dev/v1 (knative-eventing v1.3.1-0.20220307200636-9590bc3a96a3)

```

Previous `release-1.2` branch with cherry pick 

```
➜  client git:(release-1.2) ✗ TAG="v1.2.0" ./hack/build.sh -f
🚧 Compile
➜  client git:(release-1.2) ✗ kn version                     
Version:      v1.2.0
Build Date:   2022-03-08 16:00:12
Git Revision: 9743f15b
Supported APIs:
* Serving
  - serving.knative.dev/v1 (knative-serving v1.2.0)
* Eventing
  - sources.knative.dev/v1 (knative-eventing v1.2.0)
  - eventing.knative.dev/v1 (knative-eventing v1.2.0)

```
## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Refactor version command to use go modules

