### PR TITLE
Cleanup sugar controller setup

### DIFF
--- a/test/common.sh
+++ b/test/common.sh
@@ -99,10 +99,8 @@ function knative_setup() {
   header "Installing Knative Eventing (${eventing_version})"
   if [ "${eventing_version}" = "latest" ]; then
     start_latest_knative_eventing
-    start_latest_eventing_sugar_controller
   else
     start_release_knative_eventing "${eventing_version}"
-    start_release_eventing_sugar_controller "${eventing_version}"
   fi
 }
 


### PR DESCRIPTION
## Description

Since Knative >= 1.4 standalone Sugar controller is integrated into main Eventing one. Currently it's producing harmless 404 error during E2E tests setup, but it might be confusing or break in the future. 

Integrations tests should pass without issues.

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* :broom: Cleanup sugear controller setups

/cc @rhuss @vyasgun 