### PR TITLE
Add release note section to PR template

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -16,6 +16,16 @@
 <!-- Please add the corresponding issue number which this pull request is about to fix -->
 Fixes #
 
+**Release Note**
+
+<!-- Enter your extended release note in the below block. If the PR requires
+additional action from users switching to the new release, include the string
+"action required". If no release note is required, write "NONE". -->
+
+```release-note
+
+```
+
 <!--
 Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.
 


### PR DESCRIPTION
## Description

Per release process, there's an action to collect and populate release description from PRs directly. I'd like to propose it as an addition to our current manual changelog update. Once evaluated we might want to drop one or the other.

Release notes action: https://github.com/knative/actions/blob/main/.github/workflows/release-notes.yaml
Example: https://github.com/knative/serving/releases/tag/knative-v1.5.0

/cc @rhuss @maximilien @navidshaikh 

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Add release note section to PR template

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
