### PR TITLE
Add cli support for initContainers

### DIFF
--- a/pkg/kn/flags/podspec_helper.go
+++ b/pkg/kn/flags/podspec_helper.go
@@ -313,6 +313,30 @@ func UpdateContainers(spec *corev1.PodSpec, containers []corev1.Container) {
 	}
 }
 
+// UpdateInitContainers updates the initContainers array with the ones provided from file or os.Stdin
+func UpdateInitContainers(spec *corev1.PodSpec, initContainers []corev1.Container) {
+	var matched []string
+	if len(spec.InitContainers) == 1 {
+		spec.InitContainers = append(spec.InitContainers, initContainers...)
+	} else {
+		for i, initContainer := range spec.InitContainers {
+			for j, toUpdate := range initContainers {
+				if initContainer.Name == toUpdate.Name {
+
+					spec.InitContainers[i] = initContainers[j]
+
+					matched = append(matched, toUpdate.Name)
+				}
+			}
+		}
+		for _, initContainer := range initContainers {
+			if !util.SliceContainsIgnoreCase(matched, initContainer.Name) {
+				spec.InitContainers = append(spec.InitContainers, initContainer)
+			}
+		}
+	}
+}
+
 // UpdateLivenessProbe updates container liveness probe based on provided string
 func UpdateLivenessProbe(spec *corev1.PodSpec, probeString string) error {
 	c := containerOfPodSpec(spec)


### PR DESCRIPTION
## Description
This PR adds `initContainer` support to Knative client. It is part of the work tracked in https://github.com/knative/serving/issues/12024.


## Changes
* Adds `--init-containers` as a flag for `kn service X`

## Reference
Partially fixes https://github.com/knative/serving/issues/12024


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add --init-containers flag to service create command options 
```

/lint
