### PR TITLE
Added gvr sink test cases and support to specify resource as singular/plural

### DIFF
--- a/pkg/kn/commands/flags/sink.go
+++ b/pkg/kn/commands/flags/sink.go
@@ -118,6 +118,9 @@ func (i *SinkFlags) ResolveSink(ctx context.Context, knclient clientdynamic.KnDy
 		}
 		parsedVersion, _ := schema.ParseGroupVersion(groupVersion)
 
+		if !strings.HasSuffix(kind, "s") {
+			kind = kind + "s"
+		}
 		typ = schema.GroupVersionResource{
 			Group:    parsedVersion.Group,
 			Version:  parsedVersion.Version,


### PR DESCRIPTION
## Description
Added gvr sink test cases and support to specify resource as singular/plural
<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Added 2 tests for singular/plural forms of pingsource resource type
* Added a negative test for an absent resource

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #1704 

Follow up for: https://github.com/knative/client/pull/1717
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add singular/plural support to `--sink` flag
```

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
