### PR TITLE
Add timeout option to service create

### DIFF
--- a/docs/cmd/kn_service_apply.md
+++ b/docs/cmd/kn_service_apply.md
@@ -68,6 +68,7 @@ kn service apply s0 --filename my-svc.yml
       --scale-utilization int             Percentage of concurrent requests utilization before scaling up. (default 70)
       --scale-window string               Duration to look back for making auto-scaling decisions. The service is scaled to zero if no request was received in during that time. (eg: 10s)
       --service-account string            Service account name to set. An empty argument ("") clears the service account. The referenced service account must exist in the service's namespace.
+      --timeout int                       duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying (default 300)
       --user int                          The user ID to run the container (e.g., 1001).
       --volume stringArray                Add a volume from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret: or sc:). Example: --volume myvolume=cm:myconfigmap or --volume myvolume=secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --volume myvolume-.
       --wait                              Wait for 'service apply' operation to be completed. (default true)

--- a/docs/cmd/kn_service_apply.md
+++ b/docs/cmd/kn_service_apply.md
@@ -68,7 +68,7 @@ kn service apply s0 --filename my-svc.yml
       --scale-utilization int             Percentage of concurrent requests utilization before scaling up. (default 70)
       --scale-window string               Duration to look back for making auto-scaling decisions. The service is scaled to zero if no request was received in during that time. (eg: 10s)
       --service-account string            Service account name to set. An empty argument ("") clears the service account. The referenced service account must exist in the service's namespace.
-      --timeout int                       duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying (default 300)
+      --timeout int                       Duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying (default 300)
       --user int                          The user ID to run the container (e.g., 1001).
       --volume stringArray                Add a volume from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret: or sc:). Example: --volume myvolume=cm:myconfigmap or --volume myvolume=secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --volume myvolume-.
       --wait                              Wait for 'service apply' operation to be completed. (default true)

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -95,7 +95,7 @@ kn service create NAME --image IMAGE
       --service-account string            Service account name to set. An empty argument ("") clears the service account. The referenced service account must exist in the service's namespace.
       --tag strings                       Set tag (format: --tag revisionRef=tagName) where revisionRef can be a revision or '@latest' string representing latest ready revision. This flag can be specified multiple times.
       --target string                     Work on local directory instead of a remote cluster (experimental)
-      --timeout int                       duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying (default 300)
+      --timeout int                       Duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying (default 300)
       --user int                          The user ID to run the container (e.g., 1001).
       --volume stringArray                Add a volume from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret: or sc:). Example: --volume myvolume=cm:myconfigmap or --volume myvolume=secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --volume myvolume-.
       --wait                              Wait for 'service create' operation to be completed. (default true)

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -95,6 +95,7 @@ kn service create NAME --image IMAGE
       --service-account string            Service account name to set. An empty argument ("") clears the service account. The referenced service account must exist in the service's namespace.
       --tag strings                       Set tag (format: --tag revisionRef=tagName) where revisionRef can be a revision or '@latest' string representing latest ready revision. This flag can be specified multiple times.
       --target string                     Work on local directory instead of a remote cluster (experimental)
+      --timeout int                       duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying (default 300)
       --user int                          The user ID to run the container (e.g., 1001).
       --volume stringArray                Add a volume from a ConfigMap (prefix cm: or config-map:) or a Secret (prefix secret: or sc:). Example: --volume myvolume=cm:myconfigmap or --volume myvolume=secret:mysecret. You can use this flag multiple times. To unset a ConfigMap/Secret reference, append "-" to the name, e.g. --volume myvolume-.
       --wait                              Wait for 'service create' operation to be completed. (default true)

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -82,6 +82,7 @@ kn service update NAME
       --service-account string            Service account name to set. An empty argument ("") clears the service account. The referenced service account must exist in the service's namespace.
       --tag strings                       Set tag (format: --tag revisionRef=tagName) where revisionRef can be a revision or '@latest' string representing latest ready revision. This flag can be specified multiple times.
       --target string                     Work on local directory instead of a remote cluster (experimental)
