### PR TITLE
Fix release script version calculation

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -18,10 +18,10 @@
 # at https://github.com/knative/hack
 
 source $(dirname $0)/../vendor/knative.dev/hack/release.sh
-source $(dirname $0)/build-flags.sh
 
 function build_release() {
   # Env var exported by hack/build-flags.sh
+  source $(dirname $0)/build-flags.sh
   local ld_flags="${KN_BUILD_LD_FLAGS:-}"
 
   export CGO_ENABLED=0


### PR DESCRIPTION
## Description

This should fix display version for release. IMO the `build_flags.sh` script was sourced too soon, before release values (especially `${TAG}`) were properly populated.

/cc @rhuss 

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Fix release script version calculation


## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix release script version calculation
```

/kind bug

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
