### PR TITLE
Update PR template not to mention changelog anymore

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -27,22 +27,6 @@ additional action from users switching to the new release, include the string
 ```
 
 <!--
-Please add an entry to CHANGELOG.adoc file, too, as part of your Pull Request.
-
-In the following cases, add a short description of PR to the unreleased section in CHANGELOG.adoc:
-
-- 🎁 New feature
-- 🐛 Bug fix
-- ✨ Feature Update
-- 🐣 Refactoring
-- 🗑️ Remove feature or internal logic
-
-See other entries in CHANGELOG.adoc as an example for how to add the entry, including a reference to the corresponding issue/PR
-
-PLEASE DON'T ADD THAT LINE HERE IN THE PULL-REQUEST DESCRIPTION BUT DIRECTLY IN CHANGELOG.ADOC AND ADD CHANGELOG.ADOC AS PART OF YOUR PULL-REQUEST.
--->
-
-<!--
 To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->
 
 <!--


### PR DESCRIPTION
## Description

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Update PR template not to mention changelog anymore

For a while now, we are fully on-boarded to automated Release Notes collection from PRs. This removes the leftover message that might be confusing. 

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @rhuss @vyasgun 