### PR TITLE
fix: Use go_run from common lib

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -15,7 +15,8 @@
 # limitations under the License.
 
 set -o pipefail
-set -eu
+set -o errexit
+set -o nounset
 
 source_dirs="cmd pkg test lib tools"
 

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 set -o pipefail
+set -eu
 
 source_dirs="cmd pkg test lib tools"
 
@@ -25,7 +26,9 @@ else
     ARGS=("$@")
 fi
 
-set -eu
+# Tool version
+readonly GOIMPORTS_VERSION="v0.7.0"
+readonly GOLINT_VERSION="v1.52.0"
 
 # Run build
 run() {
@@ -115,14 +118,14 @@ go_fmt() {
 
 source_format() {
   set +e
-  run_go_tool golang.org/x/tools/cmd/goimports goimports -w $(echo $source_dirs)
+  go_run "golang.org/x/tools/cmd/goimports@${GOIMPORTS_VERSION}" -w $(echo $source_dirs)
   find $(echo $source_dirs) -name "*.go" -print0 | xargs -0 gofmt -s -w
   set -e
 }
 
 source_lint() {
   echo "🔍 Lint"
-  run_go_tool github.com/golangci/golangci-lint/cmd/golangci-lint golangci-lint run  || \
+  go_run "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLINT_VERSION}" run  || \
   { echo "--- FAIL: golangci-lint failed please fix the reported errors"; return 1; }
 }
 

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -114,13 +114,13 @@ codegen() {
 
 go_fmt() {
   echo "🧹 ${S}Format"
-  find $(echo $source_dirs) -name "*.go" -print0 | xargs -0 gofmt -s -w
+  find $(echo "$source_dirs") -name "*.go" -print0 | xargs -0 gofmt -s -w
 }
 
 source_format() {
   set +e
-  go_run "golang.org/x/tools/cmd/goimports@${GOIMPORTS_VERSION}" -w $(echo $source_dirs)
-  find $(echo $source_dirs) -name "*.go" -print0 | xargs -0 gofmt -s -w
+  go_run "golang.org/x/tools/cmd/goimports@${GOIMPORTS_VERSION}" -w $(echo "$source_dirs")
+  find $(echo "$source_dirs") -name "*.go" -print0 | xargs -0 gofmt -s -w
   set -e
 }
 


### PR DESCRIPTION
## Description

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* ✨fix: Use go_run from common lib instead of deprecated `run_go_tool`
* Move bash flags up and expand to names

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @rhuss 