### PR TITLE
fix: Fix image tag for nightly builds

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -56,7 +56,7 @@ function build_release() {
       if ((current_minor >= latest_minor)); then
         echo "Newer patch release - publish latest image tag"
       else
-        echo "Patch release of older minor version - do not publish lates image tag"
+        echo "Patch release of older minor version - do not publish latest image tag"
         KO_FLAGS=$KO_FLAGS" --tags \"\""
       fi
     fi

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -47,16 +47,18 @@ function build_release() {
   #
   # Tagging of images by the $TAG variable is done in `tag_images_in_yamls()` of hack/release.sh.
   #
-  if [ "$(patch_version "${TAG}")" == 0 ]; then
-    echo "Newest .0 release - publish latest image tag"
-  else
-    local latest_minor=$(minor_version "$(latest_version)")
-    local current_minor=$(minor_version "${TAG}")
-    if ((current_minor >= latest_minor)); then
-      echo "Newer patch release - publish latest image tag"
+  if is_release_branch; then
+    if [ "$(patch_version "${TAG}")" == 0 ]; then
+      echo "Newest .0 release - publish latest image tag"
     else
-      echo "Patch release of older minor version - do not publish lates image tag"
-      KO_FLAGS=$KO_FLAGS" --tags \"\""
+      local latest_minor=$(minor_version "$(latest_version)")
+      local current_minor=$(minor_version "${TAG}")
+      if ((current_minor >= latest_minor)); then
+        echo "Newer patch release - publish latest image tag"
+      else
+        echo "Patch release of older minor version - do not publish lates image tag"
+        KO_FLAGS=$KO_FLAGS" --tags \"\""
+      fi
     fi
   fi
   echo "KO_FLAGS:${KO_FLAGS}"


### PR DESCRIPTION
## Description

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* fix: Fix image tag for nightly builds

That's a follow up to my previous PR that added check around "latest" tag. We need those on release branches only, nightly release for main should always be tagged latest.

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Follow-up https://github.com/knative/client/pull/1792

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @rhuss 
