### PR TITLE
cli options to enable user, uid, and group impersonation

### DIFF
--- a/docs/cmd/kn.md
+++ b/docs/cmd/kn.md
@@ -11,12 +11,14 @@ Find more information about Knative at: https://knative.dev
 ### Options
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-  -h, --help                help for kn
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+  -h, --help                   help for kn
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn.md
+++ b/docs/cmd/kn.md
@@ -13,6 +13,7 @@ Find more information about Knative at: https://knative.dev
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_broker.md
+++ b/docs/cmd/kn_broker.md
@@ -17,6 +17,7 @@ kn broker
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_broker.md
+++ b/docs/cmd/kn_broker.md
@@ -15,11 +15,13 @@ kn broker
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_broker_create.md
+++ b/docs/cmd/kn_broker_create.md
@@ -54,6 +54,7 @@ kn broker create NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_broker_create.md
+++ b/docs/cmd/kn_broker_create.md
@@ -52,11 +52,13 @@ kn broker create NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_broker_delete.md
+++ b/docs/cmd/kn_broker_delete.md
@@ -33,6 +33,7 @@ kn broker delete NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_broker_delete.md
+++ b/docs/cmd/kn_broker_delete.md
@@ -31,11 +31,13 @@ kn broker delete NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_broker_describe.md
+++ b/docs/cmd/kn_broker_describe.md
@@ -37,11 +37,13 @@ kn broker describe NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_broker_describe.md
+++ b/docs/cmd/kn_broker_describe.md
@@ -39,6 +39,7 @@ kn broker describe NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_broker_list.md
+++ b/docs/cmd/kn_broker_list.md
@@ -35,6 +35,7 @@ kn broker list
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_broker_list.md
+++ b/docs/cmd/kn_broker_list.md
@@ -33,11 +33,13 @@ kn broker list
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_broker_update.md
+++ b/docs/cmd/kn_broker_update.md
@@ -34,11 +34,13 @@ kn broker update NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_broker_update.md
+++ b/docs/cmd/kn_broker_update.md
@@ -36,6 +36,7 @@ kn broker update NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_channel.md
+++ b/docs/cmd/kn_channel.md
@@ -15,11 +15,13 @@ kn channel COMMAND
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_channel.md
+++ b/docs/cmd/kn_channel.md
@@ -17,6 +17,7 @@ kn channel COMMAND
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_channel_create.md
+++ b/docs/cmd/kn_channel_create.md
@@ -33,11 +33,13 @@ kn channel create NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_channel_create.md
+++ b/docs/cmd/kn_channel_create.md
@@ -35,6 +35,7 @@ kn channel create NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_channel_delete.md
+++ b/docs/cmd/kn_channel_delete.md
@@ -26,6 +26,7 @@ kn channel delete NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_channel_delete.md
+++ b/docs/cmd/kn_channel_delete.md
@@ -24,11 +24,13 @@ kn channel delete NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_channel_describe.md
+++ b/docs/cmd/kn_channel_describe.md
@@ -34,6 +34,7 @@ kn channel describe NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_channel_describe.md
+++ b/docs/cmd/kn_channel_describe.md
@@ -32,11 +32,13 @@ kn channel describe NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_channel_list-types.md
+++ b/docs/cmd/kn_channel_list-types.md
@@ -34,6 +34,7 @@ kn channel list-types
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_channel_list-types.md
+++ b/docs/cmd/kn_channel_list-types.md
@@ -32,11 +32,13 @@ kn channel list-types
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_channel_list.md
+++ b/docs/cmd/kn_channel_list.md
@@ -35,6 +35,7 @@ kn channel list
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_channel_list.md
+++ b/docs/cmd/kn_channel_list.md
@@ -33,11 +33,13 @@ kn channel list
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_completion.md
+++ b/docs/cmd/kn_completion.md
@@ -39,6 +39,7 @@ kn completion SHELL
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_completion.md
+++ b/docs/cmd/kn_completion.md
@@ -37,11 +37,13 @@ kn completion SHELL
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_container.md
+++ b/docs/cmd/kn_container.md
@@ -15,11 +15,13 @@ kn container COMMAND
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_container.md
+++ b/docs/cmd/kn_container.md
@@ -17,6 +17,7 @@ kn container COMMAND
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_container_add.md
+++ b/docs/cmd/kn_container_add.md
@@ -56,6 +56,7 @@ kn container add NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_container_add.md
+++ b/docs/cmd/kn_container_add.md
@@ -54,11 +54,13 @@ kn container add NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_domain.md
+++ b/docs/cmd/kn_domain.md
@@ -17,6 +17,7 @@ kn domain COMMAND
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_domain.md
+++ b/docs/cmd/kn_domain.md
@@ -15,11 +15,13 @@ kn domain COMMAND
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_domain_create.md
+++ b/docs/cmd/kn_domain_create.md
@@ -26,11 +26,13 @@ kn domain create NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_domain_create.md
+++ b/docs/cmd/kn_domain_create.md
@@ -28,6 +28,7 @@ kn domain create NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_domain_delete.md
+++ b/docs/cmd/kn_domain_delete.md
@@ -26,6 +26,7 @@ kn domain delete NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_domain_delete.md
+++ b/docs/cmd/kn_domain_delete.md
@@ -24,11 +24,13 @@ kn domain delete NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_domain_describe.md
+++ b/docs/cmd/kn_domain_describe.md
@@ -29,11 +29,13 @@ kn domain describe NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_domain_describe.md
+++ b/docs/cmd/kn_domain_describe.md
@@ -31,6 +31,7 @@ kn domain describe NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_domain_list.md
+++ b/docs/cmd/kn_domain_list.md
@@ -35,6 +35,7 @@ kn domain list
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_domain_list.md
+++ b/docs/cmd/kn_domain_list.md
@@ -33,11 +33,13 @@ kn domain list
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_domain_update.md
+++ b/docs/cmd/kn_domain_update.md
@@ -27,6 +27,7 @@ kn domain update NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_domain_update.md
+++ b/docs/cmd/kn_domain_update.md
@@ -25,11 +25,13 @@ kn domain update NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_eventtype.md
+++ b/docs/cmd/kn_eventtype.md
@@ -17,6 +17,7 @@ kn eventtype
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_eventtype.md
+++ b/docs/cmd/kn_eventtype.md
@@ -15,11 +15,13 @@ kn eventtype
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_eventtype_create.md
+++ b/docs/cmd/kn_eventtype_create.md
@@ -33,6 +33,7 @@ kn eventtype create
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_eventtype_create.md
+++ b/docs/cmd/kn_eventtype_create.md
@@ -31,11 +31,13 @@ kn eventtype create
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_eventtype_delete.md
+++ b/docs/cmd/kn_eventtype_delete.md
@@ -30,6 +30,7 @@ kn eventtype delete
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_eventtype_delete.md
+++ b/docs/cmd/kn_eventtype_delete.md
@@ -28,11 +28,13 @@ kn eventtype delete
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_eventtype_describe.md
+++ b/docs/cmd/kn_eventtype_describe.md
@@ -34,11 +34,13 @@ kn eventtype describe
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_eventtype_describe.md
+++ b/docs/cmd/kn_eventtype_describe.md
@@ -36,6 +36,7 @@ kn eventtype describe
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_eventtype_list.md
+++ b/docs/cmd/kn_eventtype_list.md
@@ -35,6 +35,7 @@ kn eventtype list
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_eventtype_list.md
+++ b/docs/cmd/kn_eventtype_list.md
@@ -33,11 +33,13 @@ kn eventtype list
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_options.md
+++ b/docs/cmd/kn_options.md
@@ -26,11 +26,13 @@ kn options
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_options.md
+++ b/docs/cmd/kn_options.md
@@ -28,6 +28,7 @@ kn options
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_plugin.md
+++ b/docs/cmd/kn_plugin.md
@@ -24,6 +24,7 @@ kn plugin
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_plugin.md
+++ b/docs/cmd/kn_plugin.md
@@ -22,11 +22,13 @@ kn plugin
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_plugin_list.md
+++ b/docs/cmd/kn_plugin_list.md
@@ -28,6 +28,7 @@ kn plugin list
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_plugin_list.md
+++ b/docs/cmd/kn_plugin_list.md
@@ -26,11 +26,13 @@ kn plugin list
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_revision.md
+++ b/docs/cmd/kn_revision.md
@@ -17,6 +17,7 @@ kn revision
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_revision.md
+++ b/docs/cmd/kn_revision.md
@@ -15,11 +15,13 @@ kn revision
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_revision_delete.md
+++ b/docs/cmd/kn_revision_delete.md
@@ -38,6 +38,7 @@ kn revision delete NAME [NAME ...]
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_revision_delete.md
+++ b/docs/cmd/kn_revision_delete.md
@@ -36,11 +36,13 @@ kn revision delete NAME [NAME ...]
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_revision_describe.md
+++ b/docs/cmd/kn_revision_describe.md
@@ -21,11 +21,13 @@ kn revision describe NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_revision_describe.md
+++ b/docs/cmd/kn_revision_describe.md
@@ -23,6 +23,7 @@ kn revision describe NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_revision_list.md
+++ b/docs/cmd/kn_revision_list.md
@@ -44,11 +44,13 @@ kn revision list
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_revision_list.md
+++ b/docs/cmd/kn_revision_list.md
@@ -46,6 +46,7 @@ kn revision list
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_route.md
+++ b/docs/cmd/kn_route.md
@@ -17,6 +17,7 @@ kn route
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_route.md
+++ b/docs/cmd/kn_route.md
@@ -15,11 +15,13 @@ kn route
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_route_describe.md
+++ b/docs/cmd/kn_route_describe.md
@@ -23,6 +23,7 @@ kn route describe NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_route_describe.md
+++ b/docs/cmd/kn_route_describe.md
@@ -21,11 +21,13 @@ kn route describe NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_route_list.md
+++ b/docs/cmd/kn_route_list.md
@@ -38,6 +38,7 @@ kn route list NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_route_list.md
+++ b/docs/cmd/kn_route_list.md
@@ -36,11 +36,13 @@ kn route list NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_service.md
+++ b/docs/cmd/kn_service.md
@@ -15,11 +15,13 @@ kn service
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_service.md
+++ b/docs/cmd/kn_service.md
@@ -17,6 +17,7 @@ kn service
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_service_apply.md
+++ b/docs/cmd/kn_service_apply.md
@@ -85,11 +85,13 @@ kn service apply s0 --filename my-svc.yml
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_service_apply.md
+++ b/docs/cmd/kn_service_apply.md
@@ -87,6 +87,7 @@ kn service apply s0 --filename my-svc.yml
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -112,11 +112,13 @@ kn service create NAME --image IMAGE
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_service_create.md
+++ b/docs/cmd/kn_service_create.md
@@ -114,6 +114,7 @@ kn service create NAME --image IMAGE
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_service_delete.md
+++ b/docs/cmd/kn_service_delete.md
@@ -43,6 +43,7 @@ kn service delete NAME [NAME ...]
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_service_delete.md
+++ b/docs/cmd/kn_service_delete.md
@@ -41,11 +41,13 @@ kn service delete NAME [NAME ...]
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_service_describe.md
+++ b/docs/cmd/kn_service_describe.md
@@ -43,6 +43,7 @@ kn service describe NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_service_describe.md
+++ b/docs/cmd/kn_service_describe.md
@@ -41,11 +41,13 @@ kn service describe NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_service_export.md
+++ b/docs/cmd/kn_service_export.md
@@ -41,6 +41,7 @@ kn service export NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_service_export.md
+++ b/docs/cmd/kn_service_export.md
@@ -39,11 +39,13 @@ kn service export NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_service_import.md
+++ b/docs/cmd/kn_service_import.md
@@ -31,11 +31,13 @@ kn service import FILENAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_service_import.md
+++ b/docs/cmd/kn_service_import.md
@@ -33,6 +33,7 @@ kn service import FILENAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_service_list.md
+++ b/docs/cmd/kn_service_list.md
@@ -43,11 +43,13 @@ kn service list
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_service_list.md
+++ b/docs/cmd/kn_service_list.md
@@ -45,6 +45,7 @@ kn service list
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -101,11 +101,13 @@ kn service update NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_service_update.md
+++ b/docs/cmd/kn_service_update.md
@@ -103,6 +103,7 @@ kn service update NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source.md
+++ b/docs/cmd/kn_source.md
@@ -17,6 +17,7 @@ kn source SOURCE|COMMAND
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source.md
+++ b/docs/cmd/kn_source.md
@@ -15,11 +15,13 @@ kn source SOURCE|COMMAND
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_apiserver.md
+++ b/docs/cmd/kn_source_apiserver.md
@@ -15,11 +15,13 @@ kn source apiserver COMMAND
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_apiserver.md
+++ b/docs/cmd/kn_source_apiserver.md
@@ -17,6 +17,7 @@ kn source apiserver COMMAND
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_apiserver_create.md
+++ b/docs/cmd/kn_source_apiserver_create.md
@@ -32,11 +32,13 @@ kn source apiserver create NAME --resource RESOURCE --sink SINK
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_apiserver_create.md
+++ b/docs/cmd/kn_source_apiserver_create.md
@@ -34,6 +34,7 @@ kn source apiserver create NAME --resource RESOURCE --sink SINK
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_apiserver_delete.md
+++ b/docs/cmd/kn_source_apiserver_delete.md
@@ -24,11 +24,13 @@ kn source apiserver delete NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_apiserver_delete.md
+++ b/docs/cmd/kn_source_apiserver_delete.md
@@ -26,6 +26,7 @@ kn source apiserver delete NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_apiserver_describe.md
+++ b/docs/cmd/kn_source_apiserver_describe.md
@@ -32,11 +32,13 @@ kn source apiserver describe NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_apiserver_describe.md
+++ b/docs/cmd/kn_source_apiserver_describe.md
@@ -34,6 +34,7 @@ kn source apiserver describe NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_apiserver_list.md
+++ b/docs/cmd/kn_source_apiserver_list.md
@@ -35,6 +35,7 @@ kn source apiserver list
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_apiserver_list.md
+++ b/docs/cmd/kn_source_apiserver_list.md
@@ -33,11 +33,13 @@ kn source apiserver list
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_apiserver_update.md
+++ b/docs/cmd/kn_source_apiserver_update.md
@@ -32,11 +32,13 @@ kn source apiserver update NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_apiserver_update.md
+++ b/docs/cmd/kn_source_apiserver_update.md
@@ -34,6 +34,7 @@ kn source apiserver update NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_binding.md
+++ b/docs/cmd/kn_source_binding.md
@@ -15,11 +15,13 @@ kn source binding COMMAND
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_binding.md
+++ b/docs/cmd/kn_source_binding.md
@@ -17,6 +17,7 @@ kn source binding COMMAND
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_binding_create.md
+++ b/docs/cmd/kn_source_binding_create.md
@@ -27,11 +27,13 @@ kn source binding create NAME --subject SUBJECT --sink SINK
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_binding_create.md
+++ b/docs/cmd/kn_source_binding_create.md
@@ -29,6 +29,7 @@ kn source binding create NAME --subject SUBJECT --sink SINK
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_binding_delete.md
+++ b/docs/cmd/kn_source_binding_delete.md
@@ -24,11 +24,13 @@ kn source binding delete NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_binding_delete.md
+++ b/docs/cmd/kn_source_binding_delete.md
@@ -26,6 +26,7 @@ kn source binding delete NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_binding_describe.md
+++ b/docs/cmd/kn_source_binding_describe.md
@@ -32,11 +32,13 @@ kn source binding describe NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_binding_describe.md
+++ b/docs/cmd/kn_source_binding_describe.md
@@ -34,6 +34,7 @@ kn source binding describe NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_binding_list.md
+++ b/docs/cmd/kn_source_binding_list.md
@@ -33,11 +33,13 @@ kn source binding list
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_binding_list.md
+++ b/docs/cmd/kn_source_binding_list.md
@@ -35,6 +35,7 @@ kn source binding list
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_binding_update.md
+++ b/docs/cmd/kn_source_binding_update.md
@@ -27,11 +27,13 @@ kn source binding update NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_binding_update.md
+++ b/docs/cmd/kn_source_binding_update.md
@@ -29,6 +29,7 @@ kn source binding update NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_container.md
+++ b/docs/cmd/kn_source_container.md
@@ -17,6 +17,7 @@ kn source container create|delete|update|list|describe
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_container.md
+++ b/docs/cmd/kn_source_container.md
@@ -15,11 +15,13 @@ kn source container create|delete|update|list|describe
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_container_create.md
+++ b/docs/cmd/kn_source_container_create.md
@@ -48,6 +48,7 @@ kn source container create NAME --image IMAGE --sink SINK
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_container_create.md
+++ b/docs/cmd/kn_source_container_create.md
@@ -46,11 +46,13 @@ kn source container create NAME --image IMAGE --sink SINK
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_container_delete.md
+++ b/docs/cmd/kn_source_container_delete.md
@@ -26,6 +26,7 @@ kn source container delete NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_container_delete.md
+++ b/docs/cmd/kn_source_container_delete.md
@@ -24,11 +24,13 @@ kn source container delete NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_container_describe.md
+++ b/docs/cmd/kn_source_container_describe.md
@@ -25,11 +25,13 @@ kn source container describe NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_container_describe.md
+++ b/docs/cmd/kn_source_container_describe.md
@@ -27,6 +27,7 @@ kn source container describe NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_container_list.md
+++ b/docs/cmd/kn_source_container_list.md
@@ -33,11 +33,13 @@ kn source container list
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_container_list.md
+++ b/docs/cmd/kn_source_container_list.md
@@ -35,6 +35,7 @@ kn source container list
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_container_update.md
+++ b/docs/cmd/kn_source_container_update.md
@@ -46,11 +46,13 @@ kn source container update NAME --image IMAGE
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_container_update.md
+++ b/docs/cmd/kn_source_container_update.md
@@ -48,6 +48,7 @@ kn source container update NAME --image IMAGE
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_list-types.md
+++ b/docs/cmd/kn_source_list-types.md
@@ -32,11 +32,13 @@ kn source list-types
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_list-types.md
+++ b/docs/cmd/kn_source_list-types.md
@@ -34,6 +34,7 @@ kn source list-types
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_list.md
+++ b/docs/cmd/kn_source_list.md
@@ -39,6 +39,7 @@ kn source list
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_list.md
+++ b/docs/cmd/kn_source_list.md
@@ -37,11 +37,13 @@ kn source list
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_ping.md
+++ b/docs/cmd/kn_source_ping.md
@@ -15,11 +15,13 @@ kn source ping COMMAND
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_ping.md
+++ b/docs/cmd/kn_source_ping.md
@@ -17,6 +17,7 @@ kn source ping COMMAND
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_ping_create.md
+++ b/docs/cmd/kn_source_ping_create.md
@@ -29,11 +29,13 @@ kn source ping create NAME --sink SINK
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_ping_create.md
+++ b/docs/cmd/kn_source_ping_create.md
@@ -31,6 +31,7 @@ kn source ping create NAME --sink SINK
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_ping_delete.md
+++ b/docs/cmd/kn_source_ping_delete.md
@@ -24,11 +24,13 @@ kn source ping delete NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_ping_delete.md
+++ b/docs/cmd/kn_source_ping_delete.md
@@ -26,6 +26,7 @@ kn source ping delete NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_ping_describe.md
+++ b/docs/cmd/kn_source_ping_describe.md
@@ -34,6 +34,7 @@ kn source ping describe NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_ping_describe.md
+++ b/docs/cmd/kn_source_ping_describe.md
@@ -32,11 +32,13 @@ kn source ping describe NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_ping_list.md
+++ b/docs/cmd/kn_source_ping_list.md
@@ -35,6 +35,7 @@ kn source ping list
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_ping_list.md
+++ b/docs/cmd/kn_source_ping_list.md
@@ -33,11 +33,13 @@ kn source ping list
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_source_ping_update.md
+++ b/docs/cmd/kn_source_ping_update.md
@@ -31,6 +31,7 @@ kn source ping update NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_source_ping_update.md
+++ b/docs/cmd/kn_source_ping_update.md
@@ -29,11 +29,13 @@ kn source ping update NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_subscription.md
+++ b/docs/cmd/kn_subscription.md
@@ -17,6 +17,7 @@ kn subscription COMMAND
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_subscription.md
+++ b/docs/cmd/kn_subscription.md
@@ -15,11 +15,13 @@ kn subscription COMMAND
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_subscription_create.md
+++ b/docs/cmd/kn_subscription_create.md
@@ -33,6 +33,7 @@ kn subscription create NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_subscription_create.md
+++ b/docs/cmd/kn_subscription_create.md
@@ -31,11 +31,13 @@ kn subscription create NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_subscription_delete.md
+++ b/docs/cmd/kn_subscription_delete.md
@@ -26,6 +26,7 @@ kn subscription delete NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_subscription_delete.md
+++ b/docs/cmd/kn_subscription_delete.md
@@ -24,11 +24,13 @@ kn subscription delete NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_subscription_describe.md
+++ b/docs/cmd/kn_subscription_describe.md
@@ -31,6 +31,7 @@ kn subscription describe NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_subscription_describe.md
+++ b/docs/cmd/kn_subscription_describe.md
@@ -29,11 +29,13 @@ kn subscription describe NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_subscription_list.md
+++ b/docs/cmd/kn_subscription_list.md
@@ -33,11 +33,13 @@ kn subscription list
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_subscription_list.md
+++ b/docs/cmd/kn_subscription_list.md
@@ -35,6 +35,7 @@ kn subscription list
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_subscription_update.md
+++ b/docs/cmd/kn_subscription_update.md
@@ -30,11 +30,13 @@ kn subscription update NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_subscription_update.md
+++ b/docs/cmd/kn_subscription_update.md
@@ -32,6 +32,7 @@ kn subscription update NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_trigger.md
+++ b/docs/cmd/kn_trigger.md
@@ -17,6 +17,7 @@ kn trigger
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_trigger.md
+++ b/docs/cmd/kn_trigger.md
@@ -15,11 +15,13 @@ kn trigger
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_trigger_create.md
+++ b/docs/cmd/kn_trigger_create.md
@@ -32,6 +32,7 @@ kn trigger create NAME --sink SINK
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_trigger_create.md
+++ b/docs/cmd/kn_trigger_create.md
@@ -30,11 +30,13 @@ kn trigger create NAME --sink SINK
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_trigger_delete.md
+++ b/docs/cmd/kn_trigger_delete.md
@@ -24,11 +24,13 @@ kn trigger delete NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_trigger_delete.md
+++ b/docs/cmd/kn_trigger_delete.md
@@ -26,6 +26,7 @@ kn trigger delete NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_trigger_describe.md
+++ b/docs/cmd/kn_trigger_describe.md
@@ -32,11 +32,13 @@ kn trigger describe NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_trigger_describe.md
+++ b/docs/cmd/kn_trigger_describe.md
@@ -34,6 +34,7 @@ kn trigger describe NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_trigger_list.md
+++ b/docs/cmd/kn_trigger_list.md
@@ -35,6 +35,7 @@ kn trigger list
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_trigger_list.md
+++ b/docs/cmd/kn_trigger_list.md
@@ -33,11 +33,13 @@ kn trigger list
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_trigger_update.md
+++ b/docs/cmd/kn_trigger_update.md
@@ -36,6 +36,7 @@ kn trigger update NAME
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/docs/cmd/kn_trigger_update.md
+++ b/docs/cmd/kn_trigger_update.md
@@ -34,11 +34,13 @@ kn trigger update NAME
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_version.md
+++ b/docs/cmd/kn_version.md
@@ -16,11 +16,13 @@ kn version
 ### Options inherited from parent commands
 
 ```
-      --cluster string      name of the kubeconfig cluster to use
-      --config string       kn configuration file (default: ~/.config/kn/config.yaml)
-      --context string      name of the kubeconfig context to use
-      --kubeconfig string   kubectl configuration file (default: ~/.kube/config)
-      --log-http            log http traffic
+      --as string              username to impersonate for the operation
+      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --cluster string         name of the kubeconfig cluster to use
+      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
+      --context string         name of the kubeconfig context to use
+      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
+      --log-http               log http traffic
 ```
 
 ### SEE ALSO