+      --timeout int                       Duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying (default 300)
       --traffic strings                   Set traffic distribution (format: --traffic revisionRef=percent) where revisionRef can be a revision or a tag or '@latest' string representing latest ready revision. This flag can be given multiple times with percent summing up to 100%.
       --untag strings                     Untag revision (format: --untag tagName). This flag can be specified multiple times.
       --user int                          The user ID to run the container (e.g., 1001).

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -220,7 +220,7 @@ func (p *ConfigurationEditFlags) AddCreateFlags(command *cobra.Command) {
 			"any number of times to set multiple labels.")
 	p.markFlagMakesRevision("label")
 	command.Flags().Int64Var(&p.TimeoutSeconds, "timeout", config.DefaultRevisionTimeoutSeconds,
-		"duration in seconds that the request routing layer will wait for a request delivered to a "+""+
+		"Duration in seconds that the request routing layer will wait for a request delivered to a "+""+
 			"container to begin replying")
 	p.markFlagMakesRevision("timeout")
 }

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -54,6 +54,7 @@ type ConfigurationEditFlags struct {
 	AnnotationsRevision []string
 	ClusterLocal        bool
 	ScaleInit           int
+	TimeoutSeconds      int64
 
 	// Preferences about how to do the action.
 	LockToDigest         bool
@@ -217,6 +218,8 @@ func (p *ConfigurationEditFlags) AddCreateFlags(command *cobra.Command) {
 		"Labels to set for both Service and Revision. name=value; you may provide this flag "+
 			"any number of times to set multiple labels.")
 	p.markFlagMakesRevision("label")
+	command.Flags().Int64Var(&p.TimeoutSeconds, "timeout", 300, "duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying")
+	p.markFlagMakesRevision("timeout")
 }
 
 // Apply mutates the given service according to the flags in the command.

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -21,9 +21,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"knative.dev/serving/pkg/apis/config"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/serving/pkg/apis/config"
 
 	knflags "knative.dev/client/pkg/kn/flags"
 	servinglib "knative.dev/client/pkg/serving"
@@ -172,6 +171,11 @@ func (p *ConfigurationEditFlags) addSharedFlags(command *cobra.Command) {
 
 	command.Flags().IntVar(&p.ScaleInit, "scale-init", 0, "Initial number of replicas with which a service starts. Can be 0 or a positive integer.")
 	p.markFlagMakesRevision("scale-init")
+
+	command.Flags().Int64Var(&p.TimeoutSeconds, "timeout", config.DefaultRevisionTimeoutSeconds,
+		"Duration in seconds that the request routing layer will wait for a request delivered to a "+""+
+			"container to begin replying")
+	p.markFlagMakesRevision("timeout")
 }
 
 // AddUpdateFlags adds the flags specific to update.
@@ -219,10 +223,6 @@ func (p *ConfigurationEditFlags) AddCreateFlags(command *cobra.Command) {
 		"Labels to set for both Service and Revision. name=value; you may provide this flag "+
 			"any number of times to set multiple labels.")
 	p.markFlagMakesRevision("label")
-	command.Flags().Int64Var(&p.TimeoutSeconds, "timeout", config.DefaultRevisionTimeoutSeconds,
-		"Duration in seconds that the request routing layer will wait for a request delivered to a "+""+
-			"container to begin replying")
-	p.markFlagMakesRevision("timeout")
 }
 
 // Apply mutates the given service according to the flags in the command.
@@ -454,6 +454,10 @@ func (p *ConfigurationEditFlags) Apply(
 		if err != nil {
 			return err
 		}
+	}
+
+	if cmd.Flags().Changed("timeout") {
+		service.Spec.Template.Spec.TimeoutSeconds = &p.TimeoutSeconds
 	}
 
 	return nil

