### PR TITLE
Fix volume creation for PVC

### DIFF
--- a/pkg/kn/flags/podspec_helper.go
+++ b/pkg/kn/flags/podspec_helper.go
@@ -528,7 +528,7 @@ func updateVolume(volume *corev1.Volume, info *volumeSourceInfo) error {
 	case EmptyDirVolumeSourceType:
 		volume.EmptyDir = &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMedium(info.emptyDirMemoryType), SizeLimit: info.emptyDirSize}
 	case PVCVolumeSourceType:
-		volume.PersistentVolumeClaim = &corev1.PersistentVolumeClaimVolumeSource{ClaimName: info.volumeSourceName, ReadOnly: true}
+		volume.PersistentVolumeClaim = &corev1.PersistentVolumeClaimVolumeSource{ClaimName: info.volumeSourceName}
 	default:
 		return fmt.Errorf("Invalid VolumeSourceType")
 	}


### PR DESCRIPTION
## Description

When initializing volumes for flag usage like in E2E `--mount /mydir5=pvc:test-pvc`. We shouldn't probably enforce `readOnly: true` on the created volume PVC. We may end up with service stuck in initialization phase, because of underlying storage config, e.g. some volumes are being formatted first. 

Error from volume init:
```
  Warning  FailedMount             1s (x4 over 7s)  kubelet                  MountVolume.MountDevice failed for volume "pvc-1577f113-81c1-44f9-861f-5def40d13e8b" : cannot mount unformatted disk /dev/nvme2n1 as we are manipulating it in read-only mode
```

Former behavior:
```
        volumes:
        - name: mydir5-aa14be68
          persistentVolumeClaim:
            claimName: test-pvc
            readOnly: true
```
/cc @vyasgun @rhuss @skonto 


## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Fix volume creation for PVC

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix mounted PVC not to be created as read-only
```

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
/kind bug