### PR TITLE
Populate container.SecurityContext.RunAsUser when --user flag is used

### DIFF
--- a/pkg/kn/flags/podspec.go
+++ b/pkg/kn/flags/podspec.go
@@ -372,13 +372,6 @@ func (p *PodSpecFlags) ResolvePodSpec(podSpec *corev1.PodSpec, flags *pflag.Flag
 		UpdateImagePullSecrets(podSpec, p.ImagePullSecrets)
 	}
 
-	if flags.Changed("user") {
-		err = UpdateUser(podSpec, p.User)
-		if err != nil {
-			return err
-		}
-	}
-
 	if flags.Changed("containers") || flags.Changed("extra-containers") || p.ExtraContainers == "-" {
 		var fromFile *corev1.PodSpec
 		fromFile, err = decodeContainersFromFile(p.ExtraContainers)
@@ -414,6 +407,13 @@ func (p *PodSpecFlags) ResolvePodSpec(podSpec *corev1.PodSpec, flags *pflag.Flag
 
 	if flags.Changed("security-context") {
 		if err := UpdateSecurityContext(podSpec, p.SecurityContext); err != nil {
+			return err
+		}
+	}
+
+	if flags.Changed("user") {
+		err = UpdateUser(podSpec, p.User)
+		if err != nil {
 			return err
 		}
 	}

--- a/pkg/kn/flags/podspec_helper.go
+++ b/pkg/kn/flags/podspec_helper.go
@@ -236,9 +236,10 @@ func UpdateContainerPort(spec *corev1.PodSpec, port string) error {
 // UpdateUser updates container with a given user id
 func UpdateUser(spec *corev1.PodSpec, user int64) error {
 	container := containerOfPodSpec(spec)
-	container.SecurityContext = &corev1.SecurityContext{
-		RunAsUser: &user,
+	if container.SecurityContext == nil {
+		container.SecurityContext = &v1.SecurityContext{}
 	}
+	container.SecurityContext.RunAsUser = &user
 	return nil
 }
 

--- a/pkg/kn/flags/podspec_test.go
+++ b/pkg/kn/flags/podspec_test.go
@@ -71,7 +71,7 @@ func TestPodSpecResolve(t *testing.T) {
 		"--port", "8080", "--limit", "cpu=1000m", "--limit", "memory=1024Mi",
 		"--cmd", "/app/start", "--arg", "myArg1", "--service-account", "foo-bar-account",
 		"--mount", "/mount/path=volume-name", "--volume", "volume-name=cm:config-map-name",
-		"--env-from", "config-map:config-map-name", "--user", "1001", "--pull-policy", "always",
+		"--env-from", "config-map:config-map-name", "--user", "1001", "--security-context", "none", "--pull-policy", "always",
 		"--probe-readiness", "http::8080:/path", "--probe-liveness", "http::8080:/path"}
 	expectedPodSpec := corev1.PodSpec{
 		Containers: []corev1.Container{


### PR DESCRIPTION
## Description

<!-- Please add a short summary about what the pull request is going to bring on the table -->

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Setting container's RunAsUser field based on the `--user` flag at the end so it does not reinitialize the security context


## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Fixes #1926 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->

<!--
/lint
-->