--- a/pkg/kn/commands/service/configuration_edit_flags.go
+++ b/pkg/kn/commands/service/configuration_edit_flags.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"knative.dev/serving/pkg/apis/config"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -218,7 +219,9 @@ func (p *ConfigurationEditFlags) AddCreateFlags(command *cobra.Command) {
 		"Labels to set for both Service and Revision. name=value; you may provide this flag "+
 			"any number of times to set multiple labels.")
 	p.markFlagMakesRevision("label")
-	command.Flags().Int64Var(&p.TimeoutSeconds, "timeout", 300, "duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying")
+	command.Flags().Int64Var(&p.TimeoutSeconds, "timeout", config.DefaultRevisionTimeoutSeconds,
+		"duration in seconds that the request routing layer will wait for a request delivered to a "+""+
+			"container to begin replying")
 	p.markFlagMakesRevision("timeout")
 }
 

--- a/pkg/kn/commands/service/create.go
+++ b/pkg/kn/commands/service/create.go
@@ -265,6 +265,7 @@ func constructService(cmd *cobra.Command, editFlags ConfigurationEditFlags, name
 		},
 	}
 	service.Spec.Template.Spec.Containers = []corev1.Container{{}}
+	service.Spec.Template.Spec.TimeoutSeconds = &editFlags.TimeoutSeconds
 
 	err := editFlags.Apply(&service, nil, cmd)
 	if err != nil {

--- a/pkg/kn/commands/service/create.go
+++ b/pkg/kn/commands/service/create.go
@@ -265,7 +265,6 @@ func constructService(cmd *cobra.Command, editFlags ConfigurationEditFlags, name
 		},
 	}
 	service.Spec.Template.Spec.Containers = []corev1.Container{{}}
-	service.Spec.Template.Spec.TimeoutSeconds = &editFlags.TimeoutSeconds
 
 	err := editFlags.Apply(&service, nil, cmd)
 	if err != nil {

--- a/pkg/kn/commands/service/create_mock_test.go
+++ b/pkg/kn/commands/service/create_mock_test.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"knative.dev/serving/pkg/apis/autoscaling"
-	"knative.dev/serving/pkg/apis/config"
 
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -480,8 +479,6 @@ func getService(name string) *servingv1.Service {
 		},
 	}}
 
-	var defaultTimeout int64 = config.DefaultRevisionTimeoutSeconds
-	service.Spec.Template.Spec.TimeoutSeconds = &defaultTimeout
 	return service
 }
 

--- a/pkg/kn/commands/service/create_mock_test.go
+++ b/pkg/kn/commands/service/create_mock_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"knative.dev/serving/pkg/apis/autoscaling"
+	"knative.dev/serving/pkg/apis/config"
 
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -478,6 +479,9 @@ func getService(name string) *servingv1.Service {
 			Requests: corev1.ResourceList{},
 		},
 	}}
+
+	var defaultTimeout int64 = config.DefaultRevisionTimeoutSeconds
+	service.Spec.Template.Spec.TimeoutSeconds = &defaultTimeout
 	return service
 }
 

--- a/pkg/kn/commands/service/create_test.go
+++ b/pkg/kn/commands/service/create_test.go
@@ -193,6 +193,17 @@ func TestServiceCreateCommand(t *testing.T) {
 	assert.DeepEqual(t, template.Spec.Containers[0].Command, []string{"sh", "/app/start.sh"})
 }
 
+func TestServiceCreateTimeout(t *testing.T) {
+	action, created, _, err := fakeServiceCreate([]string{
+		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz", "--timeout", "2"}, false)
+	assert.NilError(t, err)
+	assert.Assert(t, action.Matches("create", "services"))
+
+	timeoutSeconds := *created.Spec.Template.Spec.TimeoutSeconds
+	assert.NilError(t, err)
+	assert.DeepEqual(t, int64(2), timeoutSeconds)
+}
+
 func TestServiceCreateArg(t *testing.T) {
 	action, created, _, err := fakeServiceCreate([]string{
 		"service", "create", "foo", "--image", "gcr.io/foo/bar:baz",


### PR DESCRIPTION
## Description

Add `--timeout` option which will set the field, `timeoutInSeconds` in service spec. 

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Added the flag


## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #1181 

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
