### PR TITLE
Remove unusable `--broker` flag from `trigger update` cmd

### DIFF
--- a/docs/cmd/kn_trigger_update.md
+++ b/docs/cmd/kn_trigger_update.md
@@ -24,7 +24,6 @@ kn trigger update NAME
 ### Options
 
 ```
-      --broker string      Name of the Broker which the trigger associates with. (default "default")
       --filter strings     Key-value pair for exact CloudEvent attribute matching against incoming events, e.g type=dev.knative.foo
   -h, --help               help for update
   -n, --namespace string   Specify the namespace to operate in.

--- a/pkg/kn/commands/trigger/update_flags.go
+++ b/pkg/kn/commands/trigger/update_flags.go
@@ -50,7 +50,10 @@ func (f *TriggerUpdateFlags) GetUpdateFilters() (map[string]string, []string, er
 
 // Add is to set parameters
 func (f *TriggerUpdateFlags) Add(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&f.Broker, "broker", "default", "Name of the Broker which the trigger associates with.")
+	if cmd.Name() != "update" {
+		// Spec.Broker is immutable field
+		cmd.Flags().StringVar(&f.Broker, "broker", "default", "Name of the Broker which the trigger associates with.")
+	}
 	// The Sugar controller was integrated into main Eventing controller. With that the default behavior was changed as well.
 	// Users need to configure 'Automatic Broker Creation' per linked docs.
 	// Deprecated in 1.4, remove in 1.6.

--- a/pkg/kn/commands/trigger/update_test.go
+++ b/pkg/kn/commands/trigger/update_test.go
@@ -62,20 +62,6 @@ func TestTriggerUpdateWithError(t *testing.T) {
 	eventingRecorder.Validate()
 }
 
-func TestTriggerUpdateInvalidBroker(t *testing.T) {
-	eventingClient := clienteventingv1.NewMockKnEventingClient(t)
-	eventingRecorder := eventingClient.Recorder()
-	present := createTrigger("default", triggerName, map[string]string{"type": "dev.knative.new"}, "mybroker", "newsvc")
-	eventingRecorder.GetTrigger(triggerName, present, nil)
-
-	out, err := executeTriggerCommand(eventingClient, nil, "update", triggerName,
-		"--broker", "newbroker")
-	assert.ErrorContains(t, err, "broker is immutable")
-	assert.Assert(t, util.ContainsAll(out, "Usage", triggerName))
-
-	eventingRecorder.Validate()
-}
-
 func TestTriggerUpdateDeletionTimestampNotNil(t *testing.T) {
 	eventingClient := clienteventingv1.NewMockKnEventingClient(t)
 


### PR DESCRIPTION
## Description

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Remove unusable `--broker` flag from `trigger update` cmd


## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #1813 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Remove unusable `--broker` flag from `trigger update` cmd
```

/cc @rhuss @vyasgun 
