### PR TITLE
Add --https flag for e2e tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -75,8 +75,6 @@ When running tests against a cluster configured to use HTTPS, use the `--https` 
 test/local-e2e-tests.sh --https
 ```
 
-
-
 ### Running E2E tests as a project admin
 
 It is possible to run the E2E tests by a user with reduced privileges, e.g. project admin.

--- a/test/README.md
+++ b/test/README.md
@@ -72,7 +72,7 @@ test/local-e2e-tests.sh -short
 When running tests against a cluster configured to use HTTPS, use the `--https` flag to make tests expect HTTPS URLs:
 
 ```bash
-test/local-e2e-tests.sh --https
+ test/local-e2e-tests.sh --https
 ```
 
 ### Running E2E tests as a project admin

--- a/test/README.md
+++ b/test/README.md
@@ -67,6 +67,18 @@ mode, use
 test/local-e2e-tests.sh -short
 ```
 
+### Running tests with HTTPS
+
+When running tests against a Knative cluster configured with `defaultExternalScheme=https`,
+use the `--https` flag to make tests expect HTTPS URLs for services:
+
+```bash
+test/local-e2e-tests.sh --https
+```
+
+This is particularly useful for the domain mapping tests, which need to know whether
+to expect HTTP or HTTPS URLs from services.
+
 ### Running E2E tests as a project admin
 
 It is possible to run the E2E tests by a user with reduced privileges, e.g. project admin.

--- a/test/README.md
+++ b/test/README.md
@@ -69,15 +69,13 @@ test/local-e2e-tests.sh -short
 
 ### Running tests with HTTPS
 
-When running tests against a Knative cluster configured with `defaultExternalScheme=https`,
-use the `--https` flag to make tests expect HTTPS URLs for services:
+When running tests against a cluster configured to use HTTPS, use the `--https` flag to make tests expect HTTPS URLs:
 
 ```bash
 test/local-e2e-tests.sh --https
 ```
 
-This is particularly useful for the domain mapping tests, which need to know whether
-to expect HTTP or HTTPS URLs from services.
+
 
 ### Running E2E tests as a project admin
 

--- a/test/e2e/domain_mapping_test.go
+++ b/test/e2e/domain_mapping_test.go
@@ -146,7 +146,8 @@ func domainDescribe(r *test.KnRunResultCollector, domainName string, tls bool) {
 	out := r.KnTest().Kn().Run("domain", "describe", domainName)
 	r.AssertNoError(out)
 	var url string
-	if tls {
+	// Use HTTPS if either TLS is explicitly configured or the --https flag is set
+	if tls || ClientFlags.HTTPS {
 		url = "https://" + domainName
 	} else {
 		url = "http://" + domainName

--- a/test/e2e/e2e_flags.go
+++ b/test/e2e/e2e_flags.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2025 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains logic to encapsulate flags which are needed to specify
+// what cluster, etc. to use for e2e tests.
+
+package e2e
+
+import (
+	"flag"
+
+	// Load the generic flags of knative.dev/pkg too.
+	_ "knative.dev/pkg/test"
+)
+
+// ClientFlags holds the flags or defaults for knative/client settings in the user's environment.
+var ClientFlags = initializeClientFlags()
+
+// ClientEnvironmentFlags holds the e2e flags needed only by the client repo.
+type ClientEnvironmentFlags struct {
+	HTTPS bool // Indicates where the test service will be created with https
+}
+
+func initializeClientFlags() *ClientEnvironmentFlags {
+	var f ClientEnvironmentFlags
+
+	flag.BoolVar(&f.HTTPS, "https", false,
+		"Set this flag to true to run all tests with https.")
+
+	return &f
+}

--- a/test/e2e/e2e_flags.go
+++ b/test/e2e/e2e_flags.go
@@ -22,16 +22,13 @@ package e2e
 import (
 	"flag"
 
-	// Load the generic flags of knative.dev/pkg too.
 	_ "knative.dev/pkg/test"
 )
 
-// ClientFlags holds the flags or defaults for knative/client settings in the user's environment.
 var ClientFlags = initializeClientFlags()
 
-// ClientEnvironmentFlags holds the e2e flags needed only by the client repo.
 type ClientEnvironmentFlags struct {
-	HTTPS bool // Indicates where the test service will be created with https
+	HTTPS bool
 }
 
 func initializeClientFlags() *ClientEnvironmentFlags {


### PR DESCRIPTION
This change introduces a `--https` flag for e2e tests 

part of #1520 

## Changes:
- Add `test/e2e/e2e_flags.go` with --https flag infrastructure  
- Update `domain_mapping_test.go` to respect --https flag when determining expected URL schemes
- Update `test/README.md` with documentation for the new flag

## Testing:
- [x] Flag parsing works correctly
- [x] Tests compile without errors  
- [x] Flag is passed through test script properly
- [x] Documentation updated