### PR TITLE
Mark --inject-broker flag as deprecated

### DIFF
--- a/docs/cmd/kn_trigger_create.md
+++ b/docs/cmd/kn_trigger_create.md
@@ -23,7 +23,6 @@ kn trigger create NAME --sink SINK
       --broker string      Name of the Broker which the trigger associates with. (default "default")
       --filter strings     Key-value pair for exact CloudEvent attribute matching against incoming events, e.g type=dev.knative.foo
   -h, --help               help for create
-      --inject-broker      Create new broker with name default through common annotation
   -n, --namespace string   Specify the namespace to operate in.
   -s, --sink string        Addressable sink for events. You can specify a broker, channel, Knative service or URI. Examples: '--sink broker:nest' for a broker 'nest', '--sink channel:pipe' for a channel 'pipe', '--sink ksvc:mysvc:mynamespace' for a Knative service 'mysvc' in another namespace 'mynamespace', '--sink https://event.receiver.uri' for an URI with an 'http://' or 'https://' schema, '--sink ksvc:receiver' or simply '--sink receiver' for a Knative service 'receiver' in the current namespace. If a prefix is not provided, it is considered as a Knative service in the current namespace. If referring to a Knative service in another namespace, 'ksvc:name:namespace' combination must be provided explicitly.
 ```

--- a/docs/cmd/kn_trigger_update.md
+++ b/docs/cmd/kn_trigger_update.md
@@ -27,7 +27,6 @@ kn trigger update NAME
       --broker string      Name of the Broker which the trigger associates with. (default "default")
       --filter strings     Key-value pair for exact CloudEvent attribute matching against incoming events, e.g type=dev.knative.foo
   -h, --help               help for update
-      --inject-broker      Create new broker with name default through common annotation
   -n, --namespace string   Specify the namespace to operate in.
   -s, --sink string        Addressable sink for events. You can specify a broker, channel, Knative service or URI. Examples: '--sink broker:nest' for a broker 'nest', '--sink channel:pipe' for a channel 'pipe', '--sink ksvc:mysvc:mynamespace' for a Knative service 'mysvc' in another namespace 'mynamespace', '--sink https://event.receiver.uri' for an URI with an 'http://' or 'https://' schema, '--sink ksvc:receiver' or simply '--sink receiver' for a Knative service 'receiver' in the current namespace. If a prefix is not provided, it is considered as a Knative service in the current namespace. If referring to a Knative service in another namespace, 'ksvc:name:namespace' combination must be provided explicitly.
 ```

--- a/pkg/kn/commands/trigger/update_flags.go
+++ b/pkg/kn/commands/trigger/update_flags.go
@@ -51,6 +51,12 @@ func (f *TriggerUpdateFlags) GetUpdateFilters() (map[string]string, []string, er
 //Add is to set parameters
 func (f *TriggerUpdateFlags) Add(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Broker, "broker", "default", "Name of the Broker which the trigger associates with.")
+	// The Sugar controller was integrated into main Eventing controller. With that the default behavior was changed as well.
+	// Users need to configure 'Automatic Broker Creation' per linked docs.
+	// Deprecated in 1.4, remove in 1.6.
 	cmd.Flags().BoolVar(&f.InjectBroker, "inject-broker", false, "Create new broker with name default through common annotation")
+	cmd.Flags().MarkDeprecated("inject-broker", "effective since 1.4 and will be removed in 1.6 release. \n"+
+		"Please refer to 'Automatic Broker Creation' section for configuration options, "+
+		"https://knative.dev/docs/eventing/sugar/#automatic-broker-creation.")
 	cmd.Flags().StringSliceVar(&f.Filters, "filter", nil, "Key-value pair for exact CloudEvent attribute matching against incoming events, e.g type=dev.knative.foo")
 }


### PR DESCRIPTION
## Description

Per Eventing change in Sugar controller config, user need to enable the behavior.

@rhuss maybe we should considere adding label flag to trigger creation instread of hardcoded name. 

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Mark --inject-broker flag as deprecated

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #1629 

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->

```console
➜  client git:(pr/deprecate-inject-broker) kn trigger create broker-trigger --inject-broker --sink ksvc:broker-display --filter type=dev.knative.sources.ping
Flag --inject-broker has been deprecated, effective since 1.4 and will be removed in 1.6 release. 
Please refer to 'Automatic Broker Creation' section for configuration options, https://knative.dev/docs/eventing/sugar/#automatic-broker-creation.
```
