### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -36,6 +36,10 @@
 | Added subpath functionality to --mount flag
 | https://github.com/knative/client/pull/1655[#1655]
 
+| 🐣
+| Use `T.TempDir` to create temporary test directory
+| https://github.com/knative/client/pull/1660[#1660]
+
 |===
 ## v1.3.0 (2022-03-08)
 [cols="1,10,3", options="header", width="100%"]

--- a/pkg/kn/commands/completion_helper_test.go
+++ b/pkg/kn/commands/completion_helper_test.go
@@ -16,7 +16,6 @@ package commands
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -703,8 +702,6 @@ func TestResourceNameCompletionFuncRevision(t *testing.T) {
 
 func TestResourceNameCompletionFuncGitOps(t *testing.T) {
 	tempDir := setupTempDir(t)
-	assert.Assert(t, tempDir != "")
-	defer os.RemoveAll(tempDir)
 
 	completionFunc := ResourceNameCompletionFunc(knParams)
 
@@ -1594,11 +1591,10 @@ func getResourceCommandWithTestSubcommand(resource string, addNamespace, addSubc
 }
 
 func setupTempDir(t *testing.T) string {
-	tempDir, err := ioutil.TempDir("", "test-dir")
-	assert.NilError(t, err)
+	tempDir := t.TempDir()
 
 	svcPath := path.Join(tempDir, "test-ns", "ksvc")
-	err = os.MkdirAll(svcPath, 0700)
+	err := os.MkdirAll(svcPath, 0700)
 	assert.NilError(t, err)
 
 	for i, testSvc := range []servingv1.Service{testSvc1, testSvc2, testSvc3} {

--- a/pkg/kn/commands/namespaced_test.go
+++ b/pkg/kn/commands/namespaced_test.go
@@ -139,13 +139,11 @@ func TestGetNamespaceAllNamespacesNotDefined(t *testing.T) {
 }
 
 func TestGetNamespaceFallback(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "kn-unit-tests")
-	defer os.RemoveAll(tempDir)
-	assert.NilError(t, err)
+	tempDir := t.TempDir()
 
 	t.Run("MockConfig", func(t *testing.T) {
 		tempFile := filepath.Join(tempDir, "mock")
-		err = ioutil.WriteFile(tempFile, []byte(BASIC_KUBECONFIG), test.FileModeReadWrite)
+		err := ioutil.WriteFile(tempFile, []byte(BASIC_KUBECONFIG), test.FileModeReadWrite)
 		assert.NilError(t, err)
 
 		kp := &KnParams{KubeCfgPath: tempFile}
@@ -163,7 +161,7 @@ func TestGetNamespaceFallback(t *testing.T) {
 
 	t.Run("EmptyConfig", func(t *testing.T) {
 		tempFile := filepath.Join(tempDir, "empty")
-		err = ioutil.WriteFile(tempFile, []byte(""), test.FileModeReadWrite)
+		err := ioutil.WriteFile(tempFile, []byte(""), test.FileModeReadWrite)
 		assert.NilError(t, err)
 
 		kp := &KnParams{KubeCfgPath: tempFile}
@@ -190,14 +188,12 @@ func TestGetNamespaceFallback(t *testing.T) {
 }
 
 func TestCurrentNamespace(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "kn-unit-tests")
-	defer os.RemoveAll(tempDir)
-	assert.NilError(t, err)
+	tempDir := t.TempDir()
 
 	t.Run("EmptyConfig", func(t *testing.T) {
 		// Invalid kubeconfig
 		tempFile := filepath.Join(tempDir, "empty")
-		err = ioutil.WriteFile(tempFile, []byte(""), test.FileModeReadWrite)
+		err := ioutil.WriteFile(tempFile, []byte(""), test.FileModeReadWrite)
 		assert.NilError(t, err)
 
 		kp := &KnParams{KubeCfgPath: tempFile}
@@ -234,7 +230,7 @@ func TestCurrentNamespace(t *testing.T) {
 	t.Run("MockConfig", func(t *testing.T) {
 		// Fallback to "default" namespace from mock kubeconfig
 		tempFile := filepath.Join(tempDir, "mock")
-		err = ioutil.WriteFile(tempFile, []byte(BASIC_KUBECONFIG), test.FileModeReadWrite)
+		err := ioutil.WriteFile(tempFile, []byte(BASIC_KUBECONFIG), test.FileModeReadWrite)
 		assert.NilError(t, err)
 		kp := &KnParams{KubeCfgPath: tempFile}
 		actual, err := kp.CurrentNamespace()

--- a/pkg/kn/commands/plugin/list_test.go
+++ b/pkg/kn/commands/plugin/list_test.go
@@ -133,8 +133,7 @@ func TestPluginListExtendingBuiltinCommandGroup(t *testing.T) {
 // Private
 
 func prepareTestSetup(t *testing.T, args ...interface{}) (string, func()) {
-	tmpPathDir, err := ioutil.TempDir("", "plugin_list")
-	assert.NilError(t, err)
+	tmpPathDir := t.TempDir()
 
 	// Prepare configuration to for our test
 	oldConfig := config.GlobalConfig
@@ -151,7 +150,6 @@ func prepareTestSetup(t *testing.T, args ...interface{}) (string, func()) {
 
 	return tmpPathDir, func() {
 		config.GlobalConfig = oldConfig
-		os.RemoveAll(tmpPathDir)
 	}
 }
 

--- a/pkg/kn/commands/service/create_test.go
+++ b/pkg/kn/commands/service/create_test.go
@@ -894,9 +894,7 @@ func TestServiceCreateFromFile(t *testing.T) {
 }
 
 func testWithServiceFiles(t *testing.T, testFunction func(t *testing.T, file string)) {
-	tempDir, err := ioutil.TempDir("", "kn-file")
-	defer os.RemoveAll(tempDir)
-	assert.NilError(t, err)
+	tempDir := t.TempDir()
 
 	for _, d := range []struct {
 		filename string
@@ -910,7 +908,7 @@ func testWithServiceFiles(t *testing.T, testFunction func(t *testing.T, file str
 		},
 	} {
 		tempFile := filepath.Join(tempDir, d.filename)
-		err = ioutil.WriteFile(tempFile, []byte(d.content), os.FileMode(0666))
+		err := ioutil.WriteFile(tempFile, []byte(d.content), os.FileMode(0666))
 		assert.NilError(t, err)
 		testFunction(t, tempFile)
 	}
@@ -941,14 +939,12 @@ func TestServiceCreateFileError(t *testing.T) {
 }
 
 func TestServiceCreateInvalidDataJSON(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "kn-file")
-	defer os.RemoveAll(tempDir)
-	assert.NilError(t, err)
+	tempDir := t.TempDir()
 	tempFile := filepath.Join(tempDir, "invalid.json")
 
 	// Double curly bracket at the beginning of file
 	invalidData := strings.Replace(serviceJSON, "{\n", "{{\n", 1)
-	err = ioutil.WriteFile(tempFile, []byte(invalidData), os.FileMode(0666))
+	err := ioutil.WriteFile(tempFile, []byte(invalidData), os.FileMode(0666))
 	assert.NilError(t, err)
 	_, _, _, err = fakeServiceCreate([]string{"service", "create", "foo", "--filename", tempFile}, false)
 	assert.Assert(t, util.ContainsAll(err.Error(), "invalid", "character", "'{'", "beginning"))
@@ -969,14 +965,12 @@ func TestServiceCreateInvalidDataJSON(t *testing.T) {
 }
 
 func TestServiceCreateInvalidDataYAML(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "kn-file")
-	defer os.RemoveAll(tempDir)
-	assert.NilError(t, err)
+	tempDir := t.TempDir()
 	tempFile := filepath.Join(tempDir, "invalid.yaml")
 
 	// Remove dash
 	invalidData := strings.Replace(serviceYAML, "- image", "image", 1)
-	err = ioutil.WriteFile(tempFile, []byte(invalidData), os.FileMode(0666))
+	err := ioutil.WriteFile(tempFile, []byte(invalidData), os.FileMode(0666))
 	assert.NilError(t, err)
 	_, _, _, err = fakeServiceCreate([]string{"service", "create", "foo", "--filename", tempFile}, false)
 	assert.Assert(t, util.ContainsAll(err.Error(), "mapping", "values", "not", "allowed"))
@@ -997,12 +991,10 @@ func TestServiceCreateInvalidDataYAML(t *testing.T) {
 }
 
 func TestServiceCreateFromYAMLWithOverride(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "kn-file")
-	defer os.RemoveAll(tempDir)
-	assert.NilError(t, err)
+	tempDir := t.TempDir()
 
 	tempFile := filepath.Join(tempDir, "service.yaml")
-	err = ioutil.WriteFile(tempFile, []byte(serviceYAML), os.FileMode(0666))
+	err := ioutil.WriteFile(tempFile, []byte(serviceYAML), os.FileMode(0666))
 	assert.NilError(t, err)
 	// Merge env vars
 	expectedEnvVars := map[string]string{
@@ -1077,12 +1069,10 @@ func TestServiceCreateFromYAMLWithOverride(t *testing.T) {
 }
 
 func TestServiceCreateFromYAMLWithOverrideError(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "kn-file")
-	defer os.RemoveAll(tempDir)
-	assert.NilError(t, err)
+	tempDir := t.TempDir()
 
 	tempFile := filepath.Join(tempDir, "service.yaml")
-	err = ioutil.WriteFile(tempFile, []byte(serviceYAML), os.FileMode(0666))
+	err := ioutil.WriteFile(tempFile, []byte(serviceYAML), os.FileMode(0666))
 	assert.NilError(t, err)
 
 	_, _, _, err = fakeServiceCreate([]string{

--- a/pkg/kn/commands/service/import_test.go
+++ b/pkg/kn/commands/service/import_test.go
@@ -44,9 +44,8 @@ func TestServiceImportFilenameError(t *testing.T) {
 }
 
 func TestServiceImportExistError(t *testing.T) {
-	file, err := generateFile([]byte(exportYAML))
+	file, err := generateFile(t, []byte(exportYAML))
 	assert.NilError(t, err)
-	defer os.RemoveAll(filepath.Dir(file))
 
 	client := knclient.NewMockKnServiceClient(t)
 	r := client.Recorder()
@@ -60,9 +59,8 @@ func TestServiceImportExistError(t *testing.T) {
 }
 
 func TestServiceImport(t *testing.T) {
-	file, err := generateFile([]byte(exportYAML))
+	file, err := generateFile(t, []byte(exportYAML))
 	assert.NilError(t, err)
-	defer os.RemoveAll(filepath.Dir(file))
 
 	client := knclient.NewMockKnServiceClient(t)
 	r := client.Recorder()
@@ -80,9 +78,8 @@ func TestServiceImport(t *testing.T) {
 }
 
 func TestServiceImportNoWait(t *testing.T) {
-	file, err := generateFile([]byte(exportYAML))
+	file, err := generateFile(t, []byte(exportYAML))
 	assert.NilError(t, err)
-	defer os.RemoveAll(filepath.Dir(file))
 
 	client := knclient.NewMockKnServiceClient(t)
 	r := client.Recorder()
@@ -98,9 +95,8 @@ func TestServiceImportNoWait(t *testing.T) {
 }
 
 func TestServiceImportWitRevisions(t *testing.T) {
-	file, err := generateFile([]byte(exportWithRevisionsYAML))
+	file, err := generateFile(t, []byte(exportWithRevisionsYAML))
 	assert.NilError(t, err)
-	defer os.RemoveAll(filepath.Dir(file))
 
 	client := knclient.NewMockKnServiceClient(t)
 	r := client.Recorder()
@@ -120,14 +116,11 @@ func TestServiceImportWitRevisions(t *testing.T) {
 	r.Validate()
 }
 
-func generateFile(fileContent []byte) (string, error) {
-	tempDir, err := ioutil.TempDir("", "kn-file")
-	if err != nil {
-		return "", err
-	}
+func generateFile(t *testing.T, fileContent []byte) (string, error) {
+	tempDir := t.TempDir()
 
 	tempFile := filepath.Join(tempDir, "import.yaml")
-	if err = ioutil.WriteFile(tempFile, fileContent, os.FileMode(0666)); err != nil {
+	if err := ioutil.WriteFile(tempFile, fileContent, os.FileMode(0666)); err != nil {
 		return "", err
 	}
 	return tempFile, nil

--- a/pkg/kn/commands/types_test.go
+++ b/pkg/kn/commands/types_test.go
@@ -121,11 +121,9 @@ type typeTestCase struct {
 func TestGetClientConfig(t *testing.T) {
 	multiConfigs := fmt.Sprintf("%s%s%s", "/testing/assets/kube-config-01.yml", string(os.PathListSeparator), "/testing/assets/kube-config-02.yml")
 
-	tempDir, err := ioutil.TempDir("", "kn-unit-tests")
-	defer os.RemoveAll(tempDir)
-	assert.NilError(t, err)
+	tempDir := t.TempDir()
 	tempFile := filepath.Join(tempDir, "mock")
-	err = ioutil.WriteFile(tempFile, []byte(BASIC_KUBECONFIG), test.FileModeReadWrite)
+	err := ioutil.WriteFile(tempFile, []byte(BASIC_KUBECONFIG), test.FileModeReadWrite)
 	assert.NilError(t, err)
 
 	for _, tc := range []typeTestCase{

--- a/pkg/kn/config/config_test.go
+++ b/pkg/kn/config/config_test.go
@@ -109,8 +109,7 @@ sink:
 }
 
 func setupConfig(t *testing.T, configContent string) (string, func()) {
-	tmpDir, err := ioutil.TempDir("", "configContent")
-	assert.NilError(t, err)
+	tmpDir := t.TempDir()
 
 	// Avoid to be fooled by the things in the the real homedir
 	oldHome := os.Getenv("HOME")
@@ -124,7 +123,7 @@ func setupConfig(t *testing.T, configContent string) (string, func()) {
 	if configContent != "" {
 		cfgFile = filepath.Join(tmpDir, "config.yaml")
 		os.Args = []string{"kn", "--config", cfgFile}
-		err = ioutil.WriteFile(cfgFile, []byte(configContent), 0644)
+		err := ioutil.WriteFile(cfgFile, []byte(configContent), 0644)
 		assert.NilError(t, err)
 	}
 
@@ -138,7 +137,6 @@ func setupConfig(t *testing.T, configContent string) (string, func()) {
 
 	return cfgFile, func() {
 		// Cleanup everything
-		os.RemoveAll(tmpDir)
 		os.Setenv("HOME", oldHome)
 		os.Args = backupArgs
 		bootstrapDefaults = initDefaults()

--- a/pkg/kn/flags/podspec_helper_test.go
+++ b/pkg/kn/flags/podspec_helper_test.go
@@ -879,9 +879,7 @@ containers:
 	assert.NilError(t, err)
 	assert.Equal(t, len(fromFile.Containers), 2)
 
-	tempDir, err := ioutil.TempDir("", "kn-file")
-	defer os.RemoveAll(tempDir)
-	assert.NilError(t, err)
+	tempDir := t.TempDir()
 	fileName := filepath.Join(tempDir, "container.yaml")
 	ioutil.WriteFile(fileName, []byte(rawInput), test.FileModeReadWrite)
 	fromFile, err = decodeContainersFromFile(fileName)

--- a/pkg/kn/flags/podspec_test.go
+++ b/pkg/kn/flags/podspec_test.go
@@ -244,8 +244,7 @@ containers:
 			"Input:file",
 			rawInput,
 			func(data string) string {
-				tempDir, err := ioutil.TempDir("", "kn-file")
-				assert.NilError(t, err)
+				tempDir := t.TempDir()
 				fileName := filepath.Join(tempDir, "container.yaml")
 				ioutil.WriteFile(fileName, []byte(data), test.FileModeReadWrite)
 				return fileName

--- a/pkg/kn/plugin/manager_test.go
+++ b/pkg/kn/plugin/manager_test.go
@@ -357,8 +357,7 @@ func setup(t *testing.T) testContext {
 }
 
 func setupWithPathLookup(t *testing.T, lookupInPath bool) testContext {
-	tmpPathDir, err := ioutil.TempDir("", "plugin_list")
-	assert.NilError(t, err)
+	tmpPathDir := t.TempDir()
 	return testContext{
 		pluginsDir:    tmpPathDir,
 		pluginManager: NewManager(tmpPathDir, lookupInPath),
@@ -388,13 +387,11 @@ func executePlugin(plugin Plugin, args []string) (string, error) {
 
 // Prepare a directory and set the path to this directory
 func preparePathDirectory(t *testing.T) (string, func()) {
-	tmpPathDir, err := ioutil.TempDir("", "plugin_path")
-	assert.NilError(t, err)
+	tmpPathDir := t.TempDir()
 
 	oldPath := os.Getenv("PATH")
 	os.Setenv("PATH", fmt.Sprintf("%s%c%s", tmpPathDir, os.PathListSeparator, "fast-forward-this-year-plz"))
 	return tmpPathDir, func() {
-		os.RemoveAll(tmpPathDir)
 		os.Setenv("PATH", oldPath)
 	}
 }

--- a/pkg/serving/v1/gitops_test.go
+++ b/pkg/serving/v1/gitops_test.go
@@ -16,8 +16,6 @@ package v1
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -35,12 +33,9 @@ import (
 )
 
 func TestGitOpsOperations(t *testing.T) {
-	c1TempDir, err := ioutil.TempDir("", "kn-files-cluster1")
-	assert.NilError(t, err)
-	c2TempDir, err := ioutil.TempDir("", "kn-files-cluster2")
-	assert.NilError(t, err)
-	defer os.RemoveAll(c1TempDir)
-	defer os.RemoveAll(c2TempDir)
+	c1TempDir := t.TempDir()
+	c2TempDir := t.TempDir()
+
 	// create clients
 	fooclient := NewKnServingGitOpsClient("foo-ns", c1TempDir)
 	bazclient := NewKnServingGitOpsClient("baz-ns", c1TempDir)
@@ -141,9 +136,7 @@ func TestGitOpsOperations(t *testing.T) {
 }
 
 func TestGitOpsSingleFile(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "singlefile")
-	assert.NilError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	// create clients
 	fooclient := NewKnServingGitOpsClient("", filepath.Join(tmpDir, "test.yaml"))
 	barclient := NewKnServingGitOpsClient("", filepath.Join(tmpDir, "test.yml"))

--- a/test/e2e/channels_test.go
+++ b/test/e2e/channels_test.go
@@ -18,8 +18,6 @@
 package e2e
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -42,21 +40,14 @@ type channelTypeAliasTestConfig struct {
 	knConfigPath string
 }
 
-func (tc *channelTypeAliasTestConfig) setup() error {
+func (tc *channelTypeAliasTestConfig) setup(t *testing.T) error {
 	var err error
-	tc.knConfigDir, err = ioutil.TempDir("", "kn-channel-config")
-	if err != nil {
-		return err
-	}
+	tc.knConfigDir = t.TempDir()
 	tc.knConfigPath, err = test.CreateFile("config.yaml", knChannelTypesConfigContent, tc.knConfigDir, test.FileModeReadWrite)
 	if err != nil {
 		return err
 	}
 	return nil
-}
-
-func (tc *channelTypeAliasTestConfig) teardown() {
-	os.RemoveAll(tc.knConfigDir)
 }
 
 func TestChannels(t *testing.T) {
@@ -71,8 +62,7 @@ func TestChannels(t *testing.T) {
 	defer r.DumpIfFailed()
 
 	tc := channelTypeAliasTestConfig{}
-	assert.NilError(t, tc.setup())
-	defer tc.teardown()
+	assert.NilError(t, tc.setup(t))
 
 	t.Log("Create a channel with default messaging layer settings")
 	test.ChannelCreate(r, "c0")

--- a/test/e2e/extra_containers_test.go
+++ b/test/e2e/extra_containers_test.go
@@ -21,8 +21,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -47,9 +45,7 @@ func TestMultiContainers(t *testing.T) {
 	r := test.NewKnRunResultCollector(t, it)
 	defer r.DumpIfFailed()
 
-	tempDir, err := ioutil.TempDir("", "kn-file")
-	defer os.RemoveAll(tempDir)
-	assert.NilError(t, err)
+	tempDir := t.TempDir()
 
 	t.Log("Creating a multicontainer service from file")
 	container := addContainer(r, "sidecar", pkgtest.ImagePath("sidecarcontainer"))

--- a/test/e2e/service_file_test.go
+++ b/test/e2e/service_file_test.go
@@ -19,8 +19,6 @@ package e2e
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -86,9 +84,7 @@ func TestServiceCreateFromFile(t *testing.T) {
 	r := test.NewKnRunResultCollector(t, it)
 	defer r.DumpIfFailed()
 
-	tempDir, err := ioutil.TempDir("", "kn-file")
-	defer os.RemoveAll(tempDir)
-	assert.NilError(t, err)
+	tempDir := t.TempDir()
 
 	test.CreateFile("foo.json", fmt.Sprintf(ServiceJSON, pkgtest.ImagePath("helloworld")), tempDir, test.FileModeReadWrite)
 	test.CreateFile("foo.yaml", fmt.Sprintf(ServiceYAML, pkgtest.ImagePath("helloworld")), tempDir, test.FileModeReadWrite)

--- a/test/e2e/service_import_test.go
+++ b/test/e2e/service_import_test.go
@@ -19,7 +19,6 @@ package e2e
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -39,9 +38,7 @@ func TestServiceImport(t *testing.T) {
 	r := test.NewKnRunResultCollector(t, it)
 	defer r.DumpIfFailed()
 
-	tempDir, err := ioutil.TempDir("", "kn-file")
-	defer os.RemoveAll(tempDir)
-	assert.NilError(t, err)
+	tempDir := t.TempDir()
 
 	t.Log("import service foo with revision")
 	testFile := filepath.Join(tempDir, "foo-with-revisions")

--- a/test/e2e/sinkprefix_test.go
+++ b/test/e2e/sinkprefix_test.go
@@ -18,8 +18,6 @@
 package e2e
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -41,21 +39,14 @@ type sinkprefixTestConfig struct {
 	knConfigPath string
 }
 
-func (tc *sinkprefixTestConfig) setup() error {
+func (tc *sinkprefixTestConfig) setup(t *testing.T) error {
 	var err error
-	tc.knConfigDir, err = ioutil.TempDir("", "kn1-config")
-	if err != nil {
-		return err
-	}
+	tc.knConfigDir = t.TempDir()
 	tc.knConfigPath, err = test.CreateFile("config.yaml", KnConfigContent, tc.knConfigDir, test.FileModeReadWrite)
 	if err != nil {
 		return err
 	}
 	return nil
-}
-
-func (tc *sinkprefixTestConfig) teardown() {
-	os.RemoveAll(tc.knConfigDir)
 }
 
 func TestSinkPrefixConfig(t *testing.T) {
@@ -70,8 +61,7 @@ func TestSinkPrefixConfig(t *testing.T) {
 	defer r.DumpIfFailed()
 
 	tc := sinkprefixTestConfig{}
-	assert.NilError(t, tc.setup())
-	defer tc.teardown()
+	assert.NilError(t, tc.setup(t))
 
 	t.Log("Creating a testservice")
 	test.ServiceCreate(r, "testsvc0")


### PR DESCRIPTION
## Description

A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	require.NoError(t, err)
	defer require.NoError(os.RemoveAll(tmpDir))

	// now
	tmpDir := t.TempDir()
}
```

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Replace `ioutil.TempDir` with `t.TempDir`
* Remove redundant `os.RemoveAll(tmpDir)` since the temporary directory will be removed automatically once the test complete.

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

/lint
