### PR TITLE
Remove e2e skip flags after release

### DIFF
--- a/test/e2e/eventtype_test.go
+++ b/test/e2e/eventtype_test.go
@@ -18,7 +18,6 @@
 package e2e
 
 import (
-	"os"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -38,10 +37,6 @@ const (
 )
 
 func TestEventtype(t *testing.T) {
-	//FIXME: enable after Eventing v1.11 is out
-	if os.Getenv("LATEST_RELEASE") == "true" {
-		t.Skip("The tests are skipped on Eventing v1.10")
-	}
 	t.Parallel()
 	it, err := test.NewKnTest()
 	assert.NilError(t, err)

--- a/test/e2e/service_export_test.go
+++ b/test/e2e/service_export_test.go
@@ -19,7 +19,6 @@ package e2e
 
 import (
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 
@@ -37,11 +36,6 @@ import (
 )
 
 func TestServiceExport(t *testing.T) {
-	//FIXME: enable once 0.19 is available
-	// see: https://github.com/knative/serving/pull/9685
-	if strings.HasPrefix(os.Getenv("KNATIVE_SERVING_VERSION"), "0.18") {
-		t.Skip("The test is skipped on Serving version 0.18")
-	}
 	t.Parallel()
 	it, err := test.NewKnTest()
 	assert.NilError(t, err)


### PR DESCRIPTION
## Description

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Remove e2e skip flags after release

Per the PR reviews last week, removing unneeded skips.
/cc @rhuss 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```


