### PR TITLE
Add include flag to export

### DIFF
--- a/pkg/commands/service/export.go
+++ b/pkg/commands/service/export.go
@@ -135,7 +135,7 @@ func NewServiceExportCommand(p *commands.KnParams) *cobra.Command {
 	commands.AddNamespaceFlags(flags, false)
 	flags.Bool("with-revisions", false, "Export all routed revisions (Beta)")
 	flags.String("mode", "", "Format for exporting all routed revisions. One of replay|export (Beta)")
-	flags.StringSlice("include", []string{}, "Specify comma separated list of key=value")
+	flags.StringSlice("include", []string{}, "Specify a list of fields to include. e.g.: --include securityContext,namespace")
 	machineReadablePrintFlags.AddFlags(command)
 	return command
 }


### PR DESCRIPTION
## Description

<!-- Please add a short summary about what the pull request is going to bring on the table -->
The securityContext field is now removed from the exported service by default to improve portability.
The --include flag was added to explicitly include this field when needed. 
For example: `kn service export --include securityContext foo -o yaml`

Since the --include flag accepts a list of values (comma-separated or repeated), it will be possible to add additional fields in the future


## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

 * Removes securityContext from exported services by default
 * Add new flag(--include ) to` kn service export`


## Reference

<!-- Please add the corresponding issue number which this pull request is about to fix -->
Close #1788

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The kn service export command now removes the securityContext field from the exported service by default to improve portability.
A new --include flag was added to explicitly include this field when needed (e.g., kn service export my-service --include securityContext)


```

<!--
To automatically lint go code in this pull request uncomment the line below. You get feedback as comments on your pull request then -->


/lint

