### PR TITLE
Fix `kn service wait` for already ready ksvc

### DIFF
--- a/pkg/serving/v1/client.go
+++ b/pkg/serving/v1/client.go
@@ -366,6 +366,10 @@ func (cl *knServingClient) WaitForService(ctx context.Context, name string, wcon
 		}
 		return err, 0
 	}
+	// In case of standalone wait command, it can be executed on already ready ksvc.
+	if service.IsReady() {
+		return nil, 0
+	}
 	return waitForReady.Wait(ctx, name, service.ResourceVersion, wait.Options{Timeout: &wconfig.Timeout, ErrorWindow: &wconfig.ErrorWindow}, msgCallback)
 }
 


### PR DESCRIPTION
## Description

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Fix `kn service wait` for already ready ksvc

Per the linked issue, the `wai`t cmd doesn't react properly in case of KSVC is already ready when wait-loop is started. It's caused by lack of any new events from cluster to wait upon.

/cc @rhuss 

## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #1922 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