--- a/docs/cmd/kn_version.md
+++ b/docs/cmd/kn_version.md
@@ -18,6 +18,7 @@ kn version
 ```
       --as string              username to impersonate for the operation
       --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
+      --as-uid string          uid to impersonate for the operation
       --cluster string         name of the kubeconfig cluster to use
       --config string          kn configuration file (default: ~/.config/kn/config.yaml)
       --context string         name of the kubeconfig context to use

--- a/pkg/kn/commands/types.go
+++ b/pkg/kn/commands/types.go
@@ -17,7 +17,6 @@ package commands
 import (
 	"fmt"
 	"io"
-
 	"os"
 	"path/filepath"
 
@@ -52,6 +51,7 @@ type KnParams struct {
 	KubeContext              string
 	KubeCluster              string
 	KubeAsUser               string
+	KubeAsUID                string
 	KubeAsGroup              []string
 	ClientConfig             clientcmd.ClientConfig
 	NewServingClient         func(namespace string) (clientservingv1.KnServingClient, error)
@@ -238,6 +238,9 @@ func (params *KnParams) GetClientConfig() (clientcmd.ClientConfig, error) {
 	}
 	if params.KubeAsUser != "" {
 		configOverrides.AuthInfo.Impersonate = params.KubeAsUser
+	}
+	if params.KubeAsUID != "" {
+		configOverrides.AuthInfo.ImpersonateUID = params.KubeAsUID
 	}
 	if len(params.KubeAsGroup) > 0 {
 		configOverrides.AuthInfo.ImpersonateGroups = params.KubeAsGroup

--- a/pkg/kn/commands/types.go
+++ b/pkg/kn/commands/types.go
@@ -51,6 +51,8 @@ type KnParams struct {
 	KubeCfgPath              string
 	KubeContext              string
 	KubeCluster              string
+	KubeAsUser               string
+	KubeAsGroup              []string
 	ClientConfig             clientcmd.ClientConfig
 	NewServingClient         func(namespace string) (clientservingv1.KnServingClient, error)
 	NewServingV1alpha1Client func(namespace string) (clientservingv1alpha1.KnServingClient, error)
@@ -233,6 +235,12 @@ func (params *KnParams) GetClientConfig() (clientcmd.ClientConfig, error) {
 	}
 	if params.KubeCluster != "" {
 		configOverrides.Context.Cluster = params.KubeCluster
+	}
+	if params.KubeAsUser != "" {
+		configOverrides.AuthInfo.Impersonate = params.KubeAsUser
+	}
+	if len(params.KubeAsGroup) > 0 {
+		configOverrides.AuthInfo.ImpersonateGroups = params.KubeAsGroup
 	}
 	if len(params.KubeCfgPath) == 0 {
 		return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides), nil

--- a/pkg/kn/commands/types_test.go
+++ b/pkg/kn/commands/types_test.go
@@ -113,6 +113,7 @@ type typeTestCase struct {
 	kubeCfgPath   string
 	kubeContext   string
 	kubeAsUser    string
+	kubeAsUID     string
 	kubeAsGroup   []string
 	kubeCluster   string
 	explicitPath  string
@@ -132,6 +133,7 @@ func TestGetClientConfig(t *testing.T) {
 			"",
 			"",
 			"",
+			"",
 			[]string{},
 			"",
 			clientcmd.NewDefaultClientConfigLoadingRules().ExplicitPath,
@@ -139,6 +141,7 @@ func TestGetClientConfig(t *testing.T) {
 		},
 		{
 			tempFile,
+			"",
 			"",
 			"",
 			[]string{},
@@ -150,6 +153,7 @@ func TestGetClientConfig(t *testing.T) {
 			"/testing/assets/kube-config-01.yml",
 			"foo",
 			"",
+			"",
 			[]string{},
 			"bar",
 			"",
@@ -157,6 +161,7 @@ func TestGetClientConfig(t *testing.T) {
 		},
 		{
 			multiConfigs,
+			"",
 			"",
 			"",
 			[]string{},
@@ -168,7 +173,8 @@ func TestGetClientConfig(t *testing.T) {
 			tempFile,
 			"",
 			"admin",
-			[]string{"system:masters"},
+			"",
+			[]string{},
 			"",
 			tempFile,
 			"",
@@ -177,7 +183,18 @@ func TestGetClientConfig(t *testing.T) {
 			tempFile,
 			"",
 			"admin",
+			"",
 			[]string{"system:authenticated", "system:masters"},
+			"",
+			tempFile,
+			"",
+		},
+		{
+			tempFile,
+			"",
+			"admin",
+			"abc123",
+			[]string{},
 			"",
 			tempFile,
 			"",
@@ -187,6 +204,7 @@ func TestGetClientConfig(t *testing.T) {
 			KubeCfgPath: tc.kubeCfgPath,
 			KubeContext: tc.kubeContext,
 			KubeAsUser:  tc.kubeAsUser,
+			KubeAsUID:   tc.kubeAsUID,
 			KubeAsGroup: tc.kubeAsGroup,
 			KubeCluster: tc.kubeCluster,
 		}
@@ -213,6 +231,12 @@ func TestGetClientConfig(t *testing.T) {
 				config, err := clientConfig.ClientConfig()
 				assert.NilError(t, err)
 				assert.Assert(t, config.Impersonate.UserName == tc.kubeAsUser)
+			}
+
+			if tc.kubeAsUID != "" {
+				config, err := clientConfig.ClientConfig()
+				assert.NilError(t, err)
+				assert.Assert(t, config.Impersonate.UID == tc.kubeAsUID)
 			}
 
 			if len(tc.kubeAsGroup) > 0 {

--- a/pkg/kn/root/root.go
+++ b/pkg/kn/root/root.go
@@ -87,6 +87,7 @@ Find more information about Knative at: https://knative.dev`, rootName),
 	rootCmd.PersistentFlags().StringVar(&p.KubeContext, "context", "", "name of the kubeconfig context to use")
 	rootCmd.PersistentFlags().StringVar(&p.KubeCluster, "cluster", "", "name of the kubeconfig cluster to use")
 	rootCmd.PersistentFlags().StringVar(&p.KubeAsUser, "as", "", "username to impersonate for the operation")
