### PR TITLE
Fix wait-loop in domain E2E test

### DIFF
--- a/test/e2e/domain_mapping_test.go
+++ b/test/e2e/domain_mapping_test.go
@@ -138,9 +138,9 @@ func domainDescribe(r *test.KnRunResultCollector, domainName string, tls bool) {
 	for i := 0; i < 20; i++ {
 		out, err := k.Run("get", "domainmapping", domainName, "-o=jsonpath='{.status.url}'")
 		assert.NilError(r.T(), err)
-		out = strings.TrimSpace(out)
+		// Remove additional spaces and single quotes added to kubectl output
+		out = strings.Trim(strings.TrimSpace(out), "'")
 		if len(out) > 0 {
-			println("DEBUG wait loop:" + out + "|DEBUG")
 			break
 		}
 		time.Sleep(time.Second)

--- a/test/e2e/domain_mapping_test.go
+++ b/test/e2e/domain_mapping_test.go
@@ -28,6 +28,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -137,7 +138,9 @@ func domainDescribe(r *test.KnRunResultCollector, domainName string, tls bool) {
 	for i := 0; i < 20; i++ {
 		out, err := k.Run("get", "domainmapping", domainName, "-o=jsonpath='{.status.url}'")
 		assert.NilError(r.T(), err)
+		out = strings.TrimSpace(out)
 		if len(out) > 0 {
+			println("DEBUG wait loop:" + out + "|DEBUG")
 			break
 		}
 		time.Sleep(time.Second)


### PR DESCRIPTION
## Description

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Add trim to domain wait loop

There's an ongoing intermittent failure that causing flaked E2E tests. The wait loop doesn't seem to be very effective to prevent those. Trying to add simple string trim. Any other ideas are welcome. :)

/cc @rhuss 

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #1873 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix wait-loop in domain E2E test
```

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
