### PR TITLE
remove defunct markdown linting variable

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -31,7 +31,6 @@
 # in the Kubernetes cluster, and all the tests will run against Knative
 # Serving / Eventing of this specific version.
 
-export DISABLE_MD_LINTING=1
 export PRESUBMIT_TEST_FAIL_FAST=1
 
 export GO111MODULE=on


### PR DESCRIPTION
## Description
Addresses https://github.com/knative/hack/issues/200

Removes a dead variable in the presubmit tests related to markdown linting