+	rootCmd.PersistentFlags().StringVar(&p.KubeAsUID, "as-uid", "", "uid to impersonate for the operation")
 	rootCmd.PersistentFlags().StringArrayVar(&p.KubeAsGroup, "as-group", []string{}, "group to impersonate for the operation, this flag can be repeated to specify multiple groups")
 	flags.AddBothBoolFlags(rootCmd.PersistentFlags(), &p.LogHTTP, "log-http", "", false, "log http traffic")
 

--- a/pkg/kn/root/root.go
+++ b/pkg/kn/root/root.go
@@ -86,6 +86,8 @@ Find more information about Knative at: https://knative.dev`, rootName),
 	rootCmd.PersistentFlags().StringVar(&p.KubeCfgPath, "kubeconfig", "", "kubectl configuration file (default: ~/.kube/config)")
 	rootCmd.PersistentFlags().StringVar(&p.KubeContext, "context", "", "name of the kubeconfig context to use")
 	rootCmd.PersistentFlags().StringVar(&p.KubeCluster, "cluster", "", "name of the kubeconfig cluster to use")
+	rootCmd.PersistentFlags().StringVar(&p.KubeAsUser, "as", "", "username to impersonate for the operation")
+	rootCmd.PersistentFlags().StringArrayVar(&p.KubeAsGroup, "as-group", []string{}, "group to impersonate for the operation, this flag can be repeated to specify multiple groups")
 	flags.AddBothBoolFlags(rootCmd.PersistentFlags(), &p.LogHTTP, "log-http", "", false, "log http traffic")
 
 	// Grouped commands

