### PR TITLE
Add check for PVC status in E2E tests

### DIFF
--- a/test/e2e/service_test.go
+++ b/test/e2e/service_test.go
@@ -240,11 +240,17 @@ func serviceCreateWithMount(r *test.KnRunResultCollector) {
 	assert.NilError(r.T(), err)
 	r.AssertNoError(out)
 
-	r.T().Log("update service with a new pvc mount")
-	out = r.KnTest().Kn().Run("service", "update", "test-svc", "--mount", "/mydir5=pvc:test-pvc")
-	r.AssertNoError(out)
+	_, err = kubectl.Run("wait", "--for=condition=Ready", "pvc/test-pvc", "--timeout=30s")
+	if err == nil {
+		r.T().Log("update service with a new pvc mount")
+		out = r.KnTest().Kn().Run("service", "update", "test-svc", "--mount", "/mydir5=pvc:test-pvc")
+		r.AssertNoError(out)
 
-	serviceDescribeMount(r, "test-svc", "/mydir", "key")
+		serviceDescribeMount(r, "test-svc", "/mydir", "key")
+	} else {
+		r.T().Log("PVC test skip due to unsatisfied PVC")
+	}
+
 }
 
 func getVolumeMountWithHostPath(svc *servingv1.Service, hostPath string) *v1.VolumeMount {

--- a/test/e2e/service_test.go
+++ b/test/e2e/service_test.go
@@ -240,7 +240,7 @@ func serviceCreateWithMount(r *test.KnRunResultCollector) {
 	assert.NilError(r.T(), err)
 	r.AssertNoError(out)
 
-	_, err = kubectl.Run("wait", "--for=condition=Ready", "pvc/test-pvc", "--timeout=30s")
+	_, err = kubectl.Run("wait", "--for='jsonpath={..status.phase}'=Bound", "pvc/test-pvc", "--timeout=30s")
 	if err == nil {
 		r.T().Log("update service with a new pvc mount")
 		out = r.KnTest().Kn().Run("service", "update", "test-svc", "--mount", "/mydir5=pvc:test-pvc")


### PR DESCRIPTION
## Description

Not every cluster might be ready to fulfill PVC. 

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* :broom: Add check for PVC status in E2E tests


## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
