### PR TITLE
Grab latest version in presubmit

### DIFF
--- a/test/presubmit-integration-tests-latest-release.sh
+++ b/test/presubmit-integration-tests-latest-release.sh
@@ -17,7 +17,7 @@
 # This script is used in Knative/test-infra as a custom prow job to run the
 # integration tests against Knative Serving / Eventing of a specific version.
 
-export KNATIVE_SERVING_VERSION="1.2.0"
-export KNATIVE_EVENTING_VERSION="1.2.0"
+export KNATIVE_SERVING_VERSION="`git ls-remote --heads git@github.com:knative/serving.git | grep release- | cut -d '-' -f2 | sort -r | head -n 1`"
+export KNATIVE_EVENTING_VERSION="`git ls-remote --heads git@github.com:knative/eventing.git | grep release- | cut -d '-' -f2 | sort -r | head -n 1`"
 
 $(dirname $0)/presubmit-tests.sh --integration-tests


### PR DESCRIPTION
Remove the need to update the tests with each release.
Grabs the list of remotes that start with `release-`, strip everything before `-` and sort from highest to lowest. Finally use the highest one as version.

NOTE: this returns `1.3` currently. Is the `1.3.0` needed?