### PR TITLE
add clotributor to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,5 @@ Additionally you can visit [knative.dev](https://knative.dev) for more examples.
 ## Developers
 
 If you are interested in contributing, see [CONTRIBUTING.md](./CONTRIBUTING.md)
-and [DEVELOPMENT.md](DEVELOPMENT.md).
+and [DEVELOPMENT.md](DEVELOPMENT.md). For a list of help wanted issues in Knative,
+check out [CLOTRIBUTOR](https://clotributor.dev/search?project=knative&page=1)


### PR DESCRIPTION
Part of https://github.com/knative/community/issues/1403

Adds a link to the CLOTRIBUTOR page for Knative to the README