--- a/pkg/kn/root/root_test.go
+++ b/pkg/kn/root/root_test.go
@@ -49,6 +49,7 @@ func TestNewRootCommand(t *testing.T) {
 	assert.Assert(t, rootCmd.PersistentFlags().Lookup("context") != nil)
 	assert.Assert(t, rootCmd.PersistentFlags().Lookup("cluster") != nil)
 	assert.Assert(t, rootCmd.PersistentFlags().Lookup("as") != nil)
+	assert.Assert(t, rootCmd.PersistentFlags().Lookup("as-uid") != nil)
 	assert.Assert(t, rootCmd.PersistentFlags().Lookup("as-group") != nil)
 
 	assert.Assert(t, rootCmd.RunE == nil)

--- a/pkg/kn/root/root_test.go
+++ b/pkg/kn/root/root_test.go
@@ -48,6 +48,8 @@ func TestNewRootCommand(t *testing.T) {
 	assert.Assert(t, rootCmd.PersistentFlags().Lookup("kubeconfig") != nil)
 	assert.Assert(t, rootCmd.PersistentFlags().Lookup("context") != nil)
 	assert.Assert(t, rootCmd.PersistentFlags().Lookup("cluster") != nil)
+	assert.Assert(t, rootCmd.PersistentFlags().Lookup("as") != nil)
+	assert.Assert(t, rootCmd.PersistentFlags().Lookup("as-group") != nil)
 
 	assert.Assert(t, rootCmd.RunE == nil)
 


### PR DESCRIPTION
## Description

<!-- Please add a short summary about what the pull request is going to bring on the table -->
CLI options to enable kubernetes user and group impersonation
```
❯ ./kn options
The following options can be passed to any command:

      --as string              username to impersonate for the operation
      --as-uid string          uid to impersonate for the operation
      --as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups
      --cluster string         name of the kubeconfig cluster to use
      --config string          kn configuration file (default: ~/.config/kn/config.yaml)
      --context string         name of the kubeconfig context to use
      --kubeconfig string      kubectl configuration file (default: ~/.kube/config)
      --log-http               log http traffic
```

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* provide string option `--as` for username impersonation
* provide string option `--as-uid` for uid impersonation
* provide stringArray option `--as-group` for group impersonation

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Provide cli options to enable Kubernetes user, uid, and group impersonation via `--as`, `--as-group` and `--as-uid` flags
```

<!--
Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.

In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:

- 🎁 New feature
- 🐛 Bug fix
- ✨ Feature Update
- 🐣 Refactoring
- 🗑️ Remove feature or internal logic

See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR

PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
-->
- 🎁 New feature: provide cli options to enable Kubernetes user, uid, and group impersonation via `--as` and `--as-group` flags
<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
