### PR TITLE
Add completion support for fish and PowerShell shells

### DIFF
--- a/docs/cmd/kn_completion.md
+++ b/docs/cmd/kn_completion.md
@@ -10,6 +10,8 @@ to provide interactive completion
 
 Supported Shells:
  - bash
+ - fish
+ - powershell
  - zsh
 
 ```
@@ -22,6 +24,12 @@ kn completion SHELL
 
  # Generate completion code for bash
  source <(kn completion bash)
+
+ # Generate completion code for fish
+ kn completion fish | source
+
+ # Generate completion code for powershell
+ kn completion powershell | Out-String | Invoke-Expression
 
  # Generate completion code for zsh
  source <(kn completion zsh)

--- a/pkg/kn/commands/completion/completion.go
+++ b/pkg/kn/commands/completion/completion.go
@@ -30,10 +30,18 @@ to provide interactive completion
 
 Supported Shells:
  - bash
+ - fish
+ - powershell
  - zsh`
 	eg = `
  # Generate completion code for bash
  source <(kn completion bash)
+
+ # Generate completion code for fish
+ kn completion fish | source
+
+ # Generate completion code for powershell
+ kn completion powershell | Out-String | Invoke-Expression
 
  # Generate completion code for zsh
  source <(kn completion zsh)
@@ -46,20 +54,24 @@ func NewCompletionCommand(p *commands.KnParams) *cobra.Command {
 		Use:       "completion SHELL",
 		Short:     "Output shell completion code",
 		Long:      desc,
-		ValidArgs: []string{"bash", "zsh"},
+		ValidArgs: []string{"bash", "fish", "powershell", "zsh"},
 		Example:   eg,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 1 {
 				switch args[0] {
 				case "bash":
 					return cmd.Root().GenBashCompletion(os.Stdout)
+				case "fish":
+					return cmd.Root().GenFishCompletion(os.Stdout, true)
+				case "powershell":
+					return cmd.Root().GenPowerShellCompletion(os.Stdout)
 				case "zsh":
 					return cmd.Root().GenZshCompletion(os.Stdout)
 				default:
-					return errors.New("'bash' or 'zsh' shell completion is supported")
+					return errors.New("'bash', 'fish', 'powershell' or 'zsh' shell completion is supported")
 				}
 			} else {
-				return errors.New("Only one argument can be provided, either 'bash' or 'zsh'")
+				return errors.New("Only one argument can be provided, either 'bash', 'fish', 'powershell' or 'zsh'")
 			}
 		},
 	}

--- a/pkg/kn/commands/completion/completion_test.go
+++ b/pkg/kn/commands/completion/completion_test.go
@@ -34,7 +34,7 @@ func TestCompletionUsage(t *testing.T) {
 }
 
 func TestCompletionGeneration(t *testing.T) {
-	for _, shell := range []string{"bash", "zsh"} {
+	for _, shell := range []string{"bash", "fish", "powershell", "zsh"} {
 		completionCmd := NewCompletionCommand(&commands.KnParams{})
 		c := test.CaptureOutput(t)
 		err := completionCmd.RunE(&cobra.Command{}, []string{shell})
@@ -48,11 +48,11 @@ func TestCompletionGeneration(t *testing.T) {
 func TestCompletionNoArg(t *testing.T) {
 	completionCmd := NewCompletionCommand(&commands.KnParams{})
 	err := completionCmd.RunE(&cobra.Command{}, []string{})
-	assert.Assert(t, util.ContainsAll(err.Error(), "bash", "zsh", "one", "argument"))
+	assert.Assert(t, util.ContainsAll(err.Error(), "bash", "fish", "powershell", "zsh", "one", "argument"))
 }
 
 func TestCompletionWrongArg(t *testing.T) {
 	completionCmd := NewCompletionCommand(&commands.KnParams{})
 	err := completionCmd.RunE(&cobra.Command{}, []string{"sh"})
-	assert.Assert(t, util.ContainsAll(err.Error(), "bash", "zsh", "support"))
+	assert.Assert(t, util.ContainsAll(err.Error(), "bash", "fish", "powershell", "zsh", "support"))
 }


### PR DESCRIPTION
## Description

Enable the cobra based completion support for the fish and PowerShell shells.

## Changes

* Add completion support for fish and powershell

## Reference

Fixes #1928 

**Release Note**

```release-note
Add completion support for fish and PowerShell shells
